### PR TITLE
Pass Minimal Interface Instead of SwrClient Argument in KeepAlive Composable

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/Util.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/Util.kt
@@ -48,8 +48,7 @@ fun rememberQueriesErrorReset(
 @Composable
 fun KeepAlive(
     key: QueryKey<*>,
-    // TODO Use QueryClient instead of SwrClient
-    client: SwrClient = LocalSwrClient.current
+    client: QueryClient = LocalSwrClient.current
 ) {
     val query = remember(key) { client.getQuery(key) }
     LaunchedEffect(Unit) {
@@ -68,8 +67,7 @@ fun KeepAlive(
 @Composable
 fun KeepAlive(
     key: InfiniteQueryKey<*, *>,
-    // TODO Use QueryClient instead of SwrClient
-    client: SwrClient = LocalSwrClient.current
+    client: QueryClient = LocalSwrClient.current
 ) {
     val query = remember(key) { client.getInfiniteQuery(key) }
     LaunchedEffect(Unit) {

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/Util.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/Util.kt
@@ -86,8 +86,7 @@ fun KeepAlive(
 @Composable
 fun KeepAlive(
     key: MutationKey<*, *>,
-    // TODO Use MutationClient instead of SwrClient
-    client: SwrClient = LocalSwrClient.current
+    client: MutationClient = LocalSwrClient.current
 ) {
     val query = remember(key) { client.getMutation(key) }
     LaunchedEffect(Unit) {


### PR DESCRIPTION
Changed the argument type to pass the minimal interface required within the KeepAlive Composable.

- SwrClient -> QueryClient or MutationClient