### PR TITLE
Add onError function to Query/Mutation Options

### DIFF
--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommand.kt
@@ -85,6 +85,7 @@ suspend inline fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.dispatchFetchC
         .run { key.onRecoverData()?.let(::recoverCatching) ?: this }
         .onSuccess(::dispatchFetchSuccess)
         .onFailure(::dispatchFetchFailure)
+        .onFailure { options.onError?.invoke(it, state, key.id) }
 }
 
 /**
@@ -104,4 +105,5 @@ suspend inline fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.dispatchRevali
         .run { key.onRecoverData()?.let(::recoverCatching) ?: this }
         .onSuccess(::dispatchFetchSuccess)
         .onFailure(::dispatchFetchFailure)
+        .onFailure { options.onError?.invoke(it, state, key.id) }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationCommand.kt
@@ -30,7 +30,7 @@ interface MutationCommand<T> {
     interface Context<T> {
         val receiver: MutationReceiver
         val options: MutationOptions
-        val state: MutationState<T>
+        val state: MutationModel<T>
         val dispatch: MutationDispatch<T>
         val notifier: MutationNotifier
     }
@@ -90,6 +90,7 @@ suspend inline fun <T, S> MutationCommand.Context<T>.dispatchMutateResult(
             key.onQueryUpdate(variable, data)?.let(notifier::onMutateSuccess)
         }
         .onFailure { dispatch(MutationAction.MutateFailure(it)) }
+        .onFailure { options.onError?.invoke(it, state, key.id) }
 }
 
 internal fun <T> MutationCommand.Context<T>.onRetryCallback(

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationOptions.kt
@@ -7,6 +7,7 @@ import soil.query.internal.ActorOptions
 import soil.query.internal.LoggerFn
 import soil.query.internal.LoggingOptions
 import soil.query.internal.RetryOptions
+import soil.query.internal.UniqueId
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -26,6 +27,11 @@ data class MutationOptions(
      * Requires revision match as a precondition for executing mutate.
      */
     val isStrictMode: Boolean = false,
+
+    /**
+     * This callback function will be called if some mutation encounters an error.
+     */
+    val onError: ((Throwable, MutationModel<*>, UniqueId) -> Unit)? = null,
 
     // ----- ActorOptions ----- //
     override val keepAliveTime: Duration = 5.seconds,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommand.kt
@@ -32,7 +32,7 @@ interface QueryCommand<T> {
     interface Context<T> {
         val receiver: QueryReceiver
         val options: QueryOptions
-        val state: QueryState<T>
+        val state: QueryModel<T>
         val dispatch: QueryDispatch<T>
     }
 }
@@ -103,6 +103,7 @@ suspend inline fun <T> QueryCommand.Context<T>.dispatchFetchResult(key: QueryKey
         .run { key.onRecoverData()?.let(::recoverCatching) ?: this }
         .onSuccess(::dispatchFetchSuccess)
         .onFailure(::dispatchFetchFailure)
+        .onFailure { options.onError?.invoke(it, state, key.id) }
 }
 
 /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryOptions.kt
@@ -8,6 +8,7 @@ import soil.query.internal.LoggerFn
 import soil.query.internal.LoggingOptions
 import soil.query.internal.RetryOptions
 import soil.query.internal.Retryable
+import soil.query.internal.UniqueId
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -59,6 +60,11 @@ data class QueryOptions(
      * This setting is only effective when [soil.query.internal.WindowVisibility] is available.
      */
     val revalidateOnFocus: Boolean = true,
+
+    /**
+     * This callback function will be called if some query encounters an error.
+     */
+    val onError: ((Throwable, QueryModel<*>, UniqueId) -> Unit)? = null,
 
     // ----- ActorOptions ----- //
     override val keepAliveTime: Duration = 5.seconds,


### PR DESCRIPTION
The onError callback function is useful for error logging reporting and feedback you commonly want to handle on the client.

```
SwrCache(
    policy = SwrCachePolicy(
        ..
        queryOptions = QueryOptions(
            onError = { err, query, id -> 
                logger.error(err, "Query error: $query, id: $id")
            }
        ),
    )
)
```