### PR TITLE
Add a KDoc comments for the soil.space packages

### DIFF
--- a/soil-space/src/androidMain/kotlin/soil/space/compose/AtomViewModel.kt
+++ b/soil-space/src/androidMain/kotlin/soil/space/compose/AtomViewModel.kt
@@ -15,6 +15,11 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import soil.space.AtomStore
 
+/**
+ * A [ViewModel] for managing [AtomStore].
+ *
+ * @param handle The [SavedStateHandle] to save the state of the [AtomStore].
+ */
 class AtomViewModel(
     handle: SavedStateHandle
 ) : ViewModel() {
@@ -31,8 +36,12 @@ class AtomViewModel(
     }
 }
 
-// Note:
-// ref. https://developer.android.com/topic/libraries/architecture/viewmodel/viewmodel-apis#compose
+/**
+ * Remember an [AtomStore] using [AtomViewModel].
+ *
+ * @param key The key to identify the [AtomViewModel].
+ * @return The [AtomStore] remembered by [AtomViewModel].
+ */
 @Composable
 fun rememberViewModelStore(
     key: String?
@@ -48,6 +57,13 @@ fun rememberViewModelStore(
     return remember(vm) { vm.store }
 }
 
+/**
+ * Remember an [AtomStore] using [AtomViewModel].
+ *
+ * @param viewModelStoreOwner The [ViewModelStoreOwner] to create the [AtomViewModel].
+ * @param key The key to identify the [AtomViewModel].
+ * @return The [AtomStore] remembered by [AtomViewModel].
+ */
 @Composable
 fun rememberViewModelStore(
     viewModelStoreOwner: ViewModelStoreOwner,

--- a/soil-space/src/commonMain/kotlin/soil/space/Atom.kt
+++ b/soil-space/src/commonMain/kotlin/soil/space/Atom.kt
@@ -6,6 +6,30 @@ package soil.space
 import androidx.compose.runtime.Immutable
 import kotlin.jvm.JvmName
 
+/**
+ * Atom is a unit of state in Space.
+ *
+ * The instance created serves as a key to store values of a specified type in [AtomStore].
+ * It is designed so that the instance itself acts as the reference key, instead of the user having to assign a unique key.
+ * Therefore, even if the definitions are exactly the same, different instances will be managed as separate keys.
+ *
+ * **Note:**
+ * Specifying a [saver] is optional, but if you expect state restoration on the Android platform, it is crucial to specify it.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val counterAtom = atom(0)
+ * val titleAtom = atom("hello, world", saverKey = "title")
+ * ```
+ *
+ * @param T The type of the value to be stored.
+ * @property initialValue The initial value to be stored.
+ * @property saver The saver to be used to save and restore the value.
+ * @property scope The scope to be used to manage the value.
+ *
+ * TODO constructor should be internal
+ */
 @Immutable
 class Atom<T>(
     val initialValue: T,
@@ -13,6 +37,15 @@ class Atom<T>(
     val scope: AtomScope? = null
 )
 
+/**
+ * Creates an [Atom].
+ *
+ * @param T The type of the value to be stored.
+ * @param initialValue The initial value to be stored.
+ * @param saver The saver to be used to save and restore the value.
+ * @param scope The scope to be used to manage the value.
+ * @return The created Atom.
+ */
 fun <T> atom(
     initialValue: T,
     saver: AtomSaver<T>? = null,
@@ -21,6 +54,30 @@ fun <T> atom(
     return Atom(initialValue, saver, scope)
 }
 
+/**
+ * Creates an [Atom] using [AtomSaverKey].
+ *
+ * Automatically selects an [AtomSaver] for the [Type][T] if it matches any of the following.
+ * The [saverKey] is used as a key for the [AtomSaver].
+ *
+ *    | Type        | AtomSaver     |
+ *    | :---------- | :-------------|
+ *    | String      | stringSaver   |
+ *    | Boolean     | booleanSaver  |
+ *    | Int         | intSaver      |
+ *    | Long        | longSaver     |
+ *    | Double      | doubleSaver   |
+ *    | Float       | floatSaver    |
+ *    | Char        | charSaver     |
+ *    | Short       | shortSaver    |
+ *    | Byte        | byteSaver     |
+ *
+ * @param T The type of the value to be stored.
+ * @param initialValue The initial value to be stored.
+ * @param saverKey The key to be used to save and restore the value.
+ * @param scope The scope to be used to manage the value.
+ * @return The created Atom.
+ */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T> atom(
     initialValue: T,
@@ -42,6 +99,15 @@ inline fun <reified T> atom(
     return atom(initialValue, saver, scope)
 }
 
+/**
+ * Creates an [Atom] using [AtomSaverKey] for [CommonParcelable].
+ *
+ * @param T The type of the value to be stored.
+ * @param initialValue The initial value to be stored.
+ * @param saverKey The key to be used to save and restore the value.
+ * @param scope The scope to be used to manage the value.
+ * @return The created Atom.
+ */
 inline fun <reified T : CommonParcelable> atom(
     initialValue: T,
     saverKey: AtomSaverKey,
@@ -50,6 +116,25 @@ inline fun <reified T : CommonParcelable> atom(
     return atom(initialValue, parcelableSaver(saverKey), scope)
 }
 
+/**
+ * Creates an [Atom] using [AtomSaverKey] for [ArrayList].
+ *
+ * Automatically selects an [AtomSaver] for the [Type][T] if it matches any of the following.
+ * The [saverKey] is used as a key for the [AtomSaver].
+ *
+ *    | Type            | AtomSaver                     |
+ *    | :-------------- | :---------------------------- |
+ *    | String          | stringArrayListSaver          |
+ *    | Int             | integerArrayListSaver         |
+ *    | CharSequence    | charSequenceArrayListSaver    |
+ *
+ *
+ * @param T The type of the value to be stored.
+ * @param initialValue The initial value to be stored.
+ * @param saverKey The key to be used to save and restore the value.
+ * @param scope The scope to be used to manage the value.
+ * @return The created Atom.
+ */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T> atom(
     initialValue: ArrayList<T>,
@@ -65,6 +150,15 @@ inline fun <reified T> atom(
     return atom(initialValue, saver, scope)
 }
 
+/**
+ * Creates an [Atom] using [AtomSaverKey] for [ArrayList] with [CommonParcelable][T].
+ *
+ * @param T The type of the value to be stored.
+ * @param initialValue The initial value to be stored.
+ * @param saverKey The key to be used to save and restore the value.
+ * @param scope The scope to be used to manage the value.
+ * @return The created Atom.
+ */
 @JvmName("atomWithParcelable")
 inline fun <reified T : CommonParcelable> atom(
     initialValue: ArrayList<T>,
@@ -74,6 +168,15 @@ inline fun <reified T : CommonParcelable> atom(
     return atom(initialValue, parcelableArrayListSaver(saverKey), scope)
 }
 
+/**
+ * Creates an [Atom] using [AtomSaverKey] for [Array] with [CommonParcelable][T].
+ *
+ * @param T The type of the value to be stored.
+ * @param initialValue The initial value to be stored.
+ * @param saverKey The key to be used to save and restore the value.
+ * @param scope The scope to be used to manage the value.
+ * @return The created Atom.
+ */
 inline fun <reified T : CommonParcelable> atom(
     initialValue: Array<T>,
     saverKey: AtomSaverKey,
@@ -82,6 +185,15 @@ inline fun <reified T : CommonParcelable> atom(
     return atom(initialValue, parcelableArraySaver(saverKey), scope)
 }
 
+/**
+ * Creates an [Atom] using [AtomSaverKey] for [CommonSerializable].
+ *
+ * @param T The type of the value to be stored.
+ * @param initialValue The initial value to be stored.
+ * @param saverKey The key to be used to save and restore the value.
+ * @param scope The scope to be used to manage the value.
+ * @return The created Atom.
+ */
 inline fun <reified T : CommonSerializable> atom(
     initialValue: T,
     saverKey: AtomSaverKey,
@@ -90,13 +202,35 @@ inline fun <reified T : CommonSerializable> atom(
     return atom(initialValue, serializableSaver(saverKey), scope)
 }
 
+/**
+ * Interface for saving and restoring values to a [CommonBundle].
+ *
+ * Currently, this restoration feature is designed specifically for the Android Platform.
+ *
+ * @param T The type of the value to be saved and restored.
+ */
 interface AtomSaver<T> {
+
+    /**
+     * Saves a value to a [CommonBundle].
+     *
+     * @param bundle The [CommonBundle] to save the value to.
+     * @param value The value to save.
+     */
     fun save(bundle: CommonBundle, value: T)
+
+    /**
+     * Restores a value from a [CommonBundle].
+     *
+     * @param bundle The [CommonBundle] to restore the value from.
+     * @return The restored value.
+     */
     fun restore(bundle: CommonBundle): T?
 }
 
 typealias AtomSaverKey = String
 
+// TODO Switch to internal using @PublishedApi
 fun stringSaver(key: AtomSaverKey): AtomSaver<String> {
     return object : AtomSaver<String> {
         override fun save(bundle: CommonBundle, value: String) {
@@ -249,6 +383,26 @@ fun charSequenceArrayListSaver(key: AtomSaverKey): AtomSaver<ArrayList<CharSeque
     }
 }
 
+/**
+ * Provides a scope for creating [Atom]s that manage state in different [AtomStore]s.
+ *
+ * Similar to [Atom], each instance acts as a key representing a single scope.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val navGraphScope = atomScope()
+ * val screenScope = atomScope()
+ *
+ * val counter1Atom = atom(0, scope = navGraphScope)
+ * val counter2Atom = atom(0, scope = screenScope)
+ * ```
+ *
+ * TODO constructor should be internal
+ */
 class AtomScope
 
+/**
+ * Creates an [AtomScope].
+ */
 fun atomScope() = AtomScope()

--- a/soil-space/src/commonMain/kotlin/soil/space/AtomSelector.kt
+++ b/soil-space/src/commonMain/kotlin/soil/space/AtomSelector.kt
@@ -5,16 +5,62 @@ package soil.space
 
 import androidx.compose.runtime.Immutable
 
+/**
+ * Interface for retrieving the value associated with the [Atom]s reference key.
+ *
+ * This interface is used as part of [AtomRef].
+ */
 interface AtomSelector {
+
+    /**
+     * Retrieves the value associated with the specified [Atom] reference key.
+     *
+     * @param T The type of the value to be retrieved.
+     * @param atom The [Atom] reference key for the value to be retrieved.
+     * @return The retrieved value.
+     */
     fun <T> get(atom: Atom<T>): T
+
+    /**
+     * Retrieves the value associated with the specified [AtomRef] reference key.
+     *
+     * @param T The type of the value to be retrieved.
+     * @param atom The [AtomRef] reference key for the value to be retrieved.
+     * @return The retrieved value.
+     */
     fun <T> get(atom: AtomRef<T>): T
 }
 
+/**
+ * AtomRef holds a value derived from one or more [Atom] references as a [block] function.
+ *
+ * @param T The type of the value to be retrieved.
+ * @property block The function that retrieves the value derived from one or more [Atom] references key.
+ *
+ * TODO: The constructor should be internal.
+ */
 @Immutable
 class AtomRef<T>(
     val block: AtomSelector.() -> T
 )
 
+/**
+ * Creates an [AtomRef] with the specified [block] function.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val counter1Atom = atom(0)
+ * val counter2Atom = atom(0)
+ * val sumAtom = atom {
+ *     get(counter1Atom) + get(counter2Atom)
+ * }
+ * ```
+ *
+ * @param T The type of the value to be retrieved.
+ * @param block The function that retrieves the value derived from one or more [Atom] references key.
+ * @return The created [AtomRef].
+ */
 fun <T> atom(block: AtomSelector.() -> T): AtomRef<T> {
     return AtomRef(block)
 }

--- a/soil-space/src/commonMain/kotlin/soil/space/AtomStore.kt
+++ b/soil-space/src/commonMain/kotlin/soil/space/AtomStore.kt
@@ -3,7 +3,18 @@
 
 package soil.space
 
+/**
+ * An interface for storing and retrieving atoms.
+ */
 interface AtomStore : AtomSelector {
+
+    /**
+     * Set the value of an atom.
+     *
+     * @param T The type of the value to be stored.
+     * @param atom The reference key.
+     * @param value The value to be stored.
+     */
     fun <T> set(atom: Atom<T>, value: T)
 
     override fun <T> get(atom: AtomRef<T>): T {

--- a/soil-space/src/commonMain/kotlin/soil/space/Platform.kt
+++ b/soil-space/src/commonMain/kotlin/soil/space/Platform.kt
@@ -3,9 +3,21 @@
 
 package soil.space
 
+/**
+ * Interface for handling Android platform-specific Parcelable within KMP.
+ */
 expect interface CommonParcelable
+
+/**
+ * Class for handling JVM-specific Serializable within KMP.
+ */
 expect interface CommonSerializable
 
+/**
+ * Class for handling Android platform-specific Bundle within KMP.
+ *
+ * Currently, this class provides operations specific to the Android platform's Bundle.
+ */
 expect class CommonBundle() {
     fun containsKey(key: String): Boolean
     fun putString(key: String?, value: String?)
@@ -42,6 +54,9 @@ expect class CommonBundle() {
     fun getCharSequenceArrayList(key: String?): ArrayList<CharSequence>?
 }
 
+/**
+ * Interface for handling Android platform-specific SavedStateProvider within KMP.
+ */
 expect fun interface CommonSavedStateProvider {
     fun saveState(): CommonBundle
 }

--- a/soil-space/src/commonMain/kotlin/soil/space/compose/AtomRoot.kt
+++ b/soil-space/src/commonMain/kotlin/soil/space/compose/AtomRoot.kt
@@ -11,6 +11,17 @@ import soil.space.Atom
 import soil.space.AtomScope
 import soil.space.AtomStore
 
+/**
+ * Provides multiple [AtomStore]. You can provide [AtomStore] corresponding to [AtomScope] with different lifecycles.
+ *
+ * To use the Remember API for handling [Atom] within [content], it is essential to declare [AtomRoot] somewhere in the parent tree.
+ * The scoped store is provided to child components using the Remember API via [LocalAtomOwner].
+ *
+ * @param primary The specified [AtomScope] used preferentially as the default value for [fallbackScope].
+ * @param others Additional [AtomScope] and [AtomStore] pairs with lifecycles different from [primary].
+ * @param fallbackScope A function that returns an alternate [AtomScope] if a corresponding [AtomScope] for an [Atom] is not found. By default, it returns the [AtomScope] of [primary].
+ * @param content The content of the [AtomRoot].
+ */
 @Composable
 fun AtomRoot(
     primary: Pair<AtomScope, AtomStore>,
@@ -26,6 +37,15 @@ fun AtomRoot(
     }
 }
 
+/**
+ * Provides a single [AtomStore].
+ *
+ * To use the Remember API for handling [Atom] within [content], it is essential to declare [AtomRoot] somewhere in the parent tree.
+ * The [store] is provided to child components using the Remember API via [LocalAtomOwner].
+ *
+ * @param store An instance of [AtomStore].
+ * @param content The content of the [AtomRoot].
+ */
 @Composable
 fun AtomRoot(
     store: AtomStore,
@@ -54,6 +74,9 @@ private class ScopedAtomStore(
     }
 }
 
+/**
+ * CompositionLocal for [AtomStore].
+ */
 val LocalAtomOwner = staticCompositionLocalOf<AtomStore> {
     error("CompositionLocal 'LocalAtomOwner' not present")
 }

--- a/soil-space/src/commonMain/kotlin/soil/space/compose/AtomSaveableStore.kt
+++ b/soil-space/src/commonMain/kotlin/soil/space/compose/AtomSaveableStore.kt
@@ -15,6 +15,11 @@ import soil.space.AtomStore
 import soil.space.CommonBundle
 import soil.space.CommonSavedStateProvider
 
+/**
+ * A [AtomStore] implementation that saves and restores the state of [Atom]s.
+ *
+ * @param savedState The saved state to be restored.
+ */
 @Suppress("SpellCheckingInspection")
 class AtomSaveableStore(
     private val savedState: CommonBundle? = null
@@ -64,6 +69,16 @@ class AtomSaveableStore(
     }
 }
 
+/**
+ * Remember a [AtomSaveableStore] that saves and restores the state of [Atom]s.
+ *
+ * **Note:**
+ * [LocalSaveableStateRegistry] is required to save and restore the state.
+ * If [LocalSaveableStateRegistry] is not found, the state will not be saved and restored.
+ *
+ * @param key The key to save and restore the state. By default, it resolves using [currentCompositeKeyHash].
+ * @return The remembered [AtomSaveableStore].
+ */
 @Suppress("SpellCheckingInspection")
 @Composable
 fun rememberSaveableStore(key: String? = null): AtomStore {

--- a/soil-space/src/commonMain/kotlin/soil/space/compose/AtomState.kt
+++ b/soil-space/src/commonMain/kotlin/soil/space/compose/AtomState.kt
@@ -12,6 +12,13 @@ import androidx.compose.runtime.remember
 import soil.space.Atom
 import soil.space.AtomStore
 
+/**
+ * [MutableState] for handling the state values of [Atom] managed by [AtomStore].
+ *
+ * @param T The type of the state value.
+ * @param state The [State] used to retrieve the state value.
+ * @param update A function to update the state value.
+ */
 @Stable
 class AtomState<T>(
     private val state: State<T>,
@@ -25,6 +32,14 @@ class AtomState<T>(
     override operator fun component2(): (T) -> Unit = update
 }
 
+/**
+ * Remember an [AtomState] for the specified [Atom] reference key.
+ *
+ * @param T The type of the state value.
+ * @param atom The reference key.
+ * @param store The [AtomStore] that manages the state using the [atom] reference key. By default, it resolves using [LocalAtomOwner].
+ * @return The [AtomState] for the specified [Atom] reference key.
+ */
 @Composable
 fun <T> rememberAtomState(
     atom: Atom<T>,

--- a/soil-space/src/commonMain/kotlin/soil/space/compose/AtomValue.kt
+++ b/soil-space/src/commonMain/kotlin/soil/space/compose/AtomValue.kt
@@ -12,11 +12,26 @@ import soil.space.Atom
 import soil.space.AtomRef
 import soil.space.AtomStore
 
+/**
+ * [State] for handling the state values of [Atom] managed by [AtomStore].
+ *
+ * @param T The type of the state value.
+ * @param state The [State] used to retrieve the state value.
+ */
 @Stable
 class AtomValue<T>(
     private val state: State<T>,
 ) : State<T> by state
 
+
+/**
+ * Remember an [AtomValue] for the specified [Atom] reference key.
+ *
+ * @param T The type of the state value.
+ * @param atom The reference key.
+ * @param store The [AtomStore] that manages the state using the [atom] reference key. By default, it resolves using [LocalAtomOwner].
+ * @return The [AtomValue] for the specified [Atom] reference key.
+ */
 @Composable
 fun <T> rememberAtomValue(
     atom: Atom<T>,
@@ -26,6 +41,14 @@ fun <T> rememberAtomValue(
     return remember(state) { AtomValue(state) }
 }
 
+/**
+ * Remember an [AtomValue] for the specified [AtomRef] reference key.
+ *
+ * @param T The type of the state value.
+ * @param atom The reference key.
+ * @param store The [AtomStore] that manages the state using the [atom] reference key. By default, it resolves using [LocalAtomOwner].
+ * @return The [AtomValue] for the specified [AtomRef] reference key.
+ */
 @Composable
 fun <T> rememberAtomValue(
     atom: AtomRef<T>,


### PR DESCRIPTION
The goal is to make the API documentation and source code easier to understand.
The first step is to add KDoc comments to the code.
