### PR TITLE
Improve the results of synchronously executed Queries.

### DIFF
--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommands.kt
@@ -4,6 +4,7 @@
 package soil.query
 
 import soil.query.internal.vvv
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Query command for [InfiniteQueryKey].
@@ -23,19 +24,21 @@ sealed class InfiniteQueryCommands<T, S> : QueryCommand<QueryChunks<T, S>> {
      */
     data class Connect<T, S>(
         val key: InfiniteQueryKey<T, S>,
-        val revision: String? = null
+        val revision: String? = null,
+        val callback: QueryCallback<QueryChunks<T, S>>? = null
     ) : InfiniteQueryCommands<T, S>() {
         override suspend fun handle(ctx: QueryCommand.Context<QueryChunks<T, S>>) {
             if (!ctx.shouldFetch(revision)) {
                 ctx.options.vvv(key.id) { "skip fetch(shouldFetch=false)" }
+                callback?.invoke(Result.failure(CancellationException("skip fetch")))
                 return
             }
             ctx.dispatch(QueryAction.Fetching())
             val chunks = ctx.state.data
             if (chunks.isNullOrEmpty() || ctx.state.isPlaceholderData) {
-                ctx.dispatchFetchChunksResult(key, key.initialParam())
+                ctx.dispatchFetchChunksResult(key, key.initialParam(), callback)
             } else {
-                ctx.dispatchRevalidateChunksResult(key, chunks)
+                ctx.dispatchRevalidateChunksResult(key, chunks, callback)
             }
         }
     }
@@ -50,19 +53,21 @@ sealed class InfiniteQueryCommands<T, S> : QueryCommand<QueryChunks<T, S>> {
      */
     data class Invalidate<T, S>(
         val key: InfiniteQueryKey<T, S>,
-        val revision: String
+        val revision: String,
+        val callback: QueryCallback<QueryChunks<T, S>>? = null
     ) : InfiniteQueryCommands<T, S>() {
         override suspend fun handle(ctx: QueryCommand.Context<QueryChunks<T, S>>) {
             if (ctx.state.revision != revision) {
                 ctx.options.vvv(key.id) { "skip fetch(revision is not matched)" }
+                callback?.invoke(Result.failure(CancellationException("skip fetch")))
                 return
             }
             ctx.dispatch(QueryAction.Fetching(isInvalidated = true))
             val chunks = ctx.state.data
             if (chunks.isNullOrEmpty() || ctx.state.isPlaceholderData) {
-                ctx.dispatchFetchChunksResult(key, key.initialParam())
+                ctx.dispatchFetchChunksResult(key, key.initialParam(), callback)
             } else {
-                ctx.dispatchRevalidateChunksResult(key, chunks)
+                ctx.dispatchRevalidateChunksResult(key, chunks, callback)
             }
         }
     }
@@ -75,17 +80,19 @@ sealed class InfiniteQueryCommands<T, S> : QueryCommand<QueryChunks<T, S>> {
      */
     data class LoadMore<T, S>(
         val key: InfiniteQueryKey<T, S>,
-        val param: S
+        val param: S,
+        val callback: QueryCallback<QueryChunks<T, S>>? = null
     ) : InfiniteQueryCommands<T, S>() {
         override suspend fun handle(ctx: QueryCommand.Context<QueryChunks<T, S>>) {
             val chunks = ctx.state.data
             if (param != key.loadMoreParam(chunks.orEmpty())) {
                 ctx.options.vvv(key.id) { "skip fetch(param is changed)" }
+                callback?.invoke(Result.failure(CancellationException("skip fetch")))
                 return
             }
 
             ctx.dispatch(QueryAction.Fetching())
-            ctx.dispatchFetchChunksResult(key, param)
+            ctx.dispatchFetchChunksResult(key, param, callback)
         }
     }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
@@ -3,6 +3,7 @@
 
 package soil.query
 
+import kotlinx.coroutines.Job
 import soil.query.internal.UniqueId
 
 /**
@@ -32,7 +33,7 @@ interface QueryClient {
      * Prefetch is executed within a [kotlinx.coroutines.CoroutineScope] associated with the instance of [QueryClient].
      * After data retrieval, subscription is automatically unsubscribed, hence the caching period depends on [QueryOptions].
      */
-    fun <T> prefetchQuery(key: QueryKey<T>)
+    fun <T> prefetchQuery(key: QueryKey<T>): Job
 
     /**
      * Prefetches the infinite query by the specified [InfiniteQueryKey].
@@ -41,7 +42,7 @@ interface QueryClient {
      * Prefetch is executed within a [kotlinx.coroutines.CoroutineScope] associated with the instance of [QueryClient].
      * After data retrieval, subscription is automatically unsubscribed, hence the caching period depends on [QueryOptions].
      */
-    fun <T, S> prefetchInfiniteQuery(key: InfiniteQueryKey<T, S>)
+    fun <T, S> prefetchInfiniteQuery(key: InfiniteQueryKey<T, S>): Job
 }
 
 /**
@@ -127,3 +128,4 @@ typealias QueryEffect = QueryMutableClient.() -> Unit
 
 typealias QueryRecoverData<T> = (error: Throwable) -> T
 typealias QueryOptionsOverride = (QueryOptions) -> QueryOptions
+typealias QueryCallback<T> = (Result<T>) -> Unit

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommand.kt
@@ -98,12 +98,16 @@ suspend fun <T> QueryCommand.Context<T>.fetch(
  *
  * @param key Instance of a class implementing [QueryKey].
  */
-suspend inline fun <T> QueryCommand.Context<T>.dispatchFetchResult(key: QueryKey<T>) {
+suspend inline fun <T> QueryCommand.Context<T>.dispatchFetchResult(
+    key: QueryKey<T>,
+    noinline callback: QueryCallback<T>? = null
+) {
     fetch(key)
         .run { key.onRecoverData()?.let(::recoverCatching) ?: this }
         .onSuccess(::dispatchFetchSuccess)
         .onFailure(::dispatchFetchFailure)
         .onFailure { options.onError?.invoke(it, state, key.id) }
+        .also { callback?.invoke(it) }
 }
 
 /**


### PR DESCRIPTION
The prefetch internal processing can now be handled synchronously.

By using a callback, the execution results of the Mutation can be awaited on the calling side, ensuring that the results of the call are reliably referenced.