### PR TITLE
Add a KDoc comments for the soil.query package

### DIFF
--- a/soil-query-core/src/androidMain/kotlin/soil/query/AndroidMemoryPressure.kt
+++ b/soil-query-core/src/androidMain/kotlin/soil/query/AndroidMemoryPressure.kt
@@ -9,6 +9,23 @@ import android.content.res.Configuration
 import soil.query.internal.MemoryPressure
 import soil.query.internal.MemoryPressureLevel
 
+/**
+ * Implementation of [MemoryPressure] for Android.
+ *
+ * In the Android system, [ComponentCallbacks2] is used to monitor memory pressure states.
+ * It notifies the memory pressure state based on the level parameter of [ComponentCallbacks2.onTrimMemory].
+ *
+ *     | Android Trim Level             | MemoryPressureLevel   |
+ *     |:-------------------------------|:----------------------|
+ *     | TRIM_MEMORY_UI_HIDDEN          | Low                   |
+ *     | TRIM_MEMORY_MODERATE           | Low                   |
+ *     | TRIM_MEMORY_RUNNING_MODERATE   | Low                   |
+ *     | TRIM_MEMORY_BACKGROUND         | High                  |
+ *     | TRIM_MEMORY_RUNNING_LOW        | High                  |
+ *     | TRIM_MEMORY_COMPLETE           | Critical              |
+ *     | TRIM_MEMORY_RUNNING_CRITICAL   | Critical              |
+ *
+ */
 class AndroidMemoryPressure(
     private val context: Context
 ) : MemoryPressure {
@@ -23,6 +40,9 @@ class AndroidMemoryPressure(
         obw = null
     }
 
+    /**
+     * Implementation of [ComponentCallbacks2] for observing memory pressure.
+     */
     class ObserverWrapper(
         private val observer: MemoryPressure.Observer
     ) : ComponentCallbacks2 {

--- a/soil-query-core/src/androidMain/kotlin/soil/query/AndroidNetworkConnectivity.kt
+++ b/soil-query-core/src/androidMain/kotlin/soil/query/AndroidNetworkConnectivity.kt
@@ -12,6 +12,17 @@ import androidx.annotation.RequiresPermission
 import soil.query.internal.NetworkConnectivity
 import soil.query.internal.NetworkConnectivityEvent
 
+/**
+ * Implementation of [NetworkConnectivity] for Android.
+ *
+ * In the Android system, [ConnectivityManager] is used to monitor network connectivity states.
+ *
+ * **Note**: This implementation requires the `ACCESS_NETWORK_STATE` permission.
+ *
+ * ```
+ * <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+ * ```
+ */
 class AndroidNetworkConnectivity(
     private val context: Context
 ) : NetworkConnectivity {
@@ -37,6 +48,9 @@ class AndroidNetworkConnectivity(
         obw = null
     }
 
+    /**
+     * Implementation of [ConnectivityManager.NetworkCallback] for observing network connectivity.
+     */
     class ObserverWrapper(
         private val observer: NetworkConnectivity.Observer
     ) : ConnectivityManager.NetworkCallback() {

--- a/soil-query-core/src/androidMain/kotlin/soil/query/AndroidWindowVisibility.kt
+++ b/soil-query-core/src/androidMain/kotlin/soil/query/AndroidWindowVisibility.kt
@@ -11,6 +11,12 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import soil.query.internal.WindowVisibility
 import soil.query.internal.WindowVisibilityEvent
 
+/**
+ * Implementation of [WindowVisibility] for Android.
+ *
+ * In the Android system, [ProcessLifecycleOwner] is used to monitor window visibility states.
+ * It notifies the window visibility state based on the lifecycle state of [ProcessLifecycleOwner].
+ */
 class AndroidWindowVisibility(
     private val lifecycleOwner: LifecycleOwner = ProcessLifecycleOwner.get()
 ) : WindowVisibility {
@@ -36,6 +42,9 @@ class AndroidWindowVisibility(
         }
     }
 
+    /**
+     * Implementation of [DefaultLifecycleObserver] for observing window visibility.
+     */
     class CallbackWrapper(
         private val callback: WindowVisibility.Observer
     ) : DefaultLifecycleObserver {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommand.kt
@@ -7,6 +7,16 @@ import soil.query.internal.RetryFn
 import soil.query.internal.exponentialBackOff
 import kotlin.coroutines.cancellation.CancellationException
 
+/**
+ * Fetches data for the [InfiniteQueryKey] using the value of [variable].
+ *
+ * @receiver [QueryCommand.Context] for [InfiniteQueryKey].
+ * @param T Type of data to retrieve.
+ * @param S Type of parameter.
+ * @param key Instance of a class implementing [InfiniteQueryKey].
+ * @param variable Value of the parameter required for fetching data for [InfiniteQueryKey].
+ * @param retryFn Retry strategy.
+ */
 suspend fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.fetch(
     key: InfiniteQueryKey<T, S>,
     variable: S,
@@ -22,6 +32,15 @@ suspend fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.fetch(
     }
 }
 
+/**
+ * Revalidates the data for the [InfiniteQueryKey] using the value of [chunks].
+ *
+ * @receiver [QueryCommand.Context] for [InfiniteQueryKey].
+ * @param T Type of data to retrieve.
+ * @param S Type of parameter.
+ * @param key Instance of a class implementing [InfiniteQueryKey].
+ * @param chunks Data to revalidate.
+ */
 suspend fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.revalidate(
     key: InfiniteQueryKey<T, S>,
     chunks: QueryChunks<T, S>
@@ -47,6 +66,15 @@ suspend fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.revalidate(
     return Result.success(newData)
 }
 
+/**
+ * Dispatches the result of fetching data for the [InfiniteQueryKey].
+ *
+ * @receiver [QueryCommand.Context] for [InfiniteQueryKey].
+ * @param T Type of data to retrieve.
+ * @param S Type of parameter.
+ * @param key Instance of a class implementing [InfiniteQueryKey].
+ * @param variable Value of the parameter required for fetching data for [InfiniteQueryKey].
+ */
 suspend inline fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.dispatchFetchChunksResult(
     key: InfiniteQueryKey<T, S>,
     variable: S
@@ -59,6 +87,15 @@ suspend inline fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.dispatchFetchC
         .onFailure(::dispatchFetchFailure)
 }
 
+/**
+ * Dispatches the result of revalidating data for the [InfiniteQueryKey].
+ *
+ * @receiver [QueryCommand.Context] for [InfiniteQueryKey].
+ * @param T Type of data to retrieve.
+ * @param S Type of parameter.
+ * @param key Instance of a class implementing [InfiniteQueryKey].
+ * @param chunks Data to revalidate.
+ */
 suspend inline fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.dispatchRevalidateChunksResult(
     key: InfiniteQueryKey<T, S>,
     chunks: QueryChunks<T, S>

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommands.kt
@@ -5,8 +5,22 @@ package soil.query
 
 import soil.query.internal.vvv
 
+/**
+ * Query command for [InfiniteQueryKey].
+ *
+ * @param T Type of data to retrieve.
+ * @param S Type of parameter.
+ */
 sealed class InfiniteQueryCommands<T, S> : QueryCommand<QueryChunks<T, S>> {
 
+    /**
+     * Performs data fetching and validation based on the current data state.
+     *
+     * This command is invoked via [InfiniteQueryRef] when a new mount point (subscriber) is added.
+     *
+     * @param key Instance of a class implementing [InfiniteQueryKey].
+     * @param revision The revision of the data to be fetched.
+     */
     data class Connect<T, S>(
         val key: InfiniteQueryKey<T, S>,
         val revision: String? = null
@@ -26,6 +40,14 @@ sealed class InfiniteQueryCommands<T, S> : QueryCommand<QueryChunks<T, S>> {
         }
     }
 
+    /**
+     * Invalidates the data and performs data fetching and validation based on the current data state.
+     *
+     * This command is invoked via [InfiniteQueryRef] when the data is invalidated.
+     *
+     * @param key Instance of a class implementing [InfiniteQueryKey].
+     * @param revision The revision of the data to be invalidated.
+     */
     data class Invalidate<T, S>(
         val key: InfiniteQueryKey<T, S>,
         val revision: String
@@ -45,6 +67,12 @@ sealed class InfiniteQueryCommands<T, S> : QueryCommand<QueryChunks<T, S>> {
         }
     }
 
+    /**
+     * Fetches additional data for [InfiniteQueryKey] using [param].
+     *
+     * @param key Instance of a class implementing [InfiniteQueryKey].
+     * @param param The parameter required for fetching data for [InfiniteQueryKey].
+     */
     data class LoadMore<T, S>(
         val key: InfiniteQueryKey<T, S>,
         val param: S

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryRef.kt
@@ -7,11 +7,27 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.launch
 
+/**
+ * A reference to an [Query] for [InfiniteQueryKey].
+ *
+ * @param T Type of data to retrieve.
+ * @param S Type of parameter.
+ * @property key Instance of a class implementing [InfiniteQueryKey].
+ * @param query Transparently referenced [Query].
+ * @constructor Creates an [InfiniteQueryRef].
+ */
 class InfiniteQueryRef<T, S>(
     val key: InfiniteQueryKey<T, S>,
     query: Query<QueryChunks<T, S>>
 ) : Query<QueryChunks<T, S>> by query {
 
+    /**
+     * Starts the [Query].
+     *
+     * This function must be invoked when a new mount point (subscriber) is added.
+     *
+     * @param scope The [CoroutineScope] to launch the [Query] actor.
+     */
     fun start(scope: CoroutineScope) {
         actor.launchIn(scope = scope)
         scope.launch {
@@ -20,14 +36,26 @@ class InfiniteQueryRef<T, S>(
         }
     }
 
+    /**
+     * Invalidates the [Query].
+     *
+     * Calling this function will invalidate the retrieved data of the [Query],
+     * setting [QueryModel.isInvalidated] to `true` until revalidation is completed.
+     */
     suspend fun invalidate() {
         command.send(InfiniteQueryCommands.Invalidate(key, state.value.revision))
     }
 
+    /**
+     * Resumes the [Query].
+     */
     private suspend fun resume() {
         command.send(InfiniteQueryCommands.Connect(key, state.value.revision))
     }
 
+    /**
+     * Fetches data for the [InfiniteQueryKey] using the value of [param].
+     */
     suspend fun loadMore(param: S) {
         command.send(InfiniteQueryCommands.LoadMore(key, param))
     }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/Mutation.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/Mutation.kt
@@ -8,13 +8,37 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
+/**
+ * Mutation as the base interface for an [MutationClient] implementations.
+ *
+ * @param T Type of the return value from the mutation.
+ */
 interface Mutation<T> {
+
+    /**
+     * Coroutine [Flow] to launch the actor.
+     */
     val actor: Flow<*>
+
+    /**
+     * [Shared Flow][SharedFlow] to receive mutation [events][MutationEvent].
+     */
     val event: SharedFlow<MutationEvent>
+
+    /**
+     * [State Flow][StateFlow] to receive the current state of the mutation.
+     */
     val state: StateFlow<MutationState<T>>
+
+    /**
+     * [Send Channel][SendChannel] to manipulate the state of the mutation.
+     */
     val command: SendChannel<MutationCommand<T>>
 }
 
+/**
+ * Events occurring in the mutation.
+ */
 enum class MutationEvent {
     Ping
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationAction.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationAction.kt
@@ -5,17 +5,40 @@ package soil.query
 
 import soil.query.internal.epoch
 
+/**
+ * Mutation actions are used to update the [mutation state][MutationState].
+ *
+ * @param T Type of the return value from the mutation.
+ */
 sealed interface MutationAction<out T> {
 
+    /**
+     * Resets the mutation state.
+     */
     data object Reset : MutationAction<Nothing>
 
+    /**
+     * Indicates that the mutation is in progress.
+     */
     data object Mutating : MutationAction<Nothing>
 
+    /**
+     * Indicates that the mutation is successful.
+     *
+     * @param data The data to be updated.
+     * @param dataUpdatedAt The timestamp when the data was updated.
+     */
     data class MutateSuccess<T>(
         val data: T,
         val dataUpdatedAt: Long? = null
     ) : MutationAction<T>
 
+    /**
+     * Indicates that the mutation has failed.
+     *
+     * @param error The error that occurred.
+     * @param errorUpdatedAt The timestamp when the error occurred.
+     */
     data class MutateFailure(
         val error: Throwable,
         val errorUpdatedAt: Long? = null
@@ -25,6 +48,9 @@ sealed interface MutationAction<out T> {
 typealias MutationReducer<T> = (MutationState<T>, MutationAction<T>) -> MutationState<T>
 typealias MutationDispatch<T> = (MutationAction<T>) -> Unit
 
+/**
+ * Creates a [MutationReducer] function.
+ */
 fun <T> createMutationReducer(): MutationReducer<T> = { state, action ->
     when (action) {
         is MutationAction.Reset -> {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationClient.kt
@@ -3,10 +3,19 @@
 
 package soil.query
 
+/**
+ * A Mutation client, which allows you to make mutations actor and handle [MutationKey].
+ */
 interface MutationClient {
 
+    /**
+     * The default mutation options.
+     */
     val defaultMutationOptions: MutationOptions
 
+    /**
+     * Gets the [MutationRef] by the specified [MutationKey].
+     */
     fun <T, S> getMutation(
         key: MutationKey<T, S>
     ): MutationRef<T, S>

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationCommands.kt
@@ -5,7 +5,22 @@ package soil.query
 
 import soil.query.internal.vvv
 
+/**
+ * Mutation commands are used to update the [mutation state][MutationState].
+ *
+ * @param T Type of the return value from the mutation.
+ */
 sealed class MutationCommands<T> : MutationCommand<T> {
+
+    /**
+     * Executes the [mutate][MutationKey.mutate] function of the specified [MutationKey].
+     *
+     * **Note:** The mutation is not executed if the revision is different.
+     *
+     * @param key Instance of a class implementing [MutationKey].
+     * @param variable The variable to be mutated.
+     * @param revision The revision of the mutation state.
+     */
     data class Mutate<T, S>(
         val key: MutationKey<T, S>,
         val variable: S,
@@ -22,6 +37,9 @@ sealed class MutationCommands<T> : MutationCommand<T> {
         }
     }
 
+    /**
+     * Resets the mutation state.
+     */
     class Reset<T> : MutationCommands<T>() {
 
         override suspend fun handle(ctx: MutationCommand.Context<T>) {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationModel.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationModel.kt
@@ -5,23 +5,84 @@ package soil.query
 
 import kotlin.math.max
 
+/**
+ * Data model for the state handled by [MutationKey].
+ *
+ * All data models related to mutations, implement this interface.
+ *
+ * @param T Type of the return value from the mutation.
+ */
 interface MutationModel<out T> {
+
+    /**
+     * The return value from the mutation.
+     */
     val data: T?
+
+    /**
+     * The timestamp when the data was updated.
+     */
     val dataUpdatedAt: Long
+
+    /**
+     * The error that occurred.
+     */
     val error: Throwable?
+
+    /**
+     * The timestamp when the error occurred.
+     */
     val errorUpdatedAt: Long
+
+    /**
+     * The status of the mutation.
+     */
     val status: MutationStatus
+
+    /**
+     * The number of times the mutation has been mutated.
+     */
     val mutatedCount: Int
 
+    /**
+     * The revision of the currently snapshot.
+     */
     val revision: String get() = "d-$dataUpdatedAt/e-$errorUpdatedAt"
+
+    /**
+     * The timestamp when the mutation was submitted.
+     */
     val submittedAt: Long get() = max(dataUpdatedAt, errorUpdatedAt)
+
+    /**
+     * Returns `true` if the mutation is idle, `false` otherwise.
+     */
     val isIdle: Boolean get() = status == MutationStatus.Idle
+
+    /**
+     * Returns `true` if the mutation is pending, `false` otherwise.
+     */
     val isPending: Boolean get() = status == MutationStatus.Pending
+
+    /**
+     * Returns `true` if the mutation is successful, `false` otherwise.
+     */
     val isSuccess: Boolean get() = status == MutationStatus.Success
+
+    /**
+     * Returns `true` if the mutation is a failure, `false` otherwise.
+     */
     val isFailure: Boolean get() = status == MutationStatus.Failure
+
+    /**
+     * Returns `true` if the mutation has been mutated, `false` otherwise.
+     */
     val isMutated: Boolean get() = mutatedCount > 0
 }
 
+/**
+ * The status of the mutation.
+ */
 enum class MutationStatus {
     Idle,
     Pending,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationNotifier.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationNotifier.kt
@@ -3,6 +3,19 @@
 
 package soil.query
 
+/**
+ * MutationNotifier is used to notify the mutation result.
+ */
 fun interface MutationNotifier {
+
+    /**
+     * Notifies the mutation success
+     *
+     * Mutation success usually implies data update, causing side effects on related queries.
+     * This callback is used as a trigger for re-fetching or revalidating data managed by queries.
+     * It invokes with the [QueryEffect] set in [MutationKey.onQueryUpdate].
+     *
+     * @param sideEffects The side effects of the mutation for related queries.
+     */
     fun onMutateSuccess(sideEffects: QueryEffect)
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationOptions.kt
@@ -12,11 +12,19 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-
+/**
+ * [MutationOptions] providing settings related to the internal behavior of an [Mutation].
+ */
 data class MutationOptions(
-    // NOTE: Only allows mutate to execute once while active (until reset).
+
+    /**
+     * Only allows mutate to execute once while active (until reset).
+     */
     val isOneShot: Boolean = false,
-    // NOTE: Requires revision match as a precondition for executing mutate.
+
+    /**
+     * Requires revision match as a precondition for executing mutate.
+     */
     val isStrictMode: Boolean = false,
 
     // ----- ActorOptions ----- //

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationReceiver.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationReceiver.kt
@@ -3,7 +3,21 @@
 
 package soil.query
 
-// NOTE: Extension receiver for referencing external instances needed when executing mutate
+/**
+ * Extension receiver for referencing external instances needed when executing [mutate][MutationKey.mutate].
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * class KtorReceiver(
+ *     val client: HttpClient
+ * ) : QueryReceiver, MutationReceiver
+ * ```
+ */
 interface MutationReceiver {
+
+    /**
+     * Default implementation for [MutationReceiver].
+     */
     companion object : MutationReceiver
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationRef.kt
@@ -9,11 +9,27 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.launch
 
+/**
+ * A reference to a [Mutation] for [MutationKey].
+ *
+ * @param T Type of the return value from the mutation.
+ * @param S Type of the variable to be mutated.
+ * @property key Instance of a class implementing [MutationKey].
+ * @param mutation The mutation to perform.
+ * @constructor Creates a [MutationRef].
+ */
 class MutationRef<T, S>(
     val key: MutationKey<T, S>,
     mutation: Mutation<T>
 ) : Mutation<T> by mutation {
 
+    /**
+     * Starts the [Mutation].
+     *
+     * This function must be invoked when a new mount point (subscriber) is added.
+     *
+     * @param scope The [CoroutineScope] to launch the [Mutation] actor.
+     */
     fun start(scope: CoroutineScope) {
         actor.launchIn(scope = scope)
         scope.launch {
@@ -21,6 +37,12 @@ class MutationRef<T, S>(
         }
     }
 
+    /**
+     * Mutates the variable.
+     *
+     * @param variable The variable to be mutated.
+     * @return The result of the mutation.
+     */
     suspend fun mutate(variable: S): T {
         mutateAsync(variable)
         val submittedAt = state.value.submittedAt
@@ -34,10 +56,18 @@ class MutationRef<T, S>(
         }
     }
 
+    /**
+     * Mutates the variable asynchronously.
+     *
+     * @param variable The variable to be mutated.
+     */
     suspend fun mutateAsync(variable: S) {
         command.send(MutationCommands.Mutate(key, variable, state.value.revision))
     }
 
+    /**
+     * Resets the mutation state.
+     */
     suspend fun reset() {
         command.send(MutationCommands.Reset())
     }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationState.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationState.kt
@@ -3,6 +3,9 @@
 
 package soil.query
 
+/**
+ * State for managing the execution result of [Mutation].
+ */
 data class MutationState<out T>(
     override val data: T? = null,
     override val dataUpdatedAt: Long = 0,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/Query.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/Query.kt
@@ -8,13 +8,37 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
+/**
+ * Query as the base interface for an [QueryClient] implementations.
+ *
+ * @param T Type of the return value from the query.
+ */
 interface Query<T> {
+
+    /**
+     * Coroutine [Flow] to launch the actor.
+     */
     val actor: Flow<*>
+
+    /**
+     * [Shared Flow][SharedFlow] to receive query [events][QueryEvent].
+     */
     val event: SharedFlow<QueryEvent>
+
+    /**
+     * [State Flow][StateFlow] to receive the current state of the query.
+     */
     val state: StateFlow<QueryState<T>>
+
+    /**
+     * [Send Channel][SendChannel] to manipulate the state of the query.
+     */
     val command: SendChannel<QueryCommand<T>>
 }
 
+/**
+ * Events occurring in the query.
+ */
 enum class QueryEvent {
     Invalidate,
     Resume,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryAction.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryAction.kt
@@ -3,26 +3,59 @@
 
 package soil.query
 
+/**
+ * Query actions are used to update the [query state][QueryState].
+ *
+ * @param T Type of the return value from the query.
+ */
 sealed interface QueryAction<out T> {
 
+    /**
+     * Indicates that the query is fetching data.
+     *
+     * @param isInvalidated Indicates whether the query is invalidated.
+     */
     data class Fetching(
         val isInvalidated: Boolean? = null
     ) : QueryAction<Nothing>
 
+    /**
+     * Indicates that the query is successful.
+     *
+     * @param data The data to be updated.
+     * @param dataUpdatedAt The timestamp when the data was updated.
+     * @param dataStaleAt The timestamp when the data becomes stale.
+     */
     data class FetchSuccess<T>(
         val data: T,
         val dataUpdatedAt: Long,
         val dataStaleAt: Long
     ) : QueryAction<T>
 
+    /**
+     * Indicates that the query has failed.
+     *
+     * @param error The error that occurred.
+     * @param errorUpdatedAt The timestamp when the error occurred.
+     * @param paused The paused status of the query.
+     */
     data class FetchFailure(
         val error: Throwable,
         val errorUpdatedAt: Long,
         val paused: QueryFetchStatus.Paused? = null
     ) : QueryAction<Nothing>
 
+    /**
+     * Invalidates the query.
+     */
     data object Invalidate : QueryAction<Nothing>
 
+    /**
+     * Forces the query to update the data.
+     *
+     * @param data The data to be updated.
+     * @param dataUpdatedAt The timestamp when the data was updated.
+     */
     data class ForceUpdate<T>(
         val data: T,
         val dataUpdatedAt: Long
@@ -32,6 +65,9 @@ sealed interface QueryAction<out T> {
 typealias QueryReducer<T> = (QueryState<T>, QueryAction<T>) -> QueryState<T>
 typealias QueryDispatch<T> = (QueryAction<T>) -> Unit
 
+/**
+ * Creates a [QueryReducer] function.
+ */
 fun <T> createQueryReducer(): QueryReducer<T> = { state, action ->
     when (action) {
         is QueryAction.Fetching -> {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryChunk.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryChunk.kt
@@ -3,6 +3,12 @@
 
 package soil.query
 
+/**
+ * Data chunk type that holds values in combination with [param] related to [data].
+ *
+ * In [InfiniteQueryKey], multiple data fetches are performed due to additional retrieval.
+ * [QueryChunk] is a data structure for holding the result of one fetch. [QueryChunks] holds multiple [QueryChunk] results.
+ */
 data class QueryChunk<T, S>(
     val data: T,
     val param: S
@@ -10,9 +16,15 @@ data class QueryChunk<T, S>(
 
 typealias QueryChunks<T, S> = List<QueryChunk<T, S>>
 
+/**
+ * Returns the data of all chunks.
+ */
 val <T, S> QueryChunks<List<T>, S>.chunkedData: List<T>
     get() = flatMap { it.data }
 
+/**
+ * Transforms all chunk data with [transform] and returns the extracted data using [selector].
+ */
 inline fun <T, S, U, E> QueryChunks<T, S>.chunked(
     transform: (QueryChunk<T, S>) -> Iterable<U>,
     selector: (U) -> E
@@ -20,6 +32,9 @@ inline fun <T, S, U, E> QueryChunks<T, S>.chunked(
     return flatMap(transform).map(selector)
 }
 
+/**
+ * Modifies the data of all chunks that match the condition.
+ */
 fun <T, S> QueryChunks<List<T>, S>.modifyData(
     match: (T) -> Boolean,
     edit: T.() -> T

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
@@ -5,47 +5,120 @@ package soil.query
 
 import soil.query.internal.UniqueId
 
+/**
+ * A Query client, which allows you to make queries actor and handle [QueryKey] and [InfiniteQueryKey].
+ */
 interface QueryClient {
 
+    /**
+     * The default query options.
+     */
     val defaultQueryOptions: QueryOptions
 
+    /**
+     * Gets the [QueryRef] by the specified [QueryKey].
+     */
     fun <T> getQuery(key: QueryKey<T>): QueryRef<T>
 
+    /**
+     * Gets the [InfiniteQueryRef] by the specified [InfiniteQueryKey].
+     */
     fun <T, S> getInfiniteQuery(key: InfiniteQueryKey<T, S>): InfiniteQueryRef<T, S>
 
+    /**
+     * Prefetches the query by the specified [QueryKey].
+     *
+     * **Note:**
+     * Prefetch is executed within a [kotlinx.coroutines.CoroutineScope] associated with the instance of [QueryClient].
+     * After data retrieval, subscription is automatically unsubscribed, hence the caching period depends on [QueryOptions].
+     */
     fun <T> prefetchQuery(key: QueryKey<T>)
 
+    /**
+     * Prefetches the infinite query by the specified [InfiniteQueryKey].
+     *
+     * **Note:**
+     * Prefetch is executed within a [kotlinx.coroutines.CoroutineScope] associated with the instance of [QueryClient].
+     * After data retrieval, subscription is automatically unsubscribed, hence the caching period depends on [QueryOptions].
+     */
     fun <T, S> prefetchInfiniteQuery(key: InfiniteQueryKey<T, S>)
 }
 
+/**
+ * Interface for directly accessing retrieved [Query] data by [QueryClient].
+ *
+ * [QueryPlaceholderData] is designed to calculate initial data from other [Query].
+ * This is useful when the type included in the list on the overview screen matches the type of content on the detailed screen.
+ */
 interface QueryReadonlyClient {
+
+    /**
+     * Retrieves data of the [QueryKey] associated with the [id].
+     */
     fun <T> getQueryData(id: QueryId<T>): T?
 
+    /**
+     * Retrieves data of the [InfiniteQueryKey] associated with the [id].
+     */
     fun <T, S> getInfiniteQueryData(id: InfiniteQueryId<T, S>): QueryChunks<T, S>?
 }
 
+/**
+ * Interface for causing side effects on [Query] under the control of [QueryClient].
+ *
+ * [QueryEffect] is designed to allow side effects such as updating, deleting, and revalidating queries.
+ * It is useful for handling [MutationKey.onQueryUpdate] after executing [Mutation] that affects [Query] data.
+ */
 interface QueryMutableClient : QueryReadonlyClient {
 
+    /**
+     * Updates the data of the [QueryKey] associated with the [id].
+     */
     fun <T> updateQueryData(
         id: QueryId<T>,
         edit: T.() -> T
     )
 
+    /**
+     * Updates the data of the [InfiniteQueryKey] associated with the [id].
+     */
     fun <T, S> updateInfiniteQueryData(
         id: InfiniteQueryId<T, S>,
         edit: QueryChunks<T, S>.() -> QueryChunks<T, S>
     )
 
+    /**
+     * Invalidates the queries by the specified [InvalidateQueriesFilter].
+     */
     fun invalidateQueries(filter: InvalidateQueriesFilter)
 
+    /**
+     * Invalidates the queries by the specified [UniqueId].
+     */
     fun <U : UniqueId> invalidateQueriesBy(vararg ids: U)
 
+    /**
+     * Removes the queries by the specified [RemoveQueriesFilter].
+     *
+     * **Note:**
+     * Queries will be removed from [QueryClient], but [QueryRef] instances on the subscriber side will remain until they are dereferenced.
+     * Also, the [kotlinx.coroutines.CoroutineScope] associated with the [kotlinx.coroutines.Job] will be canceled at the time of removal.
+     */
     fun removeQueries(filter: RemoveQueriesFilter)
 
+    /**
+     * Removes the queries by the specified [UniqueId].
+     */
     fun <U : UniqueId> removeQueriesBy(vararg ids: U)
 
+    /**
+     * Resumes the queries by the specified [ResumeQueriesFilter].
+     */
     fun resumeQueries(filter: ResumeQueriesFilter)
 
+    /**
+     * Resumes the queries by the specified [UniqueId].
+     */
     fun <U : UniqueId> resumeQueriesBy(vararg ids: U)
 }
 

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommand.kt
@@ -12,10 +12,23 @@ import soil.query.internal.toEpoch
 import soil.query.internal.vvv
 import kotlin.coroutines.cancellation.CancellationException
 
+/**
+ * Query command to handle query.
+ *
+ * @param T Type of the return value from the query.
+ */
 interface QueryCommand<T> {
 
+    /**
+     * Handles the query.
+     */
     suspend fun handle(ctx: Context<T>)
 
+    /**
+     * Context for query command.
+     *
+     * @param T Type of the return value from the query.
+     */
     interface Context<T> {
         val receiver: QueryReceiver
         val options: QueryOptions
@@ -24,6 +37,11 @@ interface QueryCommand<T> {
     }
 }
 
+/**
+ * Determines whether a fetch operation is necessary based on the current state.
+ *
+ * @return `true` if fetch operation is allowed, `false` otherwise.
+ */
 fun <T> QueryCommand.Context<T>.shouldFetch(revision: String? = null): Boolean {
     if (revision != null && revision != state.revision) {
         return false
@@ -37,6 +55,15 @@ fun <T> QueryCommand.Context<T>.shouldFetch(revision: String? = null): Boolean {
         || state.isStaled()
 }
 
+/**
+ * Determines whether query processing needs to be paused based on [error].
+ *
+ * Use [QueryOptions.pauseDurationAfter] for cases like HTTP 503 errors, where requests from the client need to be stopped for a certain period.
+ * There's currently no mechanism for automatic resumption after the specified duration.
+ * Resuming will require implementation on the UI, such as a retry button.
+ *
+ * @return Returns [QueryFetchStatus.Paused] if pausing is necessary, otherwise returns `null`.
+ */
 fun <T> QueryCommand.Context<T>.shouldPause(error: Throwable): QueryFetchStatus.Paused? {
     val pauseTime = options.pauseDurationAfter?.invoke(error)
     if (pauseTime != null && pauseTime.isPositive()) {
@@ -45,6 +72,13 @@ fun <T> QueryCommand.Context<T>.shouldPause(error: Throwable): QueryFetchStatus.
     return null
 }
 
+/**
+ * Fetches the data.
+ *
+ * @param key Instance of a class implementing [QueryKey].
+ * @param retryFn The retry function.
+ * @return The result of the fetch.
+ */
 suspend fun <T> QueryCommand.Context<T>.fetch(
     key: QueryKey<T>,
     retryFn: RetryFn<T> = options.exponentialBackOff(onRetry = onRetryCallback(key.id))
@@ -59,6 +93,11 @@ suspend fun <T> QueryCommand.Context<T>.fetch(
     }
 }
 
+/**
+ * Dispatches the fetch result.
+ *
+ * @param key Instance of a class implementing [QueryKey].
+ */
 suspend inline fun <T> QueryCommand.Context<T>.dispatchFetchResult(key: QueryKey<T>) {
     fetch(key)
         .run { key.onRecoverData()?.let(::recoverCatching) ?: this }
@@ -66,6 +105,11 @@ suspend inline fun <T> QueryCommand.Context<T>.dispatchFetchResult(key: QueryKey
         .onFailure(::dispatchFetchFailure)
 }
 
+/**
+ * Dispatches the fetch success.
+ *
+ * @param data The fetched data.
+ */
 fun <T> QueryCommand.Context<T>.dispatchFetchSuccess(data: T) {
     val currentAt = epoch()
     val action = QueryAction.FetchSuccess(
@@ -76,6 +120,11 @@ fun <T> QueryCommand.Context<T>.dispatchFetchSuccess(data: T) {
     dispatch(action)
 }
 
+/**
+ * Dispatches the fetch failure.
+ *
+ * @param error The fetch error.
+ */
 fun <T> QueryCommand.Context<T>.dispatchFetchFailure(error: Throwable) {
     val currentAt = epoch()
     val action = QueryAction.FetchFailure(

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommands.kt
@@ -5,7 +5,21 @@ package soil.query
 
 import soil.query.internal.vvv
 
+/**
+ * Query command for [QueryKey].
+ *
+ * @param T Type of data to retrieve.
+ */
 sealed class QueryCommands<T> : QueryCommand<T> {
+
+    /**
+     * Performs data fetching and validation based on the current data state.
+     *
+     * This command is invoked via [QueryRef] when a new mount point (subscriber) is added.
+     *
+     * @param key Instance of a class implementing [QueryKey].
+     * @param revision The revision of the data to be fetched.
+     */
     data class Connect<T>(
         val key: QueryKey<T>,
         val revision: String? = null
@@ -21,6 +35,14 @@ sealed class QueryCommands<T> : QueryCommand<T> {
         }
     }
 
+    /**
+     * Invalidates the data and performs data fetching and validation based on the current data state.
+     *
+     * This command is invoked via [QueryRef] when the data is invalidated.
+     *
+     * @param key Instance of a class implementing [QueryKey].
+     * @param revision The revision of the data to be invalidated.
+     */
     data class Invalidate<T>(
         val key: QueryKey<T>,
         val revision: String

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryFilter.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryFilter.kt
@@ -5,27 +5,56 @@ package soil.query
 
 import soil.query.internal.SurrogateKey
 
+/**
+ * Interface for filtering side effect queries by [QueryMutableClient].
+ */
 interface QueryFilter {
 
+    /**
+     * Management category of queries to be filtered.
+     *
+     * If unspecified, all [QueryFilterType]s are targeted.
+     */
     val type: QueryFilterType?
 
+    /**
+     * Tag keys of queries to be filtered.
+     */
     val keys: Array<SurrogateKey>?
 
+    /**
+     * Further conditions to narrow down the filtering targets based on fields of [QueryModel].
+     */
     val predicate: ((QueryModel<*>) -> Boolean)?
 }
 
+/**
+ * Filter for invalidating queries.
+ *
+ * @see [QueryMutableClient.invalidateQueries], [QueryMutableClient.invalidateQueriesBy]
+ */
 class InvalidateQueriesFilter(
     override val type: QueryFilterType? = null,
     override val keys: Array<SurrogateKey>? = null,
     override val predicate: ((QueryModel<*>) -> Boolean)? = null,
 ) : QueryFilter
 
+/**
+ * Filter for removing queries.
+ *
+ * @see [QueryMutableClient.removeQueries], [QueryMutableClient.removeQueriesBy]
+ */
 class RemoveQueriesFilter(
     override val type: QueryFilterType? = null,
     override val keys: Array<SurrogateKey>? = null,
     override val predicate: ((QueryModel<*>) -> Boolean)? = null,
 ) : QueryFilter
 
+/**
+ * Filter for resuming queries.
+ *
+ * @see [QueryMutableClient.resumeQueries], [QueryMutableClient.resumeQueriesBy]
+ */
 class ResumeQueriesFilter(
     override val keys: Array<SurrogateKey>? = null,
     override val predicate: (QueryModel<*>) -> Boolean
@@ -33,6 +62,9 @@ class ResumeQueriesFilter(
     override val type: QueryFilterType = QueryFilterType.Active
 }
 
+/**
+ * Query management categories for filtering.
+ */
 enum class QueryFilterType {
     Active,
     Inactive

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
@@ -6,16 +6,54 @@ package soil.query
 import soil.query.internal.SurrogateKey
 import soil.query.internal.UniqueId
 
+/**
+ * [QueryKey] for managing [Query] associated with [id].
+ *
+ * @param T Type of data to retrieve.
+ */
 interface QueryKey<T> {
+
+    /**
+     * A unique identifier used for managing [QueryKey].
+     */
     val id: QueryId<T>
+
+    /**
+     * Suspending function to retrieve data.
+     *
+     * @receiver QueryReceiver You can use a custom QueryReceiver within the fetch function.
+     */
     val fetch: suspend QueryReceiver.() -> T
+
+    /**
+     * Configure the Query [options].
+     *
+     * If unspecified, the default value of [SwrCachePolicy] is used.
+     */
     val options: QueryOptions?
 
+    /**
+     * Function to specify placeholder data.
+     *
+     * You can specify placeholder data instead of the initial loading state.
+     *
+     * @see QueryPlaceholderData
+     */
     fun onPlaceholderData(): QueryPlaceholderData<T>? = null
 
+    /**
+     * Function to convert specific exceptions as data.
+     *
+     * Depending on the type of exception that occurred during data retrieval, it is possible to recover it as normal data.
+     *
+     * @see QueryRecoverData
+     */
     fun onRecoverData(): QueryRecoverData<T>? = null
 }
 
+/**
+ * Unique identifier for [QueryKey].
+ */
 @Suppress("unused")
 open class QueryId<T>(
     override val namespace: String,
@@ -40,6 +78,20 @@ open class QueryId<T>(
     }
 }
 
+/**
+ * Function for building implementations of [QueryKey] using [Kotlin Delegation](https://kotlinlang.org/docs/delegation.html).
+ *
+ * **Note:** By implementing through delegation, you can reduce the impact of future changes to [QueryKey] interface extensions.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * class GetPostKey(private val postId: Int) : QueryKey<Post> by buildQueryKey(
+ *   id = Id(postId),
+ *   fetch = { ... }
+ * )
+ * ```
+ */
 fun <T> buildQueryKey(
     id: QueryId<T>,
     fetch: suspend QueryReceiver.() -> T,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryModel.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryModel.kt
@@ -5,26 +5,90 @@ package soil.query
 
 import soil.query.internal.epoch
 
+/**
+ * Data model for the state handled by [QueryKey] or [InfiniteQueryKey].
+ *
+ * All data models related to queries, implement this interface.
+ *
+ * @param T Type of data to retrieve.
+ */
 interface QueryModel<out T> {
+
+    /**
+     * The return value from the query.
+     */
     val data: T?
+
+    /**
+     * The timestamp when the data was updated.
+     */
     val dataUpdatedAt: Long
+
+    /**
+     * The timestamp when the data is considered stale.
+     */
     val dataStaleAt: Long
+
+    /**
+     * The error that occurred.
+     */
     val error: Throwable?
+
+    /**
+     * The timestamp when the error occurred.
+     */
     val errorUpdatedAt: Long
+
+    /**
+     * The status of the query.
+     */
     val status: QueryStatus
+
+    /**
+     * The fetch status of the query.
+     */
     val fetchStatus: QueryFetchStatus
+
+    /**
+     * Returns `true` if the query is invalidated, `false` otherwise.
+     */
     val isInvalidated: Boolean
+
+    /**
+     * Returns `true` if the query is placeholder data, `false` otherwise.
+     */
     val isPlaceholderData: Boolean
 
+    /**
+     * The revision of the currently snapshot.
+     */
     val revision: String get() = "d-$dataUpdatedAt/e-$errorUpdatedAt"
+
+    /**
+     * Returns `true` if the query is pending, `false` otherwise.
+     */
     val isPending: Boolean get() = status == QueryStatus.Pending
+
+    /**
+     * Returns `true` if the query is successful, `false` otherwise.
+     */
     val isSuccess: Boolean get() = status == QueryStatus.Success
+
+    /**
+     * Returns `true` if the query is a failure, `false` otherwise.
+     */
     val isFailure: Boolean get() = status == QueryStatus.Failure
 
+    /**
+     * Returns `true` if the query is staled, `false` otherwise.
+     */
     fun isStaled(currentAt: Long = epoch()): Boolean {
         return dataStaleAt < currentAt
     }
 
+    /**
+     * Returns `true` if the query is paused, `false` otherwise.
+     */
     fun isPaused(currentAt: Long = epoch()): Boolean {
         return when (val value = fetchStatus) {
             is QueryFetchStatus.Paused -> value.unpauseAt > currentAt
@@ -34,13 +98,20 @@ interface QueryModel<out T> {
     }
 }
 
+/**
+ * The status of the query.
+ */
 enum class QueryStatus {
     Pending,
     Success,
     Failure
 }
 
+/**
+ * The fetch status of the query.
+ */
 sealed class QueryFetchStatus {
+
     data object Idle : QueryFetchStatus()
     data object Fetching : QueryFetchStatus()
     data class Paused(

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryOptions.kt
@@ -14,12 +14,50 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
+/**
+ * [QueryOptions] providing settings related to the internal behavior of an [Query].
+ */
 data class QueryOptions(
+
+    /**
+     * The duration after which the returned value of the fetch function block is considered stale.
+     */
     val staleTime: Duration = Duration.ZERO,
+
+    /**
+     * The period during which the Key's return value, if not referenced anywhere, is temporarily cached in memory.
+     */
     val gcTime: Duration = 5.minutes,
+
+    /**
+     * Maximum window time on prefetch processing.
+     *
+     * If this time is exceeded, the [kotlinx.coroutines.CoroutineScope] within the prefetch processing will terminate,
+     * but the command processing within the Actor will continue as long as [keepAliveTime] is set.
+     */
     val prefetchWindowTime: Duration = 1.seconds,
+
+    /**
+     * Determines whether query processing needs to be paused based on error.
+     *
+     * @see [shouldPause]
+     */
     val pauseDurationAfter: ((Throwable) -> Duration?)? = null,
+
+    /**
+     * Automatically revalidate active [Query] when the network reconnects.
+     *
+     * **Note:**
+     * This setting is only effective when [soil.query.internal.NetworkConnectivity] is available.
+     */
     val revalidateOnReconnect: Boolean = true,
+
+    /**
+     * Automatically revalidate active [Query] when the window is refocused.
+     *
+     * **Note:**
+     * This setting is only effective when [soil.query.internal.WindowVisibility] is available.
+     */
     val revalidateOnFocus: Boolean = true,
 
     // ----- ActorOptions ----- //

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryReceiver.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryReceiver.kt
@@ -3,7 +3,21 @@
 
 package soil.query
 
-// NOTE: Extension receiver for referencing external instances needed when executing query.
+/**
+ * Extension receiver for referencing external instances needed when executing query.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * class KtorReceiver(
+ *     val client: HttpClient
+ * ) : QueryReceiver, MutationReceiver
+ * ```
+ */
 interface QueryReceiver {
+
+    /**
+     * Default implementation for [QueryReceiver].
+     */
     companion object : QueryReceiver
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryRef.kt
@@ -7,10 +7,26 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.launch
 
+/**
+ * A reference to an [Query] for [QueryKey].
+ *
+ * @param T Type of data to retrieve.
+ * @property key Instance of a class implementing [QueryKey].
+ * @param query Transparently referenced [Query].
+ * @constructor Creates an [QueryRef]
+ */
 class QueryRef<T>(
     val key: QueryKey<T>,
     query: Query<T>
 ) : Query<T> by query {
+
+    /**
+     * Starts the [Query].
+     *
+     * This function must be invoked when a new mount point (subscriber) is added.
+     *
+     * @param scope The [CoroutineScope] to launch the [Query] actor.
+     */
     fun start(scope: CoroutineScope) {
         actor.launchIn(scope = scope)
         scope.launch {
@@ -19,10 +35,19 @@ class QueryRef<T>(
         }
     }
 
+    /**
+     * Invalidates the [Query].
+     *
+     * Calling this function will invalidate the retrieved data of the [Query],
+     * setting [QueryModel.isInvalidated] to `true` until revalidation is completed.
+     */
     suspend fun invalidate() {
         command.send(QueryCommands.Invalidate(key, state.value.revision))
     }
 
+    /**
+     * Resumes the [Query].
+     */
     private suspend fun resume() {
         command.send(QueryCommands.Connect(key, state.value.revision))
     }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryState.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryState.kt
@@ -3,6 +3,9 @@
 
 package soil.query
 
+/**
+ * State for managing the execution result of [Query].
+ */
 data class QueryState<out T>(
     override val data: T? = null,
     override val dataUpdatedAt: Long = 0,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrClient.kt
@@ -3,11 +3,35 @@
 
 package soil.query
 
+/**
+ * An all-in-one [SwrClient] integrating [MutationClient] and [QueryClient] for library users.
+ *
+ * Swr stands for "stall-while-revalidate".
+ */
 interface SwrClient : MutationClient, QueryClient {
 
+    /**
+     * Executes side effects for queries.
+     */
     fun perform(sideEffects: QueryEffect)
 
+    /**
+     * Executes initialization procedures based on events.
+     *
+     * Features dependent on the platform are lazily initialized.
+     * The following features work correctly by notifying the start of [SwrClient] usage for each mount:
+     * - [soil.query.internal.NetworkConnectivity]
+     * - [soil.query.internal.MemoryPressure]
+     * - [soil.query.internal.WindowVisibility]
+     *
+     * @param id Unique string for each mount point.
+     */
     fun onMount(id: String)
 
+    /**
+     * Executes cleanup procedures based on events.
+     *
+     * @param id Unique string for each mount point.
+     */
     fun onUnmount(id: String)
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/ActorOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/ActorOptions.kt
@@ -5,10 +5,32 @@ package soil.query.internal
 
 import kotlin.time.Duration
 
+/**
+ * Interface providing settings related to the internal behavior of an Actor.
+ *
+ * The actual Actor is managed as a Coroutine Flow for each [UniqueId].
+ * Using [newSharingStarted], it remains active only when there are subscribers.
+ */
 interface ActorOptions {
+
+    /**
+     * Duration to remain state as an active.
+     *
+     * The temporary measure to keep the state active once it's no longer referenced anywhere.
+     *
+     * **Note:** On the Android platform, there is a possibility of temporarily unsubscribing due to configuration changes such as screen rotation.
+     * Set a duration of at least a few seconds to ensure that the Job processing within the Coroutine Flow is not canceled.
+     * This value has the same meaning as [SharingStarted.WhileSubscribed(5_000)](https://github.com/search?q=repo%3Aandroid%2Fnowinandroid+WhileSubscribed) defined in ViewModel in [Now in Android App](https://github.com/android/nowinandroid).
+     */
     val keepAliveTime: Duration
 }
 
+/**
+ * Creates a new [ActorSharingStarted] specific for Actor.
+ *
+ * @param onActive Callback handler to notify when becoming active.
+ * @param onInactive Callback handler to notify when becoming inactive.
+ */
 fun ActorOptions.newSharingStarted(
     onActive: ActorCallback? = null,
     onInactive: ActorCallback? = null

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/ActorSharingStarted.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/ActorSharingStarted.kt
@@ -10,6 +10,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.onEach
 import kotlin.time.Duration
 
+/**
+ * Implementation of [SharingStarted] for Actor's custom [SharingStarted.WhileSubscribed] implementations.
+ *
+ * @see [ActorOptions.newSharingStarted]
+ */
 class ActorSharingStarted(
     keepAliveTime: Duration,
     private val onActive: ActorCallback? = null,
@@ -33,4 +38,7 @@ class ActorSharingStarted(
         }
 }
 
+/**
+ * Callback handler to notify based on the active state of the Actor.
+ */
 typealias ActorCallback = () -> Unit

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/Logging.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/Logging.kt
@@ -3,6 +3,17 @@
 
 package soil.query.internal
 
+/**
+ * Logger functional interface to output log messages.
+ *
+ * This functional interface provides logging for debugging purposes for developers.
+ */
 fun interface LoggerFn {
+
+    /**
+     * Outputs the log message.
+     *
+     * @param message Log message.
+     */
     fun log(message: String)
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/LoggingOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/LoggingOptions.kt
@@ -3,7 +3,16 @@
 
 package soil.query.internal
 
+/**
+ * Interface providing settings for logging output for debugging purposes.
+ */
 interface LoggingOptions {
+
+    /**
+     * Specifies the logger function.
+     *
+     * **Note:** When LoggerFn is set, it writes internal logic state changes to the log.
+     */
     val logger: LoggerFn?
 }
 

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/MemoryPressure.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/MemoryPressure.kt
@@ -7,10 +7,24 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
+/**
+ * Interface for receiving events of memory pressure.
+ */
 interface MemoryPressure {
+
+    /**
+     * Adds an [observer] to receive events.
+     */
     fun addObserver(observer: Observer)
+
+    /**
+     * Removes an [observer] that receives events.
+     */
     fun removeObserver(observer: Observer)
 
+    /**
+     * Provides a Flow to receive events of memory pressure.
+     */
     fun asFlow(): Flow<MemoryPressureLevel> = callbackFlow {
         val observer = object : Observer {
             override fun onReceive(level: MemoryPressureLevel) {
@@ -21,10 +35,20 @@ interface MemoryPressure {
         awaitClose { removeObserver(observer) }
     }
 
+    /**
+     * Observer interface for receiving events of memory pressure.
+     */
     interface Observer {
+
+        /**
+         * Receives a [level] of memory pressure.
+         */
         fun onReceive(level: MemoryPressureLevel)
     }
 
+    /**
+     * An object indicating unsupported for the capability of memory pressure.
+     */
     companion object Unsupported : MemoryPressure {
         override fun addObserver(observer: Observer) = Unit
 
@@ -32,8 +56,23 @@ interface MemoryPressure {
     }
 }
 
+/**
+ * Levels of memory pressure.
+ */
 enum class MemoryPressureLevel {
+
+    /**
+     * Indicates low memory pressure.
+     */
     Low,
+
+    /**
+     * Indicates moderate memory pressure.
+     */
     High,
+
+    /**
+     * Indicates severe memory pressure.
+     */
     Critical
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/NetworkConnectivity.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/NetworkConnectivity.kt
@@ -7,10 +7,24 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
+/**
+ * Interface for receiving events of network connectivity.
+ */
 interface NetworkConnectivity {
+
+    /**
+     * Adds an [observer] to receive events.
+     */
     fun addObserver(observer: Observer)
+
+    /**
+     * Removes an [observer] that receives events.
+     */
     fun removeObserver(observer: Observer)
 
+    /**
+     * Provides a Flow to receive events of network connectivity.
+     */
     fun asFlow(): Flow<NetworkConnectivityEvent> = callbackFlow {
         val observer = object : Observer {
             override fun onReceive(event: NetworkConnectivityEvent) {
@@ -21,10 +35,20 @@ interface NetworkConnectivity {
         awaitClose { removeObserver(observer) }
     }
 
+    /**
+     * Observer interface for receiving events of network connectivity.
+     */
     interface Observer {
+
+        /**
+         * Receives a [event] of network connectivity.
+         */
         fun onReceive(event: NetworkConnectivityEvent)
     }
 
+    /**
+     * An object indicating unsupported for the capability of network connectivity.
+     */
     companion object Unsupported : NetworkConnectivity {
         override fun addObserver(observer: Observer) = Unit
 
@@ -32,7 +56,18 @@ interface NetworkConnectivity {
     }
 }
 
+/**
+ * Events of network connectivity.
+ */
 enum class NetworkConnectivityEvent {
+
+    /**
+     * The network is available.
+     */
     Available,
+
+    /**
+     * The network is lost.
+     */
     Lost
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/Platform.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/Platform.kt
@@ -5,8 +5,18 @@ package soil.query.internal
 
 import kotlin.time.Duration
 
+/**
+ * Returns the current epoch time.
+ *
+ * @return Epoch seconds
+ */
 expect fun epoch(): Long
 
+/**
+ * Generate a Version 4 UUID.
+ *
+ * @return UUID string.
+ */
 expect fun uuid(): String
 
 internal fun Duration.toEpoch(at: Long = epoch()): Long {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/PriorityQueue.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/PriorityQueue.kt
@@ -5,12 +5,23 @@ package soil.query.internal
 
 // TODO: Significantly slower than java.util.PriorityQueue.
 //  Consider rewriting the implementation later.
+
+/**
+ * Priority queue implementation.
+ *
+ * @param E Element that implemented [Comparable] interface.
+ * @param capacity Initial capacity.
+ * @constructor Creates a priority queue with the specified capacity.
+ */
 class PriorityQueue<E>(
     capacity: Int
 ) where E : Any, E : Comparable<E> {
 
     private val data = ArrayList<E>(capacity)
 
+    /**
+     * Adds the specified [element] to the queue.
+     */
     fun push(element: E) {
         val index = data.binarySearch(element)
         if (index < 0) {
@@ -20,14 +31,30 @@ class PriorityQueue<E>(
         }
     }
 
+    /**
+     * Returns the element with the highest priority.
+     *
+     * @return The element with the highest priority, or `null` if the queue is empty.
+     */
     fun peek(): E? {
         return data.firstOrNull()
     }
 
+    /**
+     * Removes the element with the highest priority.
+     *
+     * @return The element with the highest priority, or `null` if the queue is empty.
+     */
     fun pop(): E? {
         return data.removeFirstOrNull()
     }
 
+    /**
+     * Removes the specified [element] from the queue.
+     *
+     * @param element The element to be removed.
+     * @return `true` if the element was removed, `false` otherwise.
+     */
     fun remove(element: E): Boolean {
         val index = data.binarySearch(element)
         return if (index < 0) {
@@ -38,12 +65,23 @@ class PriorityQueue<E>(
         }
     }
 
+    /**
+     * Removes all elements from the queue.
+     */
     fun clear() {
         data.clear()
     }
 
+    /**
+     * Returns `true` if the queue is empty.
+     *
+     * @return `true` if the queue is empty, `false` otherwise.
+     */
     fun isEmpty(): Boolean = data.isEmpty()
 }
 
+/**
+ * @see [PriorityQueue.isEmpty]
+ */
 @Suppress("NOTHING_TO_INLINE")
 inline fun PriorityQueue<*>.isNotEmpty(): Boolean = !isEmpty()

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/Retry.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/Retry.kt
@@ -5,13 +5,35 @@ package soil.query.internal
 
 import kotlin.time.Duration
 
+/**
+ * Functional interface for retry logic applied to queries or mutations within a command.
+ *
+ * @param T The return type of the function to which retry logic is applied.
+ */
 fun interface RetryFn<T> {
+
+    /**
+     * Executes the [block] function under retry control.
+     *
+     * @param block Function to which retry logic is applied.
+     * @return The result of executing the [block] function.
+     */
     suspend fun withRetry(block: suspend () -> T): T
 }
 
+/**
+ * Interface to indicate whether an [Throwable] is retryable, provided as a default options.
+ */
 @Suppress("SpellCheckingInspection")
 interface Retryable {
+
+    /**
+     * @return `true` only if retrying is possible.
+     */
     val canRetry: Boolean
 }
 
+/**
+ * Callback function to notify the execution of retry logic.
+ */
 typealias RetryCallback = (err: Throwable, count: Int, nextBackOff: Duration) -> Unit

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/RetryOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/RetryOptions.kt
@@ -8,16 +8,50 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.random.Random
 import kotlin.time.Duration
 
+/**
+ * Interface providing settings for retry logic.
+ */
 interface RetryOptions {
+
+    /**
+     * Specifies whether to retry the operation.
+     */
     val shouldRetry: (Throwable) -> Boolean
+
+    /**
+     * The number of times to retry the operation.
+     */
     val retryCount: Int
+
+    /**
+     * The initial interval for retrying the operation.
+     */
     val retryInitialInterval: Duration
+
+    /**
+     * The maximum interval for retrying the operation.
+     */
     val retryMaxInterval: Duration
+
+    /**
+     * The multiplier for the next interval.
+     */
     val retryMultiplier: Double
+
+    /**
+     * The randomization factor for the next interval.
+     */
     val retryRandomizationFactor: Double
+
+    /**
+     * The random number generator for the next interval.
+     */
     val retryRandomizer: Random
 }
 
+/**
+ * Generates an [RetryFn] for Exponential Backoff Strategy.
+ */
 fun <T> RetryOptions.exponentialBackOff(
     onRetry: RetryCallback? = null
 ) = RetryFn<T> { block ->

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/UniqueId.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/UniqueId.kt
@@ -3,9 +3,42 @@
 
 package soil.query.internal
 
+/**
+ * Interface for unique identifiers.
+ *
+ * The unique identifier is a combination of a namespace and tags.
+ * This [UniqueId] is used to cache the results of queries and mutations.
+ */
 interface UniqueId {
+
+    /**
+     * The namespace of this unique identifier.
+     *
+     * There are no specific formatting rules.
+     * It's important for each resource to have a unique namespace, similar to URL paths.
+     */
     val namespace: String
+
+    /**
+     * The tags of this unique identifier.
+     *
+     * If the [namespace] matches but the tags are different, they are treated as different cache entries.
+     * Tags are useful for separating caches for variations based on query parameters or grouping for revalidation.
+     *
+     * `null` values are not allowed. Instead, represent them with compound types like [Pair].
+     *
+     * ```
+     * val tags = arrayOf(
+     *    "param1" to null,
+     *    "param2" to 123
+     * )
+     * ```
+     */
     val tags: Array<out SurrogateKey>
 }
 
+
+/**
+ * A surrogate key for unique identifiers.
+ */
 typealias SurrogateKey = Any

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/WindowVisibility.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/WindowVisibility.kt
@@ -7,11 +7,25 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
+/**
+ * Interface for receiving events of window visibility.
+
+ */
 interface WindowVisibility {
 
+    /**
+     * Adds an [observer] to receive events.
+     */
     fun addObserver(observer: Observer)
+
+    /**
+     * Removes an [observer] that receives events.
+     */
     fun removeObserver(observer: Observer)
 
+    /**
+     * Provides a Flow to receive events of window visibility.
+     */
     fun asFlow(): Flow<WindowVisibilityEvent> = callbackFlow {
         val observer = object : Observer {
             override fun onReceive(event: WindowVisibilityEvent) {
@@ -22,10 +36,20 @@ interface WindowVisibility {
         awaitClose { removeObserver(observer) }
     }
 
+    /**
+     * Observer interface for receiving events of window visibility.
+     */
     interface Observer {
+
+        /**
+         * Receives a [event] of window visibility.
+         */
         fun onReceive(event: WindowVisibilityEvent)
     }
 
+    /**
+     * An object indicating unsupported for the capability of window visibility.
+     */
     companion object Unsupported : WindowVisibility {
         override fun addObserver(observer: Observer) = Unit
 
@@ -33,7 +57,18 @@ interface WindowVisibility {
     }
 }
 
+/**
+ * Events of window visibility.
+ */
 enum class WindowVisibilityEvent {
+
+    /**
+     * The window enters the foreground.
+     */
     Foreground,
+
+    /**
+     * The window enters the background.
+     */
     Background
 }

--- a/soil-query-core/src/iosMain/kotlin/soil/query/IosMemoryPressure.kt
+++ b/soil-query-core/src/iosMain/kotlin/soil/query/IosMemoryPressure.kt
@@ -15,6 +15,17 @@ import platform.darwin.NSObject
 import soil.query.internal.MemoryPressure
 import soil.query.internal.MemoryPressureLevel
 
+/**
+ * Implementation of [MemoryPressure] for iOS.
+ *
+ * In the iOS system, [NSNotificationCenter] is used to monitor memory pressure states.
+ *
+ *    | iOS Notification                        | MemoryPressureLevel   |
+ *    |:----------------------------------------|:----------------------|
+ *    | UIApplicationDidEnterBackground         | Low                   |
+ *    | UIApplicationDidReceiveMemoryWarning    | Critical              |
+ *
+ */
 @OptIn(BetaInteropApi::class, ExperimentalForeignApi::class)
 class IosMemoryPressure : MemoryPressure {
 

--- a/soil-query-core/src/iosMain/kotlin/soil/query/IosWindowVisiblity.kt
+++ b/soil-query-core/src/iosMain/kotlin/soil/query/IosWindowVisiblity.kt
@@ -15,6 +15,13 @@ import platform.darwin.NSObject
 import soil.query.internal.WindowVisibility
 import soil.query.internal.WindowVisibilityEvent
 
+/**
+ * Implementation of [WindowVisibility] for iOS.
+ *
+ * In the iOS system, [UIApplicationDidBecomeActiveNotification] and [UIApplicationWillResignActiveNotification]
+ * are used to monitor window visibility states.
+ * It notifies the window visibility state based on the notification received.
+ */
 @OptIn(BetaInteropApi::class, ExperimentalForeignApi::class)
 class IosWindowVisibility : WindowVisibility {
 

--- a/soil-query-core/src/wasmJsMain/kotlin/soil/query/WasmJsNetworkConnectivity.kt
+++ b/soil-query-core/src/wasmJsMain/kotlin/soil/query/WasmJsNetworkConnectivity.kt
@@ -8,6 +8,9 @@ import org.w3c.dom.events.Event
 import soil.query.internal.NetworkConnectivity
 import soil.query.internal.NetworkConnectivityEvent
 
+/**
+ * Implementation of [NetworkConnectivity] for WasmJs.
+ */
 class WasmJsNetworkConnectivity : NetworkConnectivity {
 
     private var onlineListener: ((Event) -> Unit)? = null

--- a/soil-query-core/src/wasmJsMain/kotlin/soil/query/WasmJsWindowVisibility.kt
+++ b/soil-query-core/src/wasmJsMain/kotlin/soil/query/WasmJsWindowVisibility.kt
@@ -9,6 +9,9 @@ import soil.query.internal.WindowVisibility
 import soil.query.internal.WindowVisibilityEvent
 import soil.query.internal.document as documentAlt
 
+/**
+ * Implementation of [WindowVisibility] for WasmJs.
+ */
 class WasmJsWindowVisibility : WindowVisibility {
 
     private var visibilityListener: ((Event) -> Unit)? = null


### PR DESCRIPTION
The goal is to make the API documentation and source code easier to understand.
The first step is to add KDoc comments to the code.