### PR TITLE
Add a KDoc comments for the soil.form packages

### DIFF
--- a/soil-form/src/commonMain/kotlin/soil/form/Field.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/Field.kt
@@ -3,31 +3,109 @@
 
 package soil.form
 
+/**
+ * A field is a single input in a form. It has a name, a value, and a set of errors.
+ *
+ * @param V The type of the value of the field.
+ */
 interface Field<V> {
+
+    /**
+     * The name of the field.
+     */
     val name: FieldName
+
+    /**
+     * The value of the field.
+     */
     val value: V
+
+    /**
+     * The errors of the field. If the field has no errors, this should be an empty list.
+     */
     val errors: FieldErrors
+
+    /**
+     * Returns `true` if the field is dirty, `false` otherwise.
+     * A field is dirty if its value has changed since the initial value.
+     */
     val isDirty: Boolean
+
+    /**
+     * Returns `true` if the field is enabled, `false` otherwise.
+     * A field is enabled if it is not disabled.
+     */
     val isEnabled: Boolean
+
+    /**
+     * Returns `true` if the field is touched, `false` otherwise.
+     * Sets to touched when the field loses focus after being focused.
+     */
     val isTouched: Boolean
+
+    /**
+     * Returns `true` if the field is focused, `false` otherwise.
+     * Sets to focused when the field gains focus.
+     */
     val isFocused: Boolean
+
+    /**
+     * Callback to notify when the value of the field is changed.
+     */
     val onChange: (V) -> Unit
+
+    /**
+     * Callback to notify when the field gains focus.
+     */
     val onFocus: () -> Unit
+
+    /**
+     * Callback to notify when the field loses focus.
+     */
     val onBlur: () -> Unit
+
+    /**
+     * Returns `true` if the field has errors, `false` otherwise.
+     */
     val hasError: Boolean get() = errors.isNotEmpty()
 
-    // NOTE: This is an escape hatch intended for cases where you want to execute similar validation as onBlur while KeyboardActions are set.
-    // It is not intended for use in other contexts.
+    /**
+     * Triggers validation of the field.
+     *
+     * **NOTE:*
+     * This is an escape hatch intended for cases where you want to execute similar validation as onBlur while KeyboardActions are set.
+     * It is not intended for use in other contexts.
+     */
     fun virtualTrigger(validateOn: FieldValidateOn)
 }
 
+/**
+ * This field name is used to uniquely identify a field within a form.
+ */
 typealias FieldName = String
+
+/**
+ * Represents a single error message in the field.
+ */
 typealias FieldError = String
+
+/**
+ * Represents multiple error messages in the field.
+ */
 typealias FieldErrors = List<FieldError>
 
+/**
+ * Creates error messages for a field.
+ *
+ * @param messages Error messages. There must be at least one error message.
+ * @return The generated error messages for the field.
+ */
 fun fieldError(vararg messages: String): FieldErrors {
     require(messages.isNotEmpty())
     return listOf(*messages)
 }
 
+/**
+ * Syntax sugar representing that there are no errors in the field.
+ */
 val noErrors: FieldErrors = emptyList()

--- a/soil-form/src/commonMain/kotlin/soil/form/FieldPolicy.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/FieldPolicy.kt
@@ -6,26 +6,73 @@ package soil.form
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
+/**
+ * Represents the settings for field-related policies, such as validation behavior.
+ *
+ * @property validationTrigger The timing to trigger automatic validation.
+ * @property validationDelay The settings for delayed execution of field validation.
+ * @constructor Creates a new instance of [FieldPolicy].
+ */
 data class FieldPolicy(
     val validationTrigger: FieldValidationTrigger = FieldValidationTrigger,
     val validationDelay: FieldValidationDelay = FieldValidationDelay()
 )
 
+/**
+ * Represents the settings for delayed execution of field validation.
+ *
+ * @property onMount The delay before the validation when the field mount.
+ * @property onChange The delay before validation when the field value changes.
+ * @property onBlur The delay before validation when the field loses focus.
+ * @constructor Creates a new instance of [FieldValidationDelay].
+ */
 data class FieldValidationDelay(
     val onMount: Duration = Duration.ZERO,
     val onChange: Duration = 250.milliseconds,
     val onBlur: Duration = Duration.ZERO
 )
 
+/**
+ * Enumerates the timings when field validation is performed.
+ */
 enum class FieldValidateOn {
-    Mount, Change, Blur, Submit
+
+    /** When the field component is mounted */
+    Mount,
+
+    /** When the input value changes */
+    Change,
+
+    /** When the focus is lost */
+    Blur,
+
+    /** When the form is submit */
+    Submit
 }
 
