### PR TITLE
Add testing module as an internal project module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ androidx-activity = "1.8.2"
 androidx-annotation = "1.7.1"
 androidx-core = "1.12.0"
 androidx-lifecycle = "2.7.0"
+androidx-test = "1.5.0"
+androidx-test-ext-junit = "1.1.5"
 compose = "1.6.7"
 compose-multiplatform = "1.6.10"
 dokka = "1.9.20"
@@ -13,19 +15,24 @@ jbx-core-bundle = "1.0.0"
 jbx-lifecycle = "2.8.0"
 jbx-navigation = "2.7.0-alpha07"
 jbx-savedstate = "1.2.0"
+junit = "4.13.2"
 kotlin = "1.9.23"
 kotlinx-coroutines = "1.8.0"
 kotlinx-serialization = "1.6.3"
 ktor = "3.0.0-wasm2"
 maven-publish = "0.28.0"
+robolectric = "4.12.2"
 spotless = "6.25.0"
 voyager = "1.1.0-alpha04"
+
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
 compose-ui-test-junit4-android = { module = "androidx.compose.ui:ui-test-junit4-android", version.ref = "compose" }
 compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
@@ -35,7 +42,9 @@ jbx-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:l
 jbx-lifecycle-viewmodel-savedstate = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "jbx-lifecycle" }
 jbx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "jbx-navigation" }
 jbx-savedstate = { module = "org.jetbrains.androidx.savedstate:savedstate", version.ref = "jbx-savedstate" }
+junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
@@ -46,6 +55,7 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
 voyager-screenModel = { module = "cafe.adriel.voyager:voyager-screenmodel", version.ref = "voyager" }
 

--- a/internal/testing/build.gradle.kts
+++ b/internal/testing/build.gradle.kts
@@ -1,0 +1,101 @@
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.multiplatform)
+}
+
+val buildTarget = the<BuildTargetExtension>()
+
+kotlin {
+    applyDefaultHierarchyTemplate()
+
+    jvm()
+    androidTarget {
+        compilations.all {
+            kotlinOptions {
+                jvmTarget = buildTarget.javaVersion.get().toString()
+            }
+        }
+        publishLibraryVariants("release")
+    }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+    }
+
+    sourceSets {
+        all {
+            languageSettings {
+                @OptIn(ExperimentalKotlinGradlePluginApi::class)
+                compilerOptions {
+                    // https://youtrack.jetbrains.com/issue/KT-61573
+                    freeCompilerArgs.add("-Xexpect-actual-classes")
+                }
+            }
+        }
+
+        commonMain.dependencies {
+            implementation(libs.kotlin.test)
+        }
+
+        androidMain.dependencies {
+            implementation(libs.junit)
+            implementation(libs.robolectric)
+            implementation(libs.androidx.test.core)
+            implementation(libs.androidx.test.ext.junit)
+        }
+
+        val skikoMain by creating {
+            dependsOn(commonMain.get())
+        }
+
+        iosMain {
+            dependsOn(skikoMain)
+        }
+
+        jvmMain {
+            dependsOn(skikoMain)
+        }
+
+        named("wasmJsMain") {
+            dependsOn(skikoMain)
+        }
+    }
+}
+
+android {
+    namespace = "soil.testing"
+    compileSdk = buildTarget.androidCompileSdk.get()
+
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    sourceSets["main"].res.srcDirs("src/androidMain/res")
+    sourceSets["main"].resources.srcDirs("src/commonMain/resources")
+
+    defaultConfig {
+        minSdk = buildTarget.androidMinSdk.get()
+    }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+        }
+    }
+    compileOptions {
+        sourceCompatibility = buildTarget.javaVersion.get()
+        targetCompatibility = buildTarget.javaVersion.get()
+    }
+    dependencies {
+        debugImplementation(libs.compose.ui.tooling)
+    }
+}

--- a/internal/testing/src/androidMain/kotlin/soil/testing/UnitTest.kt
+++ b/internal/testing/src/androidMain/kotlin/soil/testing/UnitTest.kt
@@ -1,0 +1,9 @@
+package soil.testing
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest= Config.NONE)
+actual abstract class UnitTest

--- a/internal/testing/src/commonMain/kotlin/soil/testing/UnitTest.kt
+++ b/internal/testing/src/commonMain/kotlin/soil/testing/UnitTest.kt
@@ -1,0 +1,7 @@
+package soil.testing
+
+/**
+ * Using android robolectric tests in KMP.
+ * ref. https://github.com/robolectric/robolectric/issues/7942
+ */
+expect abstract class UnitTest()

--- a/internal/testing/src/skikoMain/kotlin/soil/testing/UnitTest.kt
+++ b/internal/testing/src/skikoMain/kotlin/soil/testing/UnitTest.kt
@@ -1,0 +1,3 @@
+package soil.testing
+
+actual abstract class UnitTest

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,5 +45,6 @@ include(
 // Private modules
 include(
     ":sample:composeApp",
-    ":internal:playground"
+    ":internal:playground",
+    ":internal:testing"
 )

--- a/soil-query-compose/build.gradle.kts
+++ b/soil-query-compose/build.gradle.kts
@@ -58,6 +58,7 @@ kotlin {
             implementation(compose.runtime)
             implementation(compose.ui)
             implementation(compose.material)
+            implementation(projects.internal.testing)
         }
 
         jvmTest.dependencies {
@@ -91,6 +92,10 @@ android {
     compileOptions {
         sourceCompatibility = buildTarget.javaVersion.get()
         targetCompatibility = buildTarget.javaVersion.get()
+    }
+    @Suppress("UnstableApiUsage")
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
     }
     dependencies {
         debugImplementation(libs.compose.ui.tooling)

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/ExampleTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/ExampleTest.kt
@@ -16,10 +16,11 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import soil.testing.UnitTest
 import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
-class ExampleTest {
+class ExampleTest: UnitTest() {
 
     @Test
     fun myTest() = runComposeUiTest {

--- a/soil-query-core/build.gradle.kts
+++ b/soil-query-core/build.gradle.kts
@@ -90,6 +90,10 @@ android {
         sourceCompatibility = buildTarget.javaVersion.get()
         targetCompatibility = buildTarget.javaVersion.get()
     }
+    @Suppress("UnstableApiUsage")
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
     dependencies {
         debugImplementation(libs.compose.ui.tooling)
     }

--- a/soil-query-core/build.gradle.kts
+++ b/soil-query-core/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
+            implementation(projects.internal.testing)
         }
 
         androidMain.dependencies {

--- a/soil-query-core/src/commonTest/kotlin/soil/query/ExampleTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/ExampleTest.kt
@@ -3,10 +3,11 @@
 
 package soil.query
 
+import soil.testing.UnitTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
-class ExampleTest {
+class ExampleTest : UnitTest() {
 
     @Test
     fun sample() {


### PR DESCRIPTION
Use [Robolectric](https://robolectric.org/) for Android unit testing.
We added it to the project as a testing module so that we can write tests directly in the commonTest of each Kotlin Multiplatform module. 

If you write a test by inheriting the UnitTest class as follows, RobolectricTestRunner will be used to run tests for Android.

```
import soil.testing.UnitTest

class FooTest extends UnitTest() {
  @Test
  fun test() { .. }
}
```
