### PR TITLE
Integrate with serialization-bundle

### DIFF
--- a/soil-form/build.gradle.kts
+++ b/soil-form/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
             implementation(compose.ui)
             implementation(compose.foundation)
             implementation(libs.kotlinx.coroutines.core)
+            api(projects.soilSerializationBundle)
         }
 
         val skikoMain by creating {

--- a/soil-serialization-bundle/build.gradle.kts
+++ b/soil-serialization-bundle/build.gradle.kts
@@ -34,8 +34,8 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.kotlinx.serialization.core)
-            implementation(libs.jbx.core.bundle)
+            api(libs.kotlinx.serialization.core)
+            api(libs.jbx.core.bundle)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/soil-space/build.gradle.kts
+++ b/soil-space/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
             implementation(libs.jbx.lifecycle.viewmodel.savedstate)
             api(libs.jbx.savedstate)
             api(libs.jbx.core.bundle)
+            api(projects.soilSerializationBundle)
         }
 
         androidMain.dependencies {


### PR DESCRIPTION
The form and space modules now have an optional API that allows you to use kotlin.serialization instead of implementing Parcelable.

refs: #35