### PR TITLE
Removed warnings in README due to fixes in the update to 1.6.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ Source code: <https://github.com/soil-kt/soil/tree/main/sample/>
 > [!NOTE]
 > Currently, the only browsers that support WasmGC are Chrome and Firefox. For the latest compatibility information, please visit https://webassembly.org/features/.
 
-> [!WARNING]
-> We are aware of an issue with Kotlin Wasm on mobile browsers where the app's screen size may not adjust correctly. [compose-multiplatform #4620](https://github.com/JetBrains/compose-multiplatform/issues/4620)
-
 
 ## Download
 


### PR DESCRIPTION
refs: #11