### PR TITLE
Experimental support kotlinx.serialization with androidx.core.bundle

### DIFF
--- a/buildSrc/src/main/kotlin/BuildModule.kt
+++ b/buildSrc/src/main/kotlin/BuildModule.kt
@@ -3,5 +3,6 @@ val publicModules = setOf(
     "soil-query-compose",
     "soil-query-compose-runtime",
     "soil-form",
+    "soil-serialization-bundle",
     "soil-space"
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,7 @@ include(
     ":soil-query-compose",
     ":soil-query-compose-runtime",
     ":soil-form",
+    ":soil-serialization-bundle",
     ":soil-space"
 )
 

--- a/soil-serialization-bundle/build.gradle.kts
+++ b/soil-serialization-bundle/build.gradle.kts
@@ -1,0 +1,79 @@
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.maven.publish)
+    alias(libs.plugins.dokka)
+}
+
+val buildTarget = the<BuildTargetExtension>()
+
+kotlin {
+    applyDefaultHierarchyTemplate()
+
+    jvm()
+    androidTarget {
+        compilations.all {
+            kotlinOptions {
+                jvmTarget = buildTarget.javaVersion.get().toString()
+            }
+        }
+        publishLibraryVariants("release")
+    }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.kotlinx.serialization.core)
+            implementation(libs.jbx.core.bundle)
+        }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(projects.internal.testing)
+        }
+    }
+}
+
+android {
+    namespace = "soil.serialization.bundle"
+    compileSdk = buildTarget.androidCompileSdk.get()
+
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    sourceSets["main"].res.srcDirs("src/androidMain/res")
+    sourceSets["main"].resources.srcDirs("src/commonMain/resources")
+
+    defaultConfig {
+        minSdk = buildTarget.androidMinSdk.get()
+    }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+        }
+    }
+    compileOptions {
+        sourceCompatibility = buildTarget.javaVersion.get()
+        targetCompatibility = buildTarget.javaVersion.get()
+    }
+    @Suppress("UnstableApiUsage")
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
+    dependencies {
+        debugImplementation(libs.compose.ui.tooling)
+    }
+}

--- a/soil-serialization-bundle/gradle.properties
+++ b/soil-serialization-bundle/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=serialization-bundle
+POM_NAME=serialization-bundle

--- a/soil-serialization-bundle/src/commonMain/kotlin/soil/serialization/bundle/BundleDecoder.kt
+++ b/soil-serialization-bundle/src/commonMain/kotlin/soil/serialization/bundle/BundleDecoder.kt
@@ -1,0 +1,101 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.serialization.bundle
+
+import androidx.core.bundle.Bundle
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.AbstractDecoder
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.modules.SerializersModule
+
+@ExperimentalSerializationApi
+@PublishedApi
+internal class BundleDecoder(
+    private val bundler: Bundler,
+    private val savedBundle: Bundle,
+    descriptor: SerialDescriptor? = null
+) : AbstractDecoder() {
+
+    private var currentStructure: SerialDescriptor? = descriptor
+    private var currentStructureIndex: Int = if (descriptor != null) 0 else -1
+
+    override val serializersModule: SerializersModule = bundler.serializersModule
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
+        if (currentStructure == null) {
+            currentStructure = descriptor
+            currentStructureIndex = 0
+            return this
+        }
+        val nestedBundle = savedBundle.getBundle(extractElementKey())!!
+        return BundleDecoder(bundler, nestedBundle, descriptor)
+    }
+
+    override fun endStructure(descriptor: SerialDescriptor) = Unit
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        error("Should not be called when decodeSequentially=true")
+    }
+
+    override fun decodeSequentially(): Boolean = true
+
+    override fun decodeCollectionSize(descriptor: SerialDescriptor): Int {
+        return savedBundle.getInt(Bundler.COLLECTION_SIZE_KEY)
+    }
+
+    override fun decodeBoolean(): Boolean {
+        return savedBundle.getBoolean(extractElementKey())
+    }
+
+    override fun decodeByte(): Byte {
+        return savedBundle.getByte(extractElementKey())
+    }
+
+    override fun decodeChar(): Char {
+        return savedBundle.getChar(extractElementKey())
+    }
+
+    override fun decodeDouble(): Double {
+        return savedBundle.getDouble(extractElementKey())
+    }
+
+    override fun decodeFloat(): Float {
+        return savedBundle.getFloat(extractElementKey())
+    }
+
+    override fun decodeInt(): Int {
+        return savedBundle.getInt(extractElementKey())
+    }
+
+    override fun decodeLong(): Long {
+        return savedBundle.getLong(extractElementKey())
+    }
+
+    override fun decodeShort(): Short {
+        return savedBundle.getShort(extractElementKey())
+    }
+
+    override fun decodeString(): String {
+        return savedBundle.getString(extractElementKey())!!
+    }
+
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int {
+        return decodeInt()
+    }
+
+    override fun decodeNotNullMark(): Boolean {
+        val key = currentStructure?.getElementName(currentStructureIndex)
+        return savedBundle.containsKey(key)
+    }
+
+    override fun decodeNull(): Nothing? {
+        currentStructureIndex++
+        return null
+    }
+
+    private fun extractElementKey(): String? {
+        return currentStructure?.getElementName(currentStructureIndex++)
+    }
+}

