### PR TITLE
Improve the results of synchronously executed Mutations.

### DIFF
--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationClient.kt
@@ -22,3 +22,4 @@ interface MutationClient {
 }
 
 typealias MutationOptionsOverride = (MutationOptions) -> MutationOptions
+typealias MutationCallback<T> = (Result<T>) -> Unit

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationCommand.kt
@@ -84,7 +84,8 @@ suspend fun <T, S> MutationCommand.Context<T>.mutate(
  */
 suspend inline fun <T, S> MutationCommand.Context<T>.dispatchMutateResult(
     key: MutationKey<T, S>,
-    variable: S
+    variable: S,
+    noinline callback: MutationCallback<T>?
 ) {
     mutate(key, variable)
         .onSuccess { data ->
@@ -98,6 +99,9 @@ suspend inline fun <T, S> MutationCommand.Context<T>.dispatchMutateResult(
         }
         .onFailure { dispatch(MutationAction.MutateFailure(it)) }
         .onFailure { options.onError?.invoke(it, state, key.id) }
+        .also {
+            callback?.invoke(it)
+        }
 }
 
 internal fun <T> MutationCommand.Context<T>.onRetryCallback(

--- a/soil-query-core/src/commonMain/kotlin/soil/query/internal/CompletableDeferredExt.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/internal/CompletableDeferredExt.kt
@@ -1,0 +1,14 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.internal
+
+import kotlinx.coroutines.CompletableDeferred
+
+internal fun <T> CompletableDeferred<T>.toResultCallback(): (Result<T>) -> Unit {
+    return { result ->
+        result
+            .onSuccess { complete(it) }
+            .onFailure { completeExceptionally(it) }
+    }
+}


### PR DESCRIPTION
When `isOneShot` in MutationOptions is set to false, multiple calls might not receive the intended results (there was a possibility of referencing the state of the next execution).

By using a callback, the execution results of the Mutation can be awaited on the calling side, ensuring that the results of the call are reliably referenced.