### PR TITLE
Add a KDoc comments for the soil.query.compose.runtime package

### DIFF
--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Await.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Await.kt
@@ -19,7 +19,6 @@ import soil.query.compose.QueryRefreshErrorObject
 import soil.query.compose.QuerySuccessObject
 import soil.query.internal.uuid
 
-
 @Composable
 inline fun <T> Await(
     state: Loadable<T>,
@@ -43,6 +42,18 @@ inline fun <T> Await(
     }
 }
 
+/**
+ * Await for a [QueryModel] to be fulfilled.
+ *
+ * The content will be displayed when the query is fulfilled.
+ * The await will be managed by the [AwaitHost].
+ *
+ * @param T Type of data to retrieve.
+ * @param state The [QueryModel] to await.
+ * @param key The key to identify the await.
+ * @param host The [AwaitHost] to manage the await. By default, it uses the [LocalAwaitHost].
+ * @param content The content to display when the query is fulfilled.
+ */
 @Composable
 inline fun <T> Await(
     state: QueryModel<T>,
@@ -64,6 +75,20 @@ inline fun <T> Await(
     }
 }
 
+/**
+ * Await for two [QueryModel] to be fulfilled.
+ *
+ * The content will be displayed when the queries are fulfilled.
+ * The await will be managed by the [AwaitHost].
+ *
+ * @param T1 Type of data to retrieve.
+ * @param T2 Type of data to retrieve.
+ * @param state1 The first [QueryModel] to await.
+ * @param state2 The second [QueryModel] to await.
+ * @param key The key to identify the await.
+ * @param host The [AwaitHost] to manage the await. By default, it uses the [LocalAwaitHost].
+ * @param content The content to display when the queries are fulfilled.
+ */
 @Composable
 inline fun <T1, T2> Await(
     state1: QueryModel<T1>,
@@ -88,6 +113,22 @@ inline fun <T1, T2> Await(
     }
 }
 
+/**
+ * Await for three [QueryModel] to be fulfilled.
+ *
+ * The content will be displayed when the queries are fulfilled.
+ * The await will be managed by the [AwaitHost].
+ *
+ * @param T1 Type of data to retrieve.
+ * @param T2 Type of data to retrieve.
+ * @param T3 Type of data to retrieve.
+ * @param state1 The first [QueryModel] to await.
+ * @param state2 The second [QueryModel] to await.
+ * @param state3 The third [QueryModel] to await.
+ * @param key The key to identify the await.
+ * @param host The [AwaitHost] to manage the await. By default, it uses the [LocalAwaitHost].
+ * @param content The content to display when the queries are fulfilled.
+ */
 @Composable
 inline fun <T1, T2, T3> Await(
     state1: QueryModel<T1>,
@@ -115,6 +156,24 @@ inline fun <T1, T2, T3> Await(
     }
 }
 
+/**
+ * Await for four [QueryModel] to be fulfilled.
+ *
+ * The content will be displayed when the queries are fulfilled.
+ * The await will be managed by the [AwaitHost].
+ *
+ * @param T1 Type of data to retrieve.
+ * @param T2 Type of data to retrieve.
+ * @param T3 Type of data to retrieve.
+ * @param T4 Type of data to retrieve.
+ * @param state1 The first [QueryModel] to await.
+ * @param state2 The second [QueryModel] to await.
+ * @param state3 The third [QueryModel] to await.
+ * @param state4 The fourth [QueryModel] to await.
+ * @param key The key to identify the await.
+ * @param host The [AwaitHost] to manage the await. By default, it uses the [LocalAwaitHost].
+ * @param content The content to display when the queries are fulfilled.
+ */
 @Composable
 inline fun <T1, T2, T3, T4> Await(
     state1: QueryModel<T1>,
@@ -145,6 +204,26 @@ inline fun <T1, T2, T3, T4> Await(
     }
 }
 
+/**
+ * Await for five [QueryModel] to be fulfilled.
+ *
+ * The content will be displayed when the queries are fulfilled.
+ * The await will be managed by the [AwaitHost].
+ *
+ * @param T1 Type of data to retrieve.
+ * @param T2 Type of data to retrieve.
+ * @param T3 Type of data to retrieve.
+ * @param T4 Type of data to retrieve.
+ * @param T5 Type of data to retrieve.
+ * @param state1 The first [QueryModel] to await.
+ * @param state2 The second [QueryModel] to await.
+ * @param state3 The third [QueryModel] to await.
+ * @param state4 The fourth [QueryModel] to await.
+ * @param state5 The fifth [QueryModel] to await.
+ * @param key The key to identify the await.
+ * @param host The [AwaitHost] to manage the await. By default, it uses the [LocalAwaitHost].
+ * @param content The content to display when the queries are fulfilled.
+ */
 @Composable
 inline fun <T1, T2, T3, T4, T5> Await(
     state1: QueryModel<T1>,
@@ -178,6 +257,16 @@ inline fun <T1, T2, T3, T4, T5> Await(
     }
 }
 