+/**
+ * Represents the timings that trigger field validation.
+ */
 interface FieldValidationTrigger {
+
+    /**
+     * The timing to trigger automatic validation.
+     */
     val startAt: FieldValidateOn
 
+    /**
+     * Returns the timing to trigger the next validation.
+     *
+     * @param state The current validation timing
+     * @param isPassed Whether the validation was successful
+     * @return The next validation timing
+     */
     fun next(state: FieldValidateOn, isPassed: Boolean): FieldValidateOn
 
+    /**
+     * By default, this setting automatically performs validation after the field loses focus,
+     * and if validation fails, it will re-validate each time the form input changes.
+     */
     companion object Default : FieldValidationTrigger {
         override val startAt: FieldValidateOn = FieldValidateOn.Blur
 
@@ -45,6 +92,10 @@ interface FieldValidationTrigger {
         }
     }
 
+    /**
+     * Automatically performs validation at the time of form submission,
+     * and thereafter re-validates each time the form input changes.
+     */
     object Submit : FieldValidationTrigger {
         override val startAt: FieldValidateOn = FieldValidateOn.Submit
 

--- a/soil-form/src/commonMain/kotlin/soil/form/FormPolicy.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/FormPolicy.kt
@@ -3,12 +3,27 @@
 
 package soil.form
 
+/**
+ * Represents the settings for the overall form policy.
+ *
+ * @property field Settings related to field policies.
+ * @property submission Settings related to submission control.
+ * @constructor Creates a new instance of [FormPolicy].
+ */
 data class FormPolicy(
     val field: FieldPolicy = FieldPolicy(),
     val submission: SubmissionPolicy = SubmissionPolicy()
 ) {
     companion object {
+
+        /**
+         * By default, this setting automatically performs validation after the field loses focus, and before submission.
+         */
         val Default = FormPolicy()
+
+        /**
+         * This setting performs validation only before submission.
+         */
         val Minimal = FormPolicy(
             field = FieldPolicy(
                 validationTrigger = FieldValidationTrigger.Submit

--- a/soil-form/src/commonMain/kotlin/soil/form/FormRule.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/FormRule.kt
@@ -3,6 +3,17 @@
 
 package soil.form
 
+/**
+ * Represents a rule that can be applied to a form field.
+ */
 fun interface FormRule<T> {
+
+    /**
+     * Tests the given value against the rule.
+     *
+     * @param value The value to test.
+     * @param dryRun Whether to perform the test without side effects.
+     * @return `true` if the value passes the rule; `false` otherwise.
+     */
     fun test(value: T, dryRun: Boolean): Boolean
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/FormValidationException.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/FormValidationException.kt
@@ -3,6 +3,16 @@
 
 package soil.form
 
+/**
+ * Exception used for handling validation errors during the submission process.
+ *
+ * This exception is useful when the validation logic is on the API side and validation errors can be detected from the response's status code.
+ * By passing a mapping of field names to error messages in [errors], you can identify the fields where errors occurred.
+ *
+ * @property errors Mapping of validation error information.
+ * @property cause The exception source that caused this exception.
+ * @constructor Creates a new instance with specified validation error information.
+ */
 class FormValidationException(
     val errors: FormErrors,
     cause: Throwable? = null

--- a/soil-form/src/commonMain/kotlin/soil/form/Submission.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/Submission.kt
@@ -3,12 +3,47 @@
 
 package soil.form
 
+/**
+ * A submission represents the submission control of a form.
+ */
 interface Submission {
+
+    /**
+     * Returns `true` if the field is dirty, `false` otherwise.
+     * A form value is dirty if its value has changed since the initial value.
+     */
     val isDirty: Boolean
+
+    /**
+     * Returns `true` if the form has validation error, `false` otherwise.
+     * A form is error if any of its fields has validation error.
+     */
     val hasError: Boolean
+
+    /**
+     * Returns `true` if the form is submitting, `false` otherwise.
+     * This is useful to prevent duplicate submissions until the submission process is completed.
+     */
     val isSubmitting: Boolean
+
+    /**
+     * Returns `true` if the form is submitted, `false` otherwise.
+     */
     val isSubmitted: Boolean
+
+    /**
+     * Returns the number of times submission process was called.
+     */
     val submitCount: Int
+
+    /**
+     * Returns `true` if the form can be submitted, `false` otherwise.
+     * This is useful when you want to disable the submit button itself until field validation errors are resolved.
+     */
     val canSubmit: Boolean
+
+    /**
+     * A callback to notify that the submit button has been clicked.
+     */
     val onSubmit: () -> Unit
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/SubmissionPolicy.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/SubmissionPolicy.kt
@@ -6,13 +6,29 @@ package soil.form
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
+/**
+ * Represents the settings for submission-related policies, such as pre-validation behavior.
+ *
+ * @property preValidation Whether to perform pre-validation before submission.
+ * @property preValidationDelay The settings for delayed execution of pre-validation.
+ * @constructor Creates a new instance of [SubmissionPolicy].
+ */
 data class SubmissionPolicy(
     val preValidation: Boolean = true,
     val preValidationDelay: SubmissionPreValidationDelay = SubmissionPreValidationDelay()
 )
 
+/**
+ * Represents the settings for delayed execution of pre-validation.
+ *
+ * **Note:**
+ * [onMount] as a zero duration is not recommended as it triggers based on the registration of Field's Rules.
+ *
+ * @property onMount The delay before the pre-validation when the form is mounted.
+ * @property onChange The delay before pre-validation when the form value changes.
+ * @constructor Creates a new instance of [SubmissionPreValidationDelay].
+ */
 data class SubmissionPreValidationDelay(
-    // NOTE: As it triggers based on the registration of Field's Rules, a zero duration is not recommended
     val onMount: Duration = 200.milliseconds,
     val onChange: Duration = 200.milliseconds
 )

--- a/soil-form/src/commonMain/kotlin/soil/form/ValidationRule.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/ValidationRule.kt
@@ -3,8 +3,25 @@
 
 package soil.form
 
+/**
+ * Represents a validation rule for a form field.
+ *
+ * @param V The type of the value to be validated.
+ */
 fun interface ValidationRule<V> {
+
+    /**
+     * Tests the given value against this rule.
+     *
+     * @param value The value to be tested.
+     * @return The errors found in the value. If the value is valid, this should be an empty list.
+     */
     fun test(value: V): FieldErrors
 }
 
+/**
+ * A set of validation rules.
+ *
+ * @param V The type of the value to be validated.
+ */
 typealias ValidationRuleSet<V> = Set<ValidationRule<V>>

--- a/soil-form/src/commonMain/kotlin/soil/form/ValidationRuleBuilder.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/ValidationRuleBuilder.kt
@@ -3,19 +3,41 @@
 
 package soil.form
 
+/**
+ * Builder for creating a set of validation rules.
+ *
+ * @param V The type of the value to be validated.
+ */
 class ValidationRuleBuilder<V> {
     private val rules: MutableSet<ValidationRule<V>> = mutableSetOf()
 
+    /**
+     * Adds a rule to the set of rules.
+     *
+     * @param rule The rule to be added.
+     */
     fun extend(rule: ValidationRule<V>) = this.apply {
         rules.add(rule)
     }
 
+    /**
+     * Builds the set of rules.
+     *
+     * @return The set of rules.
+     */
     fun build(): ValidationRuleSet<V> {
         if (rules.isEmpty()) error("Rule must be at least one.")
         return rules.toSet()
     }
 }
 
-fun <T> rules(block: ValidationRuleBuilder<T>.() -> Unit): ValidationRuleSet<T> {
-    return ValidationRuleBuilder<T>().apply(block).build()
+/**
+ * Creates a set of validation rules.
+ *
+ * @param V The type of the value to be validated.
+ * @param block The block of code to build the rules.
+ * @return The set of rules.
+ */
+fun <V> rules(block: ValidationRuleBuilder<V>.() -> Unit): ValidationRuleSet<V> {
+    return ValidationRuleBuilder<V>().apply(block).build()
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/Controller.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/Controller.kt
@@ -26,6 +26,26 @@ import soil.form.FieldName
 import soil.form.FieldValidateOn
 import soil.form.Submission
 
+/**
+ * A controller for a form [field control][FieldControl].
+ *
+ * To minimize the impact of re-composition due to updates in input values,
+ * the [FieldControl] is passed to a [Controller], which then connects the actual input component with the [Field] interface.
+ *
+ * Usage:
+ * ```kotlin
+ * Form(..) {
+ *   ..
+ *     Controller(control = rememberFirstNameFieldControl()) { field ->
+ *       TextField(value = field.value, onValueChange = field.onChange, ...)
+ *     }
+ * }
+ * ```
+ *
+ * @param V The type of the field value.
+ * @param control The field control to be managed.
+ * @param content The content to be displayed.
+ */
 @OptIn(FlowPreview::class)
 @Composable
 fun <V> Controller(
@@ -139,6 +159,26 @@ internal class FieldController<V>(
     }
 }
 
+/**
+ * A controller for a form [submission control][SubmissionControl].
+ *
+ * To minimize the impact of re-composition due to updates in input values,
+ * the [SubmissionControl] is passed to a [Controller], which then connects the actual input component with the [Submission] interface.
+ *
+ * Usage:
+ * ```kotlin
+ * Form(..) {
+ *   ..
+ *     Controller(control = rememberSubmissionRuleAutoControl()) { submission ->
+ *       Button(onClick = submission.onSubmit, enabled = submission.canSubmit, ...)
+ *     }
+ * }
+ * ```
+ *
+ * @param T The type of the submission value.
+ * @param control The submission control to be managed.
+ * @param content The content to be displayed.
+ */
 @OptIn(FlowPreview::class)
 @Composable
 fun <T> Controller(

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/FieldControl.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/FieldControl.kt
@@ -10,6 +10,21 @@ import soil.form.FieldPolicy
 import soil.form.FieldValidateOn
 import soil.form.FormRule
 
+/**
+ * Represents a field control in a form.
+ *
+ * @param V The type of the field value.
+ * @property name The name of the field.
+ * @property policy The policy of the field.
+ * @property rule The rule to validate the field value.
+ * @property defaultValue The default value of the field.
+ * @property getValue The function to get the current field value.
+ * @property setValue The function to set the new field value.
+ * @property getErrors The function to get the current field errors.
+ * @property setErrors The function to set the new field errors. If the new errors are empty, the field is considered valid.
+ * @property shouldTrigger The function to determine if the field should trigger validation on the given event.
+ * @property isEnabled The function to determine if the field is enabled.
+ */
 @Stable
 class FieldControl<V>(
     val name: FieldName,
@@ -23,6 +38,14 @@ class FieldControl<V>(
     val shouldTrigger: (FieldValidateOn) -> Boolean,
     val isEnabled: () -> Boolean
 ) {
+
+    /**
+     * Validates the field value.
+     *
+     * @param value The value to validate. Defaults to the current field value.
+     * @param dryRun Whether to perform a dry run. Defaults to `false`. If `true`, the field errors are not updated.
+     * @return `true` if the field value is valid; `false` otherwise.
+     */
     fun validate(value: V = getValue(), dryRun: Boolean = false): Boolean {
         return rule.test(value, dryRun)
     }

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/Form.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/Form.kt
@@ -28,6 +28,37 @@ import soil.form.FormPolicy
 import soil.form.FormRule
 import soil.form.FormValidationException
 
+/**
+ * A Form to manage the state and actions of input fields, and create a child block of [FormScope].
+ *
+ * Usage:
+ * ```kotlin
+ * Form(
+ *     onSubmit = {
+ *         // Handle submit
+ *     },
+ *     initialValue = "",
+ *     policy = FormPolicy.Minimal
+ * ) { // this: FormScope<String>
+ *   ..
+ * }
+ * ```
+ *
+ * **Note:**
+ * If you are expecting state restoration on the Android platform, please check if the type specified in [initialValue] is restorable.
+ * Inside the Form, `rememberSaveable` is used to manage input values, and runtime errors will be thrown from the API for unsupported types.
+ *
+ * @param T The type of the form value.
+ * @param onSubmit The submit handler to call when the form is submit.
+ * @param initialValue The initial value of the form.
+ * @param modifier The modifier to apply to this layout node.
+ * @param onError The error handler to call when an error occurs on submit.
+ * @param saver The saver to save and restore the form state.
+ * @param key The key to reset the form state.
+ * @param policy The policy to apply to the form.
+ * @param coroutineScope The coroutine scope to launch the submit handler.
+ * @param content The content block to create the child block of [FormScope].
+ */
 @Composable
 fun <T : Any> Form(
     onSubmit: suspend (T) -> Unit,

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/FormScope.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/FormScope.kt
@@ -13,15 +13,49 @@ import soil.form.FieldValidateOn
 import soil.form.FormRule
 import soil.form.FormRules
 
-
+/**
+ * A scope to manage the state and actions of input fields in a form.
+ *
+ * @param T The type of the form value.
+ */
 @Stable
 class FormScope<T : Any> internal constructor(
     private val state: FormStateImpl<T>,
     private val submitHandler: SubmitHandler<T>
 ) {
 
+    /**
+     * The current form state.
+     */
     val formState: FormState<T> get() = state
 
+    /**
+     * Remembers a field control for the given field name.
+     *
+     * Usage:
+     * ```kotlin
+     * rememberFieldControl(
+     *     name = "First name",
+     *     select = { firstName },
+     *     update = { copy(firstName = it) }
+     * ) {
+     *     if (firstName.isNotBlank()) {
+     *         noErrors
+     *     } else {
+     *         fieldError("must be not blank")
+     *     }
+     * }
+     * ```
+     *
+     * @param V The type of the field value.
+     * @param name The name of the field.
+     * @param select The function to select the field value.
+     * @param update The function to update the field value.
+     * @param enabled The function to determine if the field is enabled.
+     * @param dependsOn The set of field names that this field depends on.
+     * @param validate The function to validate the field value.
+     * @return The remembered [field control][FieldControl].
+     */
     @Composable
     fun <V> rememberFieldControl(
         name: FieldName,
@@ -100,6 +134,19 @@ class FormScope<T : Any> internal constructor(
         }
     }
 
+    /**
+     * Remembers a submission control for the form.
+     *
+     * Usage:
+     * ```kotlin
+     * rememberSubmissionControl { rules, dryRun ->
+     *     rules.values.map { it.test(this, dryRun = dryRun) }.all { it }
+     * }
+     * ```
+     *
+     * @param validate The function to validate the form value.
+     * @return The remembered [submission control][SubmissionControl].
+     */
     @Composable
     fun rememberSubmissionControl(
         validate: T.(rules: FormRules<T>, dryRun: Boolean) -> Boolean

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/FormScopeExt.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/FormScopeExt.kt
@@ -13,6 +13,29 @@ import soil.form.ValidationRuleBuilder
 import soil.form.ValidationRuleSet
 import soil.form.rules
 
+/**
+ * Remembers a field control for the given field name with the given rule set.
+ *
+ * Usage:
+ * ```kotlin
+ * rememberFieldRuleControl(
+ *     name = "First name",
+ *     select = { firstName },
+ *     update = { copy(firstName = it) }
+ * ) {
+ *     notBlank { "must be not blank" }
+ * }
+ * ```
+ *
+ * @param T The type of the form value.
+ * @param V The type of the field value.
+ * @param name The name of the field.
+ * @param select The function to select the field value.
+ * @param update The function to update the field value.
+ * @param enabled The function to determine if the field is enabled.
+ * @param dependsOn The set of field names that this field depends on.
+ * @param builder The block to build the rule set.
+ */
 @Composable
 fun <T : Any, V> FormScope<T>.rememberFieldRuleControl(
     name: FieldName,
@@ -32,6 +55,32 @@ fun <T : Any, V> FormScope<T>.rememberFieldRuleControl(
     )
 }
 
+/**
+ * Remembers a field control for the given field name with the given rule set.
+ *
+ * Usage:
+ * ```kotlin
+ * val ruleSet = rules<String> {
+ *     notBlank { "must be not blank" }
+ * }
+ *
+ * rememberFieldRuleControl(
+ *     name = "First name",
+ *     select = { firstName },
+ *     update = { copy(firstName = it) },
+ *     ruleSet = ruleSet
+ * )
+ * ```
+ *
+ * @param T The type of the form value.
+ * @param V The type of the field value.
+ * @param name The name of the field.
+ * @param select The function to select the field value.
+ * @param update The function to update the field value.
+ * @param enabled The function to determine if the field is enabled.
+ * @param dependsOn The set of field names that this field depends on.
+ * @param ruleSet The rule set to validate the field value.
+ */
 @Composable
 fun <T : Any, V> FormScope<T>.rememberFieldRuleControl(
     name: FieldName,
@@ -57,6 +106,9 @@ fun <T : Any, V> FormScope<T>.rememberFieldRuleControl(
     )
 }
 
+/**
+ * Remembers a submission rule control that automatically controls state of the form.
+ */
 @Composable
 fun <T : Any> FormScope<T>.rememberSubmissionRuleAutoControl(): SubmissionControl<T> {
     return rememberSubmissionControl(validate = { rules, dryRun ->
@@ -69,6 +121,13 @@ fun <T : Any> FormScope<T>.rememberSubmissionRuleAutoControl(): SubmissionContro
     })
 }
 
+/**
+ * Remembers a watch value that automatically updates when the form state changes.
+ *
+ * @param T The type of the form value.
+ * @param V The type of the watch value.
+ * @param select The function to select the watch value.
+ */
 @Composable
 fun <T : Any, V> FormScope<T>.rememberWatch(select: T.() -> V): V {
     val value by remember { derivedStateOf { with(formState.value) { select() } } }

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/FormState.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/FormState.kt
@@ -16,23 +16,71 @@ import soil.form.FormErrors
 import soil.form.FormFieldDependencies
 import soil.form.FormFieldNames
 import soil.form.FormPolicy
-import soil.form.FormTriggers
-import soil.form.FormRules
 import soil.form.FormRule
+import soil.form.FormRules
+import soil.form.FormTriggers
 
+/**
+ * The managed state of a form.
+ *
+ * @param T The type of the form value.
+ */
 @Stable
 interface FormState<T> {
+
+    /**
+     * The initial value of the form.
+     */
     val initialValue: T
+
+    /**
+     * The current value of the form.
+     */
     val value: T
+
+    /**
+     * Whether the form is currently submitting.
+     */
     val isSubmitting: Boolean
+
+    /**
+     * Whether the form has been submitted.
+     */
     val isSubmitted: Boolean
+
+    /**
+     * The number of times submission process was called.
+     */
     val submitCount: Int
+
+    /**
+     * The validation errors of the form.
+     */
     val errors: FormErrors
+
+    /**
+     * The validation triggers of the form.
+     */
     val triggers: FormTriggers
+
+    /**
+     * The validation rules of the form.
+     */
     val rules: FormRules<T>
+
+    /**
+     * The dependencies of the form fields.
+     */
     val dependsOn: FormFieldDependencies
+
+    /**
+     * The field dependencies of the form fields.
+     */
     val watchers: FormFieldDependencies
 
+    /**
+     * Returns `true` if the form has validation error, `false` otherwise.
+     */
     val hasError: Boolean
         get() = errors.values.any { it.isNotEmpty() }
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/ModifierExt.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/ModifierExt.kt
@@ -8,6 +8,12 @@ import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.focus.onFocusChanged
 import soil.form.Field
 
+/**
+ * Adds a callback to be invoked when the focus state of the field changes.
+ *
+ * @param target The field to observe.
+ * @return The applied modifier.
+ */
 fun Modifier.onFocusChanged(target: Field<*>): Modifier {
     return this then Modifier.onFocusChanged(target::onFocusChanged)
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/SubmissionControl.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/SubmissionControl.kt
@@ -8,6 +8,22 @@ import soil.form.FormFieldNames
 import soil.form.FormRule
 import soil.form.SubmissionPolicy
 
+/**
+ * Represents a submission control in a form.
+ *
+ * @param T The type of the form value.
+ * @property policy The policy of the submission.
+ * @property rule The rule to validate the form value.
+ * @property submit The function to submit the form.
+ * @property initialValue The initial value of the form.
+ * @property getValue The function to get the current form value.
+ * @property hasError The function to determine if the form has errors.
+ * @property getFieldKeys The function to get the keys of the form fields.
+ * @property isSubmitting The function to determine if the form is currently submitting.
+ * @property isSubmitted The function to determine if the form has been submitted.
+ * @property getSubmitCount The function to get the number of times submission process was called.
+ * @constructor Creates a submission control.
+ */
 @Stable
 class SubmissionControl<T>(
     val policy: SubmissionPolicy,
@@ -21,6 +37,14 @@ class SubmissionControl<T>(
     val isSubmitted: () -> Boolean,
     val getSubmitCount: () -> Int
 ) {
+
+    /**
+     * Validates the form value.
+     *
+     * @param value The value to validate. Defaults to the current form value.
+     * @param dryRun Whether to perform a dry run. Defaults to `false`. If `true`, the form errors are not updated.
+     * @return `true` if the form value is valid; `false` otherwise.
+     */
     fun validate(value: T, dryRun: Boolean = false): Boolean {
         return rule.test(value, dryRun)
     }

--- a/soil-form/src/commonMain/kotlin/soil/form/rule/ArrayRule.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/rule/ArrayRule.kt
@@ -3,15 +3,22 @@
 
 package soil.form.rule
 
-import soil.form.fieldError
 import soil.form.FieldErrors
 import soil.form.ValidationRule
 import soil.form.ValidationRuleBuilder
+import soil.form.fieldError
 import soil.form.noErrors
 
 typealias ArrayRule<V> = ValidationRule<Array<V>>
 typealias ArrayRuleBuilder<V> = ValidationRuleBuilder<Array<V>>
 
+/**
+ * A rule that tests the array value.
+ *
+ * @property predicate The predicate to test the array value. Returns `true` if the test passes; `false` otherwise.
+ * @property message The message to return when the test fails.
+ * @constructor Creates a new instance of [ArrayRuleTester].
+ */
 class ArrayRuleTester<V>(
     val predicate: Array<V>.() -> Boolean,
     val message: () -> String
@@ -21,14 +28,52 @@ class ArrayRuleTester<V>(
     }
 }
 
+/**
+ * Validates that the array is not empty.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Array<String>> {
+ *     notEmpty { "must be not empty" }
+ * }
+ * ```
+ *
+ * @param message The message to return when the test fails.
+ */
 fun <V> ArrayRuleBuilder<V>.notEmpty(message: () -> String) {
     extend(ArrayRuleTester(Array<V>::isNotEmpty, message))
 }
 
+/**
+ * Validates that the array size is at least [limit].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Array<String>> {
+ *     minSize(3) { "must have at least 3 items" }
+ * }
+ * ```
+ *
+ * @param limit The minimum number of elements the array must have.
+ * @param message The message to return when the test fails.
+ */
 fun <V> ArrayRuleBuilder<V>.minSize(limit: Int, message: () -> String) {
     extend(ArrayRuleTester({ size >= limit }, message))
 }
 
+/**
+ * Validates that the array size is no more than [limit].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Array<String>> {
+ *     maxSize(20) { "must have at no more 20 items" }
+ * }
+ * ```
+ *
+ * @param limit The maximum number of elements the array can have.
+ * @param message The message to return when the test fails.
+ */
 fun <V> ArrayRuleBuilder<V>.maxSize(limit: Int, message: () -> String) {
     extend(ArrayRuleTester({ size <= limit }, message))
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/rule/BooleanRule.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/rule/BooleanRule.kt
@@ -3,15 +3,22 @@
 
 package soil.form.rule
 
-import soil.form.fieldError
 import soil.form.FieldErrors
 import soil.form.ValidationRule
 import soil.form.ValidationRuleBuilder
+import soil.form.fieldError
 import soil.form.noErrors
 
 typealias BooleanRule = ValidationRule<Boolean>
 typealias BooleanRuleBuilder = ValidationRuleBuilder<Boolean>
 
+/**
+ * A rule that tests the boolean value.
+ *
+ * @property predicate The predicate to test the boolean value. Returns `true` if the test passes; `false` otherwise.
+ * @property message The message to return when the test fails.
+ * @constructor Creates a new instance of [BooleanRuleTester].
+ */
 class BooleanRuleTester(
     val predicate: Boolean.() -> Boolean,
     val message: () -> String
@@ -21,10 +28,34 @@ class BooleanRuleTester(
     }
 }
 
+/**
+ * Validates that the boolean value is `true`.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Boolean> {
+ *     isTrue { "must be true" }
+ * }
+ * ```
+ *
+ * @param message The message to return when the test fails.
+ */
 fun BooleanRuleBuilder.isTrue(message: () -> String) {
     extend(BooleanRuleTester({ this }, message))
 }
 
+/**
+ * Validates that the boolean value is `false`.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Boolean> {
+ *     isFalse { "must be false" }
+ * }
+ * ```
+ *
+ * @param message The message to return when the test fails.
+ */
 fun BooleanRuleBuilder.isFalse(message: () -> String) {
     extend(BooleanRuleTester({ !this }, message))
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/rule/CollectionRule.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/rule/CollectionRule.kt
@@ -3,15 +3,24 @@
 
 package soil.form.rule
 
-import soil.form.fieldError
 import soil.form.FieldErrors
 import soil.form.ValidationRule
 import soil.form.ValidationRuleBuilder
+import soil.form.fieldError
 import soil.form.noErrors
+
+// TODO: ListRule, SetRule, MapRule
 
 typealias CollectionRule<V> = ValidationRule<Collection<V>>
 typealias CollectionRuleBuilder<V> = ValidationRuleBuilder<Collection<V>>
 
+/**
+ * A rule that tests the collection value.
+ *
+ * @property predicate The predicate to test the collection value. Returns `true` if the test passes; `false` otherwise.
+ * @property message The message to return when the test fails.
+ * @constructor Creates a new instance of [CollectionRuleTester].
+ */
 class CollectionRuleTester<V>(
     val predicate: Collection<V>.() -> Boolean,
     val message: () -> String
@@ -21,14 +30,52 @@ class CollectionRuleTester<V>(
     }
 }
 
+/**
+ * Validates that the collection is not empty.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Collection<String>> {
+ *     notEmpty { "must not be empty" }
+ * }
+ * ```
+ *
+ * @param message The message to return when the test fails.
+ */
 fun <V> CollectionRuleBuilder<V>.notEmpty(message: () -> String) {
     extend(CollectionRuleTester(Collection<V>::isNotEmpty, message))
 }
 
+/**
+ * Validates that the collection size is at least [limit].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Collection<String>> {
+ *     minSize(3) { "must have at least 3 items" }
+ * }
+ * ```
+ *
+ * @param limit The minimum number of elements the collection must have.
+ * @param message The message to return when the test fails.
+ */
 fun <V> CollectionRuleBuilder<V>.minSize(limit: Int, message: () -> String) {
     extend(CollectionRuleTester({ size >= limit }, message))
 }
 
+/**
+ * Validates that the collection size is no more than [limit].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Collection<String>> {
+ *     maxSize(20) { "must have at no more 20 items" }
+ * }
+ * ```
+ *
+ * @param limit The maximum number of elements the collection can have.
+ * @param message The message to return when the test fails.
+ */
 fun <V> CollectionRuleBuilder<V>.maxSize(limit: Int, message: () -> String) {
     extend(CollectionRuleTester({ size <= limit }, message))
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/rule/DoubleRule.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/rule/DoubleRule.kt
@@ -3,15 +3,22 @@
 
 package soil.form.rule
 
-import soil.form.fieldError
 import soil.form.FieldErrors
 import soil.form.ValidationRule
 import soil.form.ValidationRuleBuilder
+import soil.form.fieldError
 import soil.form.noErrors
 
 typealias DoubleRule = ValidationRule<Double>
 typealias DoubleRuleBuilder = ValidationRuleBuilder<Double>
 
+/**
+ * A rule that tests the double value.
+ *
+ * @property predicate The predicate to test the double value. Returns `true` if the test passes; `false` otherwise.
+ * @property message The message to return when the test fails.
+ * @constructor Creates a new instance of [DoubleRuleTester].
+ */
 class DoubleRuleTester(
     val predicate: Double.() -> Boolean,
     val message: () -> String
@@ -21,18 +28,68 @@ class DoubleRuleTester(
     }
 }
 
+/**
+ * Validates that the double value is greater than or equal to [limit].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Double> {
+ *     minimum(3.0) { "must be greater than or equal to 3.0" }
+ * }
+ * ```
+ *
+ * @param limit The minimum value the double must have.
+ * @param message The message to return when the test fails.
+ */
 fun DoubleRuleBuilder.minimum(limit: Double, message: () -> String) {
     extend(DoubleRuleTester({ this >= limit }, message))
 }
 
+/**
+ * Validates that the double value is less than or equal to [limit].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Double> {
+ *     maximum(20.0) { "must be less than or equal to 20.0" }
+ * }
+ * ```
+ *
+ * @param limit The maximum value the double can have.
+ * @param message The message to return when the test fails.
+ */
 fun DoubleRuleBuilder.maximum(limit: Double, message: () -> String) {
     extend(DoubleRuleTester({ this <= limit }, message))
 }
 
+/**
+ * Validates that the double value is `NaN`.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Double> {
+ *     isNaN { "must be NaN" }
+ * }
+ * ```
+ *
+ * @param message The message to return when the test fails.
+ */
 fun DoubleRuleBuilder.isNaN(message: () -> String) {
     extend(DoubleRuleTester({ isNaN() }, message))
 }
 
+/**
+ * Validates that the double value is not `NaN`.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Double> {
+ *     notNaN { "must be not NaN" }
+ * }
+ * ```
+ *
+ * @param message The message to return when the test fails.
+ */
 fun DoubleRuleBuilder.notNaN(message: () -> String) {
     extend(DoubleRuleTester({ !isNaN() }, message))
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/rule/FloatRule.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/rule/FloatRule.kt
@@ -3,15 +3,22 @@
 
 package soil.form.rule
 
-import soil.form.fieldError
 import soil.form.FieldErrors
 import soil.form.ValidationRule
 import soil.form.ValidationRuleBuilder
+import soil.form.fieldError
 import soil.form.noErrors
 
 typealias FloatRule = ValidationRule<Float>
 typealias FloatRuleBuilder = ValidationRuleBuilder<Float>
 
+/**
+ * A rule that tests the float value.
+ *
+ * @property predicate The predicate to test the float value. Returns `true` if the test passes; `false` otherwise.
+ * @property message The message to return when the test fails.
+ * @constructor Creates a new instance of [FloatRuleTester].
+ */
 class FloatRuleTester(
     val predicate: Float.() -> Boolean,
     val message: () -> String
@@ -21,18 +28,68 @@ class FloatRuleTester(
     }
 }
 
+/**
+ * Validates that the float value is greater than or equal to [limit].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Float> {
+ *     minimum(3.0f) { "must be greater than or equal to 3.0" }
+ * }
+ * ```
+ *
+ * @param limit The minimum value the float must have.
+ * @param message The message to return when the test fails.
+ */
 fun FloatRuleBuilder.minimum(limit: Float, message: () -> String) {
     extend(FloatRuleTester({ this >= limit }, message))
 }
 
+/**
+ * Validates that the float value is less than or equal to [limit].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Float> {
+ *     maximum(20.0f) { "must be less than or equal to 20.0" }
+ * }
+ * ```
+ *
+ * @param limit The maximum value the float can have.
+ * @param message The message to return when the test fails.
+ */
 fun FloatRuleBuilder.maximum(limit: Float, message: () -> String) {
     extend(FloatRuleTester({ this <= limit }, message))
 }
 
+/**
+ * Validates that the float value is `NaN`.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Float> {
+ *     isNaN { "must be NaN" }
+ * }
+ * ```
+ *
+ * @param message The message to return when the test fails.
+ */
 fun FloatRuleBuilder.isNaN(message: () -> String) {
     extend(FloatRuleTester({ isNaN() }, message))
 }
 
+/**
+ * Validates that the float value is not `NaN`.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Float> {
+ *     notNaN { "must be not NaN" }
+ * }
+ * ```
+ *
+ * @param message The message to return when the test fails.
+ */
 fun FloatRuleBuilder.notNaN(message: () -> String) {
     extend(FloatRuleTester({ !isNaN() }, message))
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/rule/IntRule.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/rule/IntRule.kt
@@ -3,15 +3,22 @@
 
 package soil.form.rule
 
-import soil.form.fieldError
 import soil.form.FieldErrors
 import soil.form.ValidationRule
 import soil.form.ValidationRuleBuilder
+import soil.form.fieldError
 import soil.form.noErrors
 
 typealias IntRule = ValidationRule<Int>
 typealias IntRuleBuilder = ValidationRuleBuilder<Int>
 
+/**
+ * A rule that tests the integer value.
+ *
+ * @property predicate The predicate to test the integer value. Returns `true` if the test passes; `false` otherwise.
+ * @property message The message to return when the test fails.
+ * @constructor Creates a new instance of [IntRuleTester].
+ */
 class IntRuleTester(
     val predicate: Int.() -> Boolean,
     val message: () -> String
@@ -21,10 +28,36 @@ class IntRuleTester(
     }
 }
 
+/**
+ * Validates that the integer value is greater than or equal to [limit].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Int> {
+ *     minimum(3) { "must be greater than or equal to 3" }
+ * }
+ * ```
+ *
+ * @param limit The minimum value the integer must have.
+ * @param message The message to return when the test fails.
+ */
 fun IntRuleBuilder.minimum(limit: Int, message: () -> String) {
     extend(IntRuleTester({ this >= limit }, message))
 }
 
+/**
+ * Validates that the integer value is less than or equal to [limit].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Int> {
+ *     maximum(20) { "must be less than or equal to 20" }
+ * }
+ * ```
+ *
+ * @param limit The maximum value the integer can have.
+ * @param message The message to return when the test fails.
+ */
 fun IntRuleBuilder.maximum(limit: Int, message: () -> String) {
     extend(IntRuleTester({ this <= limit }, message))
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/rule/LongRule.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/rule/LongRule.kt
@@ -3,15 +3,22 @@
 
 package soil.form.rule
 
-import soil.form.fieldError
 import soil.form.FieldErrors
 import soil.form.ValidationRule
 import soil.form.ValidationRuleBuilder
+import soil.form.fieldError
 import soil.form.noErrors
 
 typealias LongRule = ValidationRule<Long>
 typealias LongRuleBuilder = ValidationRuleBuilder<Long>
 
+/**
+ * A rule that tests the long value.
+ *
+ * @property predicate The predicate to test the long value. Returns `true` if the test passes; `false` otherwise.
+ * @property message The message to return when the test fails.
+ * @constructor Creates a new instance of [LongRuleTester].
+ */
 class LongRuleTester(
     val predicate: Long.() -> Boolean,
     val message: () -> String
@@ -21,10 +28,33 @@ class LongRuleTester(
     }
 }
 
+/**
+ * Validates that the long value is greater than or equal to [limit].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Long> {
+ *     minimum(3) { "must be greater than or equal to 3" }
+ * }
+ * ```
+ *
+ * @param limit The minimum value the long must have.
+ * @param message The message to return when the test fails.
+ */
 fun LongRuleBuilder.minimum(limit: Long, message: () -> String) {
     extend(LongRuleTester({ this >= limit }, message))
 }
 
+/**
+ * Validates that the long value is less than or equal to [limit].
+ *
+ * rules<Long> {
+ *     maximum(20) { "must be less than or equal to 20" }
+ * }
+ *
+ * @param limit The maximum value the long can have.
+ * @param message The message to return when the test fails.
+ */
 fun LongRuleBuilder.maximum(limit: Long, message: () -> String) {
     extend(LongRuleTester({ this <= limit }, message))
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/rule/ObjectRule.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/rule/ObjectRule.kt
@@ -3,16 +3,23 @@
 
 package soil.form.rule
 
-import soil.form.fieldError
 import soil.form.FieldErrors
 import soil.form.ValidationRule
 import soil.form.ValidationRuleBuilder
+import soil.form.fieldError
 import soil.form.noErrors
 import soil.form.rules
 
 typealias ObjectRule<V> = ValidationRule<V>
 typealias ObjectRuleBuilder<V> = ValidationRuleBuilder<V>
 
+/**
+ * A rule that tests the object value.
+ *
+ * @property predicate The predicate to test the object value. Returns `true` if the test passes; `false` otherwise.
+ * @property message The message to return when the test fails.
+ * @constructor Creates a new instance of [ObjectRuleTester].
+ */
 class ObjectRuleTester<V>(
     val predicate: V.() -> Boolean,
     val message: () -> String
@@ -22,6 +29,12 @@ class ObjectRuleTester<V>(
     }
 }
 
+/**
+ * A rule that chains a transformation function with a set of rules.
+ *
+ * @property transform The transformation function to apply to the object value.
+ * @constructor Creates a new instance of [ObjectRuleChainer].
+ */
 class ObjectRuleChainer<V, S>(
     val transform: (V) -> S
 ) : ObjectRule<V> {
@@ -32,15 +45,60 @@ class ObjectRuleChainer<V, S>(
         return transform(value).let { ruleSet.flatMap { rule -> rule.test(it) } }
     }
 
+    /**
+     * Chains a set of rules to the transformation function.
+     *
+     * Usage:
+     * ```kotlin
+     * rules<String> {
+     *     notBlank { "must be not blank" }
+     *     cast { it.length } then {
+     *         minimum(3) { "must be at least 3 characters" }
+     *         maximum(20) { "must be at most 20 characters" }
+     *     }
+     * }
+     * ```
+     *
+     * @param block The block to build the set of rules.
+     */
     infix fun then(block: ValidationRuleBuilder<S>.() -> Unit) {
         ruleSet = rules(block)
     }
 }
 
+/**
+ * Validates that the object value passes the given [predicate].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<Post> {
+ *     test({ title.isNotBlank() }) { "Title must be not blank" }
+ * }
+ * ```
+ *
+ * @param predicate The predicate to test the object value. Returns `true` if the test passes; `false` otherwise.
+ * @param message The message to return when the test fails.
+ */
 fun <V : Any> ObjectRuleBuilder<V>.test(predicate: V.() -> Boolean, message: () -> String) {
     extend(ObjectRuleTester(predicate, message))
 }
 
+/**
+ * Chains a transformation function with a set of rules.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<String> {
+ *     notBlank { "must be not blank" }
+ *     cast { it.length } then {
+ *         minimum(3) { "must be at least 3 characters" }
+ *         maximum(20) { "must be at most 20 characters" }
+ *     }
+ * }
+ * ```
+ *
+ * @param transform The transformation function to apply to the object value.
+ */
 fun <V : Any, S> ObjectRuleBuilder<V>.cast(transform: (V) -> S): ObjectRuleChainer<V, S> {
     return ObjectRuleChainer(transform).also { extend(it) }
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/rule/OptionalRule.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/rule/OptionalRule.kt
@@ -3,15 +3,21 @@
 
 package soil.form.rule
 
-import soil.form.fieldError
 import soil.form.FieldErrors
 import soil.form.ValidationRule
 import soil.form.ValidationRuleBuilder
+import soil.form.fieldError
 import soil.form.rules
 
 typealias OptionalRule<V> = ValidationRule<V?>
 typealias OptionalRuleBuilder<V> = ValidationRuleBuilder<V?>
 
+/**
+ * A rule that chains non-optional rules. If the value is not `null`, the rule set is applied to the value.
+ *
+ * @property message The message to return when the value is `null`.
+ * @constructor Creates a new instance of [OptionalRuleChainer].
+ */
 class OptionalRuleChainer<V>(
     val message: () -> String
 ) : OptionalRule<V> {
@@ -26,11 +32,37 @@ class OptionalRuleChainer<V>(
         }
     }
 
+    /**
+     * Chains a set of rules to the non-optional value.
+     *
+     * Usage:
+     * ```kotlin
+     * rules<String?> {
+     *     notNull { "must be not null" } then {
+     *         minLength(3) { "must be at least 3 characters" }
+     *     }
+     * }
+     *
+     * @param block The block to build the rule set.
+     */
     infix fun then(block: ValidationRuleBuilder<V>.() -> Unit) {
         ruleSet = rules(block)
     }
 }
 
+/**
+ * Validates that the optional value is not `null`.
+ *
+ * ```kotlin
+ * rules<String?> {
+ *     notNull { "must be not null" } then {
+ *         minLength(3) { "must be at least 3 characters" }
+ *     }
+ * }
+ *
+ * @param message The message to return when the value is `null`.
+ * @return The rule chainer to chain the non-optional rules.
+ */
 fun <V : Any> OptionalRuleBuilder<V?>.notNull(message: () -> String): OptionalRuleChainer<V> {
     return OptionalRuleChainer<V>(message).also { extend(it) }
 }

--- a/soil-form/src/commonMain/kotlin/soil/form/rule/StringRule.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/rule/StringRule.kt
@@ -3,15 +3,22 @@
 
 package soil.form.rule
 
-import soil.form.fieldError
 import soil.form.FieldErrors
 import soil.form.ValidationRule
 import soil.form.ValidationRuleBuilder
+import soil.form.fieldError
 import soil.form.noErrors
 
 typealias StringRule = ValidationRule<String>
 typealias StringRuleBuilder = ValidationRuleBuilder<String>
 
+/**
+ * A rule that tests the string value.
+ *
+ * @property predicate The predicate to test the string value. Returns `true` if the test passes; `false` otherwise.
+ * @property message The message to return when the test fails.
+ * @constructor Creates a new instance of [StringRuleTester].
+ */
 class StringRuleTester(
     val predicate: String.() -> Boolean,
     val message: () -> String
@@ -21,26 +28,102 @@ class StringRuleTester(
     }
 }
 
+/**
+ * Validates that the string value is not empty.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<String> {
+ *     notEmpty { "must be not empty" }
+ * }
+ * ```
+ *
+ * @param message The message to return when the test fails.
+ */
 fun StringRuleBuilder.notEmpty(message: () -> String) {
     extend(StringRuleTester(String::isNotEmpty, message))
 }
 
+/**
+ * Validates that the string value is not blank.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<String> {
+ *     notBlank { "must be not blank" }
+ * }
+ * ```
+ *
+ * @param message The message to return when the test fails.
+ */
 fun StringRuleBuilder.notBlank(message: () -> String) {
     extend(StringRuleTester(String::isNotBlank, message))
 }
 
+/**
+ * Validates that the string length is at least [limit] characters.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<String> {
+ *     minLength(3) { "must be at least 3 characters" }
+ * }
+ * ```
+ *
+ * @param limit The minimum number of characters the string must have.
+ * @param message The message to return when the test fails.
+ */
 fun StringRuleBuilder.minLength(limit: Int, message: () -> String) {
     extend(StringRuleTester({ length >= limit }, message))
 }
 
+/**
+ * Validates that the string length is no more than [limit] characters.
+ *
+ * Usage:
+ * ```kotlin
+ * rules<String> {
+ *     maxLength(20) { "must be at no more 20 characters" }
+ * }
+ * ```
+ *
+ * @param limit The maximum number of characters the string can have.
+ * @param message The message to return when the test fails.
+ */
 fun StringRuleBuilder.maxLength(limit: Int, message: () -> String) {
     extend(StringRuleTester({ length <= limit }, message))
 }
 
+/**
+ * Validates that the string matches the [pattern].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<String> {
+ *     pattern("^[A-Za-z]+$") { "must be alphabetic" }
+ * }
+ * ```
+ *
+ * @param pattern The regular expression pattern the string must match.
+ * @param message The message to return when the test fails.
+ */
 fun StringRuleBuilder.pattern(pattern: String, message: () -> String) {
     pattern(Regex(pattern), message)
 }
 
+/**
+ * Validates that the string matches the [pattern].
+ *
+ * Usage:
+ * ```kotlin
+ * rules<String> {
+ *     pattern(Regex("^[A-Za-z]+$")) { "must be alphabetic" }
+ * }
+ * ```
+ *
+ * @param pattern The regular expression pattern the string must match.
+ * @param message The message to return when the test fails.
+ */
 fun StringRuleBuilder.pattern(pattern: Regex, message: () -> String) {
     extend(StringRuleTester({ pattern.matches(this) }, message))
 }


### PR DESCRIPTION
The goal is to make the API documentation and source code easier to understand.
The first step is to add KDoc comments to the code.