--- a/soil-serialization-bundle/src/commonMain/kotlin/soil/serialization/bundle/BundleEncoder.kt
+++ b/soil-serialization-bundle/src/commonMain/kotlin/soil/serialization/bundle/BundleEncoder.kt
@@ -1,0 +1,91 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.serialization.bundle
+
+import androidx.core.bundle.Bundle
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.AbstractEncoder
+import kotlinx.serialization.encoding.CompositeEncoder
+import kotlinx.serialization.modules.SerializersModule
+
+@ExperimentalSerializationApi
+@PublishedApi
+internal class BundleEncoder(
+    private val bundler: Bundler,
+    private val parentBundle: Bundle,
+    private val parentKey: String? = null
+) : AbstractEncoder() {
+
+    private val currentBundle = if (parentKey == null) parentBundle else Bundle()
+    private var currentKey: String? = null
+
+    override val serializersModule: SerializersModule = bundler.serializersModule
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
+        val key = currentKey ?: return this
+        return BundleEncoder(bundler, currentBundle, key)
+    }
+
+    override fun endStructure(descriptor: SerialDescriptor) {
+        val key = parentKey ?: return
+        parentBundle.putBundle(key, currentBundle)
+    }
+
+    override fun beginCollection(
+        descriptor: SerialDescriptor,
+        collectionSize: Int
+    ): CompositeEncoder {
+        val encoder = super.beginCollection(descriptor, collectionSize) as BundleEncoder
+        encoder.currentBundle.putInt(Bundler.COLLECTION_SIZE_KEY, collectionSize)
+        return encoder
+    }
+
+    override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
+        currentKey = descriptor.getElementName(index)
+        return true
+    }
+
+    override fun encodeBoolean(value: Boolean) {
+        currentBundle.putBoolean(currentKey, value)
+    }
+
+    override fun encodeByte(value: Byte) {
+        currentBundle.putByte(currentKey, value)
+    }
+
+    override fun encodeChar(value: Char) {
+        currentBundle.putChar(currentKey, value)
+    }
+
+    override fun encodeDouble(value: Double) {
+        currentBundle.putDouble(currentKey, value)
+    }
+
+    override fun encodeFloat(value: Float) {
+        currentBundle.putFloat(currentKey, value)
+    }
+
+    override fun encodeInt(value: Int) {
+        currentBundle.putInt(currentKey, value)
+    }
+
+    override fun encodeLong(value: Long) {
+        currentBundle.putLong(currentKey, value)
+    }
+
+    override fun encodeShort(value: Short) {
+        currentBundle.putShort(currentKey, value)
+    }
+
+    override fun encodeString(value: String) {
+        currentBundle.putString(currentKey, value)
+    }
+
+    override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
+        encodeInt(index)
+    }
+
+    override fun encodeNull() = Unit
+}