+/**
+ * Await for [QueryModel] to be fulfilled.
+ *
+ * This function is part of the [Await].
+ * It is used to handle the [QueryModel] state and display the content when the query is fulfilled.
+ *
+ * @param T Type of data to retrieve.
+ * @param state The [QueryModel] to await.
+ * @param content The content to display when the query is fulfilled.
+ */
 @Composable
 fun <T> AwaitHandler(
     state: QueryModel<T>,
@@ -202,6 +291,9 @@ fun <T> AwaitHandler(
     }
 }
 
+/**
+ * Returns true if the [QueryModel] is awaited.
+ */
 fun QueryModel<*>.isAwaited(): Boolean {
     return isPending
         || (isFailure && fetchStatus == QueryFetchStatus.Fetching)

--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/AwaitHost.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/AwaitHost.kt
@@ -6,17 +6,37 @@ package soil.query.compose.runtime
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
 
+/**
+ * A host to manage the await state of a key.
+ *
+ * @see Await
+ */
 @Stable
 interface AwaitHost {
 
+    /**
+     * Returns the set of keys that are awaited.
+     */
     val keys: Set<Any>
 
+    /**
+     * Returns `true` if the key is awaited.
+     */
     operator fun get(key: Any): Boolean
 
+    /**
+     * Sets the key to be awaited or not.
+     */
     operator fun set(key: Any, isAwaited: Boolean)
 
+    /**
+     * Removes the key from the awaited set.
+     */
     fun remove(key: Any)
 
+    /**
+     * A noop implementation of [AwaitHost].
+     */
     companion object Noop : AwaitHost {
 
         override val keys: Set<Any> = emptySet()
@@ -29,6 +49,9 @@ interface AwaitHost {
     }
 }
 
+/**
+ * CompositionLocal for [AwaitHost].
+ */
 val LocalAwaitHost = compositionLocalOf<AwaitHost> {
     AwaitHost
 }

--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Catch.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Catch.kt
@@ -46,6 +46,13 @@ fun <T : Throwable> Catch(
     }
 }
 
+/**
+ * Catch for a [QueryModel] to be rejected.
+ *
+ * @param state The [QueryModel] to catch.
+ * @param isEnabled Whether to catch the error.
+ * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
+ */
 @Composable
 fun Catch(
     state: QueryModel<*>,
@@ -60,6 +67,14 @@ fun Catch(
     )
 }
 
+/**
+ * Catch for any [QueryModel]s to be rejected.
+ *
+ * @param state1 The first [QueryModel] to catch.
+ * @param state2 The second [QueryModel] to catch.
+ * @param isEnabled Whether to catch the error.
+ * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
+ */
 @Composable
 fun Catch(
     state1: QueryModel<*>,
@@ -76,6 +91,15 @@ fun Catch(
     )
 }
 
+/**
+ * Catch for any [QueryModel]s to be rejected.
+ *
+ * @param state1 The first [QueryModel] to catch.
+ * @param state2 The second [QueryModel] to catch.
+ * @param state3 The third [QueryModel] to catch.
+ * @param isEnabled Whether to catch the error.
+ * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
+ */
 @Composable
 fun Catch(
     state1: QueryModel<*>,
@@ -94,6 +118,13 @@ fun Catch(
     )
 }
 
+/**
+ * Catch for any [QueryModel]s to be rejected.
+ *
+ * @param states The [QueryModel]s to catch.
+ * @param isEnabled Whether to catch the error.
+ * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
+ */
 @Composable
 fun Catch(
     vararg states: QueryModel<*>,
@@ -108,6 +139,14 @@ fun Catch(
     )
 }
 
+/**
+ * Catch for a [QueryModel] to be rejected.
+ *
+ * @param state The [QueryModel] to catch.
+ * @param filterIsInstance A function to filter the error.
+ * @param isEnabled Whether to catch the error.
+ * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
+ */
 @Composable
 fun <T : Throwable> Catch(
     state: QueryModel<*>,
@@ -121,6 +160,15 @@ fun <T : Throwable> Catch(
     }
 }
 
+/**
+ * Catch for any [QueryModel]s to be rejected.
+ *
+ * @param state1 The first [QueryModel] to catch.
+ * @param state2 The second [QueryModel] to catch.
+ * @param filterIsInstance A function to filter the error.
+ * @param isEnabled Whether to catch the error.
+ * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
+ */
 @Composable
 fun <T : Throwable> Catch(
     state1: QueryModel<*>,
@@ -138,6 +186,16 @@ fun <T : Throwable> Catch(
     }
 }
 
+/**
+ * Catch for any [QueryModel]s to be rejected.
+ *
+ * @param state1 The first [QueryModel] to catch.
+ * @param state2 The second [QueryModel] to catch.
+ * @param state3 The third [QueryModel] to catch.
+ * @param filterIsInstance A function to filter the error.
+ * @param isEnabled Whether to catch the error.
+ * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
+ */
 @Composable
 fun <T : Throwable> Catch(
     state1: QueryModel<*>,
@@ -156,6 +214,14 @@ fun <T : Throwable> Catch(
     }
 }
 
+/**
+ * Catch for any [QueryModel]s to be rejected.
+ *
+ * @param states The [QueryModel]s to catch.
+ * @param filterIsInstance A function to filter the error.
+ * @param isEnabled Whether to catch the error.
+ * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
+ */
 @Composable
 fun <T : Throwable> Catch(
     vararg states: QueryModel<*>,
@@ -172,8 +238,18 @@ fun <T : Throwable> Catch(
     }
 }
 
-
+/**
+ * A scope for handling error content within the [Catch] function.
+ */
 object CatchScope {
+
+    /**
+     * Throw propagates the caught exception to a [CatchThrowHost].
+     *
+     * @param error The caught exception.
+     * @param key The key to identify the caught exception.
+     * @param host The [CatchThrowHost] to manage the caught exception. By default, it uses the [LocalCatchThrowHost].
+     */
     @Composable
     fun Throw(
         error: Throwable,

--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/CatchThrowHost.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/CatchThrowHost.kt
@@ -6,17 +6,37 @@ package soil.query.compose.runtime
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
 
+/**
+ * A host to manage the caught errors of a key.
+ *
+ * @see Catch
+ */
 @Stable
 interface CatchThrowHost {
 
+    /**
+     * Returns the set of keys that have caught errors.
+     */
     val keys: Set<Any>
 
+    /**
+     * Returns the caught error of the key.
+     */
     operator fun get(key: Any): Throwable?
 
+    /**
+     * Sets the caught error of the key.
+     */
     operator fun set(key: Any, error: Throwable)
 
+    /**
+     * Removes the caught error of the key.
+     */
     fun remove(key: Any)
 
+    /**
+     * A noop implementation of [CatchThrowHost].
+     */
     companion object Noop : CatchThrowHost {
 
         override val keys: Set<Any> = emptySet()
@@ -29,6 +49,9 @@ interface CatchThrowHost {
     }
 }
 
+/**
+ * CompositionLocal for [CatchThrowHost].
+ */
 val LocalCatchThrowHost = compositionLocalOf<CatchThrowHost> {
     CatchThrowHost
 }

--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/ContentVisibility.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/ContentVisibility.kt
@@ -11,8 +11,17 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.invisibleToUser
 
-// NOTE: Visibility must be treated similarly to Android View's invisible because it needs to receive the loading state from Await placed as a child.
-// (If AnimatedVisibility's visible=false, the content isn't called while it's hidden, so Await won't function)
+/**
+ * A composable that can hide its [content] without removing it from the layout.
+ *
+ * **Note:**
+ * Visibility must be treated similarly to Android View's invisible because it needs to receive the loading state from Await placed as a child.
+ * (If AnimatedVisibility's visible=false, the content isn't called while it's hidden, so Await won't function)
+ *
+ * @param hidden Whether the content should be hidden.
+ * @param modifier The modifier to be applied to the layout.
+ * @param content The content of the [ContentVisibility].
+ */
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun ContentVisibility(

--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/ErrorBoundary.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/ErrorBoundary.kt
@@ -16,6 +16,52 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 
+/**
+ * Wrap an ErrorBoundary around other [Catch] composable functions to catch errors and render a fallback UI.
+ *
+ * **Note:**
+ * Typically, this function is defined at the top level of a screen and used for default error handling.
+ * Do not propagate errors from ErrorBoundary to higher-level components since the error state is managed by [state].
+ * Instead, it's recommended to catch and handle domain-specific exceptions within [Catch] content blocks.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * ErrorBoundary(
+ *     modifier = Modifier.fillMaxSize(),
+ *     fallback = {
+ *         ContentUnavailable(
+ *             error = it.err,
+ *             reset = it.reset,
+ *             modifier = Modifier.matchParentSize()
+ *         )
+ *     },
+ *     onError = { e -> println(e.toString()) },
+ *     onReset = rememberQueriesErrorReset()
+ * ) {
+ *     Suspense(..) {
+ *         val query = rememberGetPostsQuery()
+ *         ..
+ *         Catch(query) { e ->
+ *             // You can also write your own error handling logic.
+ *             if (e is DomainSpecificException) {
+ *                 Alert(..)
+ *                 return@Catch
+ *             }
+ *             Throw(e)
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @param modifier The modifier to be applied to the layout.
+ * @param fallback The fallback UI to render when an error is caught.
+ * @param onError The callback to be called when an error is caught.
+ * @param onReset The callback to be called when the reset button is clicked.
+ * @param state The state of the [ErrorBoundary].
+ * @param content The content of the [ErrorBoundary].
+ * @see Catch
+ */
 @Composable
 fun ErrorBoundary(
     modifier: Modifier = Modifier,
@@ -52,16 +98,28 @@ fun ErrorBoundary(
     }
 }
 
+/**
+ * Context information to pass to the fallback UI of [ErrorBoundary].
+ *
+ * @property err The caught error.
+ * @property reset The callback to invoke when the reset button placed within the content is clicked.
+ */
 @Stable
 class ErrorBoundaryContext(
     val err: Throwable,
     val reset: (() -> Unit)?
 )
 
+/**
+ * State of the [ErrorBoundary].
+ */
 @Stable
 class ErrorBoundaryState : CatchThrowHost {
     private val hostMap = mutableStateMapOf<Any, Throwable>()
 
+    /**
+     * Returns the caught error.
+     */
     val error: Throwable?
         get() = hostMap.values.firstOrNull()
 

--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Loadable.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Loadable.kt
@@ -6,18 +6,35 @@ package soil.query.compose.runtime
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 
-// For migration purposes only
+// TODO QueryModel implementation
+/**
+ * Promise-like data structure that represents the state of a value that is being loaded.
+ *
+ * Currently, this interface is intended for temporary use as a migration to queries.
+ * Useful when combining the `query.compose.runtime` package with other asynchronous processing.
+ *
+ * @param T The type of the value that has been loaded.
+ */
 @Stable
 sealed interface Loadable<out T> {
 
+    /**
+     * Represents the state of a value that is being loaded.
+     */
     @Immutable
     data object Pending : Loadable<Nothing>
 
+    /**
+     * Represents the state of a value that has been loaded.
+     */
     @Immutable
     data class Fulfilled<T>(
         val data: T
     ) : Loadable<T>
 
+    /**
+     * Represents the state of a value that has been rejected.
+     */
     @Immutable
     data class Rejected(
         val error: Throwable

--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Suspense.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Suspense.kt
@@ -20,7 +20,33 @@ import kotlinx.coroutines.delay
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-
+/**
+ * Suspense render a fallback UI while some asynchronous work is being done.
+ *
+ * Typically, this function is defined at least once at the top level of a screen and used for initial loading.
+ * Suspense can be nested as needed, which is useful for performing partial loading.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * Suspense(
+ *     fallback = { ContentLoading(modifier = Modifier.matchParentSize()) },
+ *     modifier = Modifier.fillMaxSize()
+ * ) {
+ *     val query = rememberGetPostsQuery()
+ *     Await(query) { posts ->
+ *         PostList(posts)
+ *     }
+ * }
+ * ```
+ *
+ * @param fallback The fallback UI to render components like loading.
+ * @param modifier The modifier to be applied to the layout.
+ * @param state The [SuspenseState] to manage the suspense.
+ * @param contentThreshold The duration after which the initial content load is considered complete.
+ * @param content The content to display when the suspense is not awaited.
+ * @see Await
+ */
 @Composable
 fun Suspense(
     fallback: @Composable BoxScope.() -> Unit,
@@ -49,6 +75,9 @@ fun Suspense(
     }
 }
 
+/**
+ * State of the [Suspense].
+ */
 @Stable
 class SuspenseState : AwaitHost {
     private val hostMap = mutableStateMapOf<Any, Boolean>()
@@ -67,6 +96,9 @@ class SuspenseState : AwaitHost {
         hostMap.remove(key)
     }
 
+    /**
+     * Returns `true` if any of the [Await] is awaited.
+     */
     fun isAwaited(): Boolean {
         return hostMap.any { it.value }
     }


### PR DESCRIPTION
The goal is to make the API documentation and source code easier to understand.
The first step is to add KDoc comments to the code.