### PR TITLE
Fix usage of semantics within ContentVisibility

### DIFF
--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/ContentVisibility.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/ContentVisibility.kt
@@ -8,8 +8,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.semantics
 
 /**
  * A composable that can hide its [content] without removing it from the layout.
@@ -32,7 +32,7 @@ fun ContentVisibility(
     Box(
         modifier = modifier
             .alpha(if (hidden) 0f else 1f)
-            .clearAndSetSemantics {
+            .semantics {
                 if (hidden) {
                     invisibleToUser()
                 }


### PR DESCRIPTION
Changed to the semantics modifier from clearAndSemantics. 
Content in ContentVisibility is now correctly recognized by UiAutomator.

The following captured image was taken using [Appium Inspector](https://appium.github.io/appium-inspector/latest/).

Before:
<img width="960" src="https://github.com/soil-kt/soil/assets/1496485/ba797ec3-edc1-4f84-8d89-66a9d74526f6"></img>

After:
<img width="960" src="https://github.com/soil-kt/soil/assets/1496485/76d36289-52fe-4c53-acc7-35611bac33f0"></img>