--- a/soil-serialization-bundle/src/commonMain/kotlin/soil/serialization/bundle/Bundler.kt
+++ b/soil-serialization-bundle/src/commonMain/kotlin/soil/serialization/bundle/Bundler.kt
@@ -1,0 +1,79 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.serialization.bundle
+
+import androidx.core.bundle.Bundle
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialFormat
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.serializer
+
+/**
+ * Implements [encoding][encodeToBundle] and [decoding][decodeFromBundle] classes to/from [androidx.core.bundle.Bundle](https://github.com/JetBrains/compose-multiplatform-core/tree/jb-main/core/core-bundle).
+ *
+ * Usage:
+ *
+ * ```
+ * @Serializable
+ * class Data(val property1: String)
+ *
+ * @Serializable
+ * class DataHolder(val data: Data, val property2: String)
+ *
+ * val bundle = Bundler.encodeToBundle(DataHolder(Data("value1"), "value2"))
+ *
+ * val dataHolder = Bundler.decodeFromBundle<DataHolder>(bundle)
+ * ```
+ *
+ * @param serializersModule A [SerializersModule] which should contain registered serializers
+ * for [kotlinx.serialization.Contextual] and [kotlinx.serialization.Polymorphic] serialization, if you have any.
+ */
+open class Bundler(
+    override val serializersModule: SerializersModule
+) : SerialFormat {
+
+    /**
+     * Encodes the given [value] to a [Bundle] using the provided [serializer] of type [T].
+     *
+     * @param T The type of the value to encode
+     * @param value The value to encode
+     * @param serializer The serializer to use
+     */
+    @ExperimentalSerializationApi
+    inline fun <reified T> encodeToBundle(
+        value: T,
+        serializer: SerializationStrategy<T> = serializer()
+    ): Bundle {
+        val result = Bundle()
+        val encoder = BundleEncoder(this, result)
+        encoder.encodeSerializableValue(serializer, value)
+        return result
+    }
+
+    /**
+     * Decodes a value from the given [bundle] using the provided [deserializer] of type [T].
+     *
+     * @param T The type of the value to decode
+     * @param bundle The bundle to decode from
+     * @param deserializer The deserializer to use
+     */
+    @ExperimentalSerializationApi
+    inline fun <reified T> decodeFromBundle(
+        bundle: Bundle,
+        deserializer: DeserializationStrategy<T> = serializer()
+    ): T {
+        val decoder = BundleDecoder(this, bundle)
+        return decoder.decodeSerializableValue(deserializer)
+    }
+
+    /**
+     * The default instance of Bundler
+     */
+    companion object : Bundler(serializersModule = EmptySerializersModule()) {
+        internal const val COLLECTION_SIZE_KEY = "\$size"
+    }
+}

--- a/soil-serialization-bundle/src/commonTest/kotlin/soil/serialization/bundle/BundleDecoderTest.kt
+++ b/soil-serialization-bundle/src/commonTest/kotlin/soil/serialization/bundle/BundleDecoderTest.kt
@@ -1,0 +1,141 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.serialization.bundle
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalSerializationApi::class)
+class BundleDecoderTest : UnitTest() {
+    @Test
+    fun decodeFromBundle_primitiveTypes() {
+        assertEquals(true, Bundler.decodeFromBundle(Bundler.encodeToBundle(true)))
+        assertEquals(8.toByte(), Bundler.decodeFromBundle(Bundler.encodeToBundle(8.toByte())))
+        assertEquals('a', Bundler.decodeFromBundle(Bundler.encodeToBundle('a')))
+        assertEquals(3.14, Bundler.decodeFromBundle(Bundler.encodeToBundle(3.14)))
+        assertEquals(3.14f, Bundler.decodeFromBundle(Bundler.encodeToBundle(3.14f)))
+        assertEquals(30, Bundler.decodeFromBundle(Bundler.encodeToBundle(30)))
+        assertEquals(30L, Bundler.decodeFromBundle(Bundler.encodeToBundle(30L)))
+        assertEquals(30.toShort(), Bundler.decodeFromBundle(Bundler.encodeToBundle(30.toShort())))
+        assertEquals("hello", Bundler.decodeFromBundle(Bundler.encodeToBundle("hello")))
+        assertEquals(EnumTestData.Bar, Bundler.decodeFromBundle(Bundler.encodeToBundle(EnumTestData.Bar)))
+    }
+
+    @Test
+    fun decodeFromBundle_collectionList() {
+        val expected = listOf(30, 20, 10)
+        val actual = Bundler.decodeFromBundle<List<Int>>(Bundler.encodeToBundle(expected))
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun decodeFromBundle_collectionMap() {
+        val expected = mapOf("k1" to 30, "k2" to 20)
+        val actual = Bundler.decodeFromBundle<Map<String, Int>>(Bundler.encodeToBundle(expected))
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun decodeFromBundle_classType() {
+        val expected = ObjectTestData("John", 30)
+        val actual = Bundler.decodeFromBundle<ObjectTestData>(Bundler.encodeToBundle(expected))
+        assertEquals(expected.name, actual.name)
+        assertEquals(expected.age, actual.age)
+    }
+
+    @Test
+    fun decodeFromBundle_optionalType() {
+        val expected = ObjectTestData(null, 30)
+        val actual = Bundler.decodeFromBundle<ObjectTestData>(Bundler.encodeToBundle(expected))
+        assertEquals(expected.name, actual.name)
+        assertEquals(expected.age, actual.age)
+    }
+
+    @Test
+    fun decodeFromBundle_sealedType() {
+        val expected = SealedTestData.Bar(30)
+        val actual = Bundler.decodeFromBundle<SealedTestData>(Bundler.encodeToBundle<SealedTestData>(expected))
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun decodeFromBundle_polymorphicType() {
+        val expected = PolymorphicBarData(30)
+        val bundler = Bundler(serializersModule = SerializersModule {
+            polymorphic(PolymorphicTestData::class) {
+                subclass(PolymorphicFooData::class)
+                subclass(PolymorphicBarData::class)
+            }
+        })
+        val polymorphicSerializer = PolymorphicSerializer(PolymorphicTestData::class)
+        val actual = bundler.decodeFromBundle<PolymorphicTestData>(
+            bundler.encodeToBundle(expected, polymorphicSerializer),
+            polymorphicSerializer
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun decodeFromBundle_testData1() {
+        val expected = TestData1(ObjectTestData("John", 30), "Tokyo")
+        val actual = Bundler.decodeFromBundle<TestData1>(Bundler.encodeToBundle(expected))
+        assertEquals(expected.data, actual.data)
+        assertEquals(expected.address, actual.address)
+    }
+
+    @Test
+    fun decodeFromBundle_testData2() {
+        val expected = TestData2(EnumTestData.Foo, "Tokyo")
+        val actual = Bundler.decodeFromBundle<TestData2>(Bundler.encodeToBundle(expected))
+        assertEquals(expected.data, actual.data)
+        assertEquals(expected.address, actual.address)
+    }
+
+    @Test
+    fun decodeFromBundle_testData3() {
+        val expected = TestData3(listOf(ObjectTestData("John", 30), ObjectTestData("Jane", 20)), "Tokyo")
+        val actual = Bundler.decodeFromBundle<TestData3>(Bundler.encodeToBundle(expected))
+        assertEquals(expected.data, actual.data)
+        assertEquals(expected.address, actual.address)
+    }
+
+    @Test
+    fun decodeFromBundle_testData4() {
+        val expected = TestData4(SealedTestData.Foo("John"), "Tokyo")
+        val actual = Bundler.decodeFromBundle<TestData4>(Bundler.encodeToBundle(expected))
+        assertEquals(expected.data, actual.data)
+        assertEquals(expected.address, actual.address)
+    }
+
+    @Test
+    fun decodeFromBundle_testData5() {
+        val expected = TestData5(PolymorphicBarData(30), "Tokyo")
+        val bundler = Bundler(serializersModule = SerializersModule {
+            polymorphic(PolymorphicTestData::class) {
+                subclass(PolymorphicFooData::class)
+                subclass(PolymorphicBarData::class)
+            }
+        })
+        val actual = bundler.decodeFromBundle<TestData5>(bundler.encodeToBundle(expected))
+        assertEquals(expected.data, actual.data)
+        assertEquals(expected.address, actual.address)
+    }
+
+    @Test
+    fun decodeFromBundle_testData6() {
+        val expected = TestData6(ContextualTestData(2024, 6, 23), "Tokyo")
+        val bundler = Bundler(serializersModule = SerializersModule {
+            contextual(ContextualTestData::class, ContextualTestDataAsStringSerializer)
+        })
+        val actual = bundler.decodeFromBundle<TestData6>(bundler.encodeToBundle(expected))
+        assertEquals(expected.data, actual.data)
+        assertEquals(expected.address, actual.address)
+    }
+}

--- a/soil-serialization-bundle/src/commonTest/kotlin/soil/serialization/bundle/BundleEncoderTest.kt
+++ b/soil-serialization-bundle/src/commonTest/kotlin/soil/serialization/bundle/BundleEncoderTest.kt
@@ -1,0 +1,174 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.serialization.bundle
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalSerializationApi::class)
+class BundleEncoderTest : UnitTest() {
+    @Test
+    fun encodeToBundle_primitiveTypes() {
+        assertEquals(true, Bundler.encodeToBundle(true).getBoolean(null))
+        assertEquals(8.toByte(), Bundler.encodeToBundle(8.toByte()).getByte(null))
+        assertEquals('a', Bundler.encodeToBundle('a').getChar(null))
+        assertEquals(3.14, Bundler.encodeToBundle(3.14).getDouble(null))
+        assertEquals(3.14f, Bundler.encodeToBundle(3.14f).getFloat(null))
+        assertEquals(30, Bundler.encodeToBundle(30).getInt(null))
+        assertEquals(30L, Bundler.encodeToBundle(30L).getLong(null))
+        assertEquals(30.toShort(), Bundler.encodeToBundle(30.toShort()).getShort(null))
+        assertEquals("hello", Bundler.encodeToBundle("hello").getString(null))
+        assertEquals(EnumTestData.Bar.ordinal, Bundler.encodeToBundle(EnumTestData.Bar).getInt(null))
+    }
+
+    @Test
+    fun encodeToBundle_collectionList() {
+        val list = listOf(30, 20, 10)
+        val actual = Bundler.encodeToBundle(list)
+        assertEquals(3, actual.getInt(Bundler.COLLECTION_SIZE_KEY))
+        assertEquals(30, actual.getInt("0"))
+        assertEquals(20, actual.getInt("1"))
+        assertEquals(10, actual.getInt("2"))
+    }
+
+    @Test
+    fun encodeToBundle_collectionMap() {
+        val map = mapOf("k1" to 30, "k2" to 20)
+        val actual = Bundler.encodeToBundle(map)
+        assertEquals(2, actual.getInt(Bundler.COLLECTION_SIZE_KEY))
+        assertEquals("k1", actual.getString("0"))
+        assertEquals(30, actual.getInt("1"))
+        assertEquals("k2", actual.getString("2"))
+        assertEquals(20, actual.getInt("3"))
+    }
+
+    @Test
+    fun encodeToBundle_classType() {
+        val obj = ObjectTestData("John", 30)
+        val actual = Bundler.encodeToBundle(obj)
+        assertEquals("John", actual.getString("name"))
+        assertEquals(30, actual.getInt("age"))
+    }
+
+    @Test
+    fun encodeToBundle_optionalType() {
+        val obj = ObjectTestData(null, 30)
+        val actual = Bundler.encodeToBundle(obj)
+        assertEquals(false, actual.containsKey("name"))
+        assertEquals(30, actual.getInt("age"))
+    }
+
+    @Test
+    fun encodeToBundle_sealedType() {
+        val obj = SealedTestData.Bar(30)
+        val actual = Bundler.encodeToBundle<SealedTestData>(obj)
+        assertEquals(true, actual.containsKey("type"))
+        assertEquals(true, actual.containsKey("value"))
+        val nested = actual.getBundle("value")!!
+        assertEquals(30, nested.getInt("age"))
+    }
+
+    @Test
+    fun encodeToBundle_polymorphicType() {
+        val obj = PolymorphicBarData(30)
+        val bundler = Bundler(serializersModule = SerializersModule {
+            polymorphic(PolymorphicTestData::class) {
+                subclass(PolymorphicFooData::class)
+                subclass(PolymorphicBarData::class)
+            }
+        })
+        val polymorphicSerializer = PolymorphicSerializer(PolymorphicTestData::class)
+        val actual = bundler.encodeToBundle(obj, polymorphicSerializer)
+        assertEquals(true, actual.containsKey("type"))
+        assertEquals(true, actual.containsKey("value"))
+        val nested = actual.getBundle("value")!!
+        assertEquals(30, nested.getInt("age"))
+    }
+
+    @Test
+    fun encodeToBundle_testData1() {
+        val data = TestData1(ObjectTestData("John", 30), "Tokyo")
+        val actual = Bundler.encodeToBundle(data)
+        assertEquals(true, actual.containsKey("data"))
+        val nested = actual.getBundle("data")!!
+        assertEquals("John", nested.getString("name"))
+        assertEquals(30, nested.getInt("age"))
+        assertEquals("Tokyo", actual.getString("address"))
+    }
+
+    @Test
+    fun encodeToBundle_testData2() {
+        val data = TestData2(EnumTestData.Bar, "Tokyo")
+        val actual = Bundler.encodeToBundle(data)
+        assertEquals(EnumTestData.Bar.ordinal, actual.getInt("data"))
+        assertEquals("Tokyo", actual.getString("address"))
+    }
+
+    @Test
+    fun encodeToBundle_testData3() {
+        val data = TestData3(listOf(ObjectTestData("John", 30), ObjectTestData("Jane", 20)), "Tokyo")
+        val actual = Bundler.encodeToBundle(data)
+        assertEquals(true, actual.containsKey("data"))
+        val nested = actual.getBundle("data")!!
+        assertEquals(2, nested.getInt(Bundler.COLLECTION_SIZE_KEY))
+        assertEquals(true, nested.containsKey("0"))
+        val nestedData1 = nested.getBundle("0")!!
+        assertEquals("John", nestedData1.getString("name"))
+        assertEquals(30, nestedData1.getInt("age"))
+        assertEquals(true, nested.containsKey("1"))
+        val nestedData2 = nested.getBundle("1")!!
+        assertEquals("Jane", nestedData2.getString("name"))
+        assertEquals(20, nestedData2.getInt("age"))
+        assertEquals("Tokyo", actual.getString("address"))
+    }
+
+    @Test
+    fun encodeToBundle_testData4() {
+        val data = TestData4(SealedTestData.Bar(30), "Tokyo")
+        val actual = Bundler.encodeToBundle(data)
+        assertEquals(true, actual.containsKey("data"))
+        val nested = actual.getBundle("data")!!
+        assertEquals(true, nested.containsKey("type"))
+        assertEquals(true, nested.containsKey("value"))
+        val nestedValue = nested.getBundle("value")!!
+        assertEquals(30, nestedValue.getInt("age"))
+        assertEquals("Tokyo", actual.getString("address"))
+    }
+
+    @Test
+    fun encodeToBundle_testData5() {
+        val data = TestData5(PolymorphicBarData(30), "Tokyo")
+        val bundler = Bundler(serializersModule = SerializersModule {
+            polymorphic(PolymorphicTestData::class) {
+                subclass(PolymorphicFooData::class)
+                subclass(PolymorphicBarData::class)
+            }
+        })
+        val actual = bundler.encodeToBundle(data)
+        assertEquals(true, actual.containsKey("data"))
+        val nested = actual.getBundle("data")!!
+        assertEquals(true, nested.containsKey("type"))
+        assertEquals(true, nested.containsKey("value"))
+        val nestedValue = nested.getBundle("value")!!
+        assertEquals(30, nestedValue.getInt("age"))
+        assertEquals("Tokyo", actual.getString("address"))
+    }
+
+    @Test
+    fun encodeToBundle_testData6() {
+        val data = TestData6(ContextualTestData(2024, 6, 23), "Tokyo")
+        val bundler = Bundler(serializersModule = SerializersModule {
+            contextual(ContextualTestData::class, ContextualTestDataAsStringSerializer)
+        })
+        val actual = bundler.encodeToBundle(data)
+        assertEquals("2024-6-23", actual.getString("data"))
+        assertEquals("Tokyo", actual.getString("address"))
+    }
+}

--- a/soil-serialization-bundle/src/commonTest/kotlin/soil/serialization/bundle/BundleTestData.kt
+++ b/soil-serialization-bundle/src/commonTest/kotlin/soil/serialization/bundle/BundleTestData.kt
@@ -1,0 +1,97 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.serialization.bundle
+
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Polymorphic
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable
+data class TestData1(
+    val data: ObjectTestData,
+    val address: String
+)
+
+@Serializable
+data class TestData2(
+    val data: EnumTestData,
+    val address: String
+)
+
+@Serializable
+data class TestData3(
+    val data: List<ObjectTestData>,
+    val address: String
+)
+
+@Serializable
+data class TestData4(
+    val data: SealedTestData,
+    val address: String
+)
+
+
+@Serializable
+data class TestData5(
+    @Polymorphic val data: PolymorphicTestData,
+    val address: String
+)
+
+@Serializable
+data class TestData6(
+    @Contextual val data: ContextualTestData,
+    val address: String
+)
+
+
+@Serializable
+data class ObjectTestData(
+    val name: String?,
+    val age: Int
+)
+
+enum class EnumTestData {
+    Foo, Bar
+}
+
+@Serializable
+sealed class SealedTestData {
+    @Serializable
+    data class Foo(val name: String) : SealedTestData()
+
+    @Serializable
+    data class Bar(val age: Int) : SealedTestData()
+}
+
+abstract class PolymorphicTestData
+
+@Serializable
+data class PolymorphicFooData(val name: String) : PolymorphicTestData()
+
+@Serializable
+data class PolymorphicBarData(val age: Int) : PolymorphicTestData()
+
+data class ContextualTestData(
+    val year: Int,
+    val month: Int,
+    val day: Int
+)
+
+object ContextualTestDataAsStringSerializer : KSerializer<ContextualTestData> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ContextualTestData", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: ContextualTestData) {
+        encoder.encodeString("${value.year}-${value.month}-${value.day}")
+    }
+
+    override fun deserialize(decoder: Decoder): ContextualTestData {
+        val parts = decoder.decodeString().split("-")
+        return ContextualTestData(year = parts[0].toInt(), month = parts[1].toInt(), day = parts[2].toInt())
+    }
+}


### PR DESCRIPTION
Since Kotlin 2.0, implementing [Parcelable](https://developer.android.com/reference/android/os/Parcelable) (with [Parcelize](https://developer.android.com/kotlin/parcelize)) for Kotlin Multiplatform has become more challenging. Currently, it is necessary to define `compilerOptions` and add a custom Parcelize wrapper to the parameters to use it.

- https://issuetracker.google.com/issues/315775835#comment16
- https://youtrack.jetbrains.com/issue/KT-58892/K2-Parcelize-doesnt-work-in-common-code-when-expect-annotation-is-actualized-with-typealias-to-Parcelize


In Soil, we have implemented functionalities related to Parcelable in the form and space library. Therefore, we decided to experimentally provide a library that converts to [androidx.core.bundle.Bundle](https://github.com/JetBrains/compose-multiplatform-core/tree/jb-main/core/core-bundle) using the mechanism of [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization).

Instead of implementing Parcelable, we plan to incorporate an alternative API using kotlin.serialization in the form and space library.
