### PR TITLE
Add a unified feedback mechanism to show error notifications.

### DIFF
--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommand.kt
@@ -86,7 +86,7 @@ suspend inline fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.dispatchFetchC
         .run { key.onRecoverData()?.let(::recoverCatching) ?: this }
         .onSuccess(::dispatchFetchSuccess)
         .onFailure(::dispatchFetchFailure)
-        .onFailure { options.onError?.invoke(it, state, key.id) }
+        .onFailure { reportQueryError(it, key.id) }
         .also { callback?.invoke(it) }
 }
 
@@ -108,6 +108,6 @@ suspend inline fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.dispatchRevali
         .run { key.onRecoverData()?.let(::recoverCatching) ?: this }
         .onSuccess(::dispatchFetchSuccess)
         .onFailure(::dispatchFetchFailure)
-        .onFailure { options.onError?.invoke(it, state, key.id) }
+        .onFailure { reportQueryError(it, key.id) }
         .also { callback?.invoke(it) }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationError.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationError.kt
@@ -1,0 +1,36 @@
+package soil.query
+
+import soil.query.core.ErrorRecord
+import soil.query.core.UniqueId
+
+/**
+ * Mutation error information that can be received via a back-channel.
+ */
+class MutationError @PublishedApi internal constructor(
+    override val exception: Throwable,
+    override val key: UniqueId,
+
+    /**
+     * The mutation state that caused the error.
+     */
+    val model: MutationModel<*>
+) : ErrorRecord {
+
+    override fun toString(): String {
+        return """
+            MutationError(
+                message=${exception.message},
+                key=$key,
+                model={
+                    dataUpdatedAt=${model.dataUpdatedAt},
+                    errorUpdatedAt=${model.errorUpdatedAt},
+                    status=${model.status},
+                    mutatedCount=${model.mutatedCount},
+                    submittedAt=${model.submittedAt},
+                }
+            )
+        """.trimIndent()
+    }
+}
+
+internal typealias MutationErrorRelay = (MutationError) -> Unit

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationError.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationError.kt
@@ -1,3 +1,6 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package soil.query
 
 import soil.query.core.ErrorRecord

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationOptions.kt
@@ -7,7 +7,6 @@ import soil.query.core.ActorOptions
 import soil.query.core.LoggerFn
 import soil.query.core.LoggingOptions
 import soil.query.core.RetryOptions
-import soil.query.core.UniqueId
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -31,7 +30,7 @@ interface MutationOptions : ActorOptions, LoggingOptions, RetryOptions {
     /**
      * This callback function will be called if some mutation encounters an error.
      */
-    val onError: ((Throwable, MutationModel<*>, UniqueId) -> Unit)?
+    val onError: ((MutationError) -> Unit)?
 
     /**
      * Whether the query side effect should be synchronous. If true, side effect will be executed synchronously.
@@ -41,7 +40,7 @@ interface MutationOptions : ActorOptions, LoggingOptions, RetryOptions {
     companion object Default : MutationOptions {
         override val isOneShot: Boolean = false
         override val isStrictMode: Boolean = false
-        override val onError: ((Throwable, MutationModel<*>, UniqueId) -> Unit)? = null
+        override val onError: ((MutationError) -> Unit)? = null
         override val shouldExecuteEffectSynchronously: Boolean = false
 
         // ----- ActorOptions ----- //
@@ -64,7 +63,7 @@ interface MutationOptions : ActorOptions, LoggingOptions, RetryOptions {
 fun MutationOptions(
     isOneShot: Boolean = MutationOptions.isOneShot,
     isStrictMode: Boolean = MutationOptions.isStrictMode,
-    onError: ((Throwable, MutationModel<*>, UniqueId) -> Unit)? = MutationOptions.onError,
+    onError: ((MutationError) -> Unit)? = MutationOptions.onError,
     shouldExecuteEffectSynchronously: Boolean = MutationOptions.shouldExecuteEffectSynchronously,
     keepAliveTime: Duration = MutationOptions.keepAliveTime,
     logger: LoggerFn? = MutationOptions.logger,
@@ -79,7 +78,7 @@ fun MutationOptions(
     return object : MutationOptions {
         override val isOneShot: Boolean = isOneShot
         override val isStrictMode: Boolean = isStrictMode
-        override val onError: ((Throwable, MutationModel<*>, UniqueId) -> Unit)? = onError
+        override val onError: ((MutationError) -> Unit)? = onError
         override val shouldExecuteEffectSynchronously: Boolean = shouldExecuteEffectSynchronously
         override val keepAliveTime: Duration = keepAliveTime
         override val logger: LoggerFn? = logger
@@ -96,7 +95,7 @@ fun MutationOptions(
 fun MutationOptions.copy(
     isOneShot: Boolean = this.isOneShot,
     isStrictMode: Boolean = this.isStrictMode,
-    onError: ((Throwable, MutationModel<*>, UniqueId) -> Unit)? = this.onError,
+    onError: ((MutationError) -> Unit)? = this.onError,
     shouldExecuteEffectSynchronously: Boolean = this.shouldExecuteEffectSynchronously,
     keepAliveTime: Duration = this.keepAliveTime,
     logger: LoggerFn? = this.logger,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryError.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryError.kt
@@ -1,0 +1,36 @@
+package soil.query
+
+import soil.query.core.ErrorRecord
+import soil.query.core.UniqueId
+
+/**
+ * Query error information that can be received via a back-channel.
+ */
+class QueryError @PublishedApi internal constructor(
+    override val exception: Throwable,
+    override val key: UniqueId,
+
+    /**
+     * The query model that caused the error.
+     */
+    val model: QueryModel<*>
+) : ErrorRecord {
+
+    override fun toString(): String {
+        return """
+            QueryError(
+                message=${exception.message},
+                key=$key,
+                model={
+                    dataUpdatedAt=${model.dataUpdatedAt},
+                    dataStaleAt=${model.dataStaleAt},
+                    errorUpdatedAt=${model.errorUpdatedAt},
+                    status=${model.status},
+                    isInvalidated=${model.isInvalidated},
+                }
+            )
+        """.trimIndent()
+    }
+}
+
+internal typealias QueryErrorRelay = (QueryError) -> Unit

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryError.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryError.kt
@@ -1,3 +1,6 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package soil.query
 
 import soil.query.core.ErrorRecord

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryOptions.kt
@@ -8,7 +8,6 @@ import soil.query.core.LoggerFn
 import soil.query.core.LoggingOptions
 import soil.query.core.RetryOptions
 import soil.query.core.Retryable
-import soil.query.core.UniqueId
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -64,7 +63,7 @@ interface QueryOptions : ActorOptions, LoggingOptions, RetryOptions {
     /**
      * This callback function will be called if some query encounters an error.
      */
-    val onError: ((Throwable, QueryModel<*>, UniqueId) -> Unit)?
+    val onError: ((QueryError) -> Unit)?
 
     companion object Default : QueryOptions {
         override val staleTime: Duration = Duration.ZERO
@@ -73,7 +72,7 @@ interface QueryOptions : ActorOptions, LoggingOptions, RetryOptions {
         override val pauseDurationAfter: ((Throwable) -> Duration?)? = null
         override val revalidateOnReconnect: Boolean = true
         override val revalidateOnFocus: Boolean = true
-        override val onError: ((Throwable, QueryModel<*>, UniqueId) -> Unit)? = null
+        override val onError: ((QueryError) -> Unit)? = null
 
         // ----- ActorOptions ----- //
         override val keepAliveTime: Duration = 5.seconds
@@ -101,7 +100,7 @@ fun QueryOptions(
     pauseDurationAfter: ((Throwable) -> Duration?)? = QueryOptions.pauseDurationAfter,
     revalidateOnReconnect: Boolean = QueryOptions.revalidateOnReconnect,
     revalidateOnFocus: Boolean = QueryOptions.revalidateOnFocus,
-    onError: ((Throwable, QueryModel<*>, UniqueId) -> Unit)? = QueryOptions.onError,
+    onError: ((QueryError) -> Unit)? = QueryOptions.onError,
     keepAliveTime: Duration = QueryOptions.keepAliveTime,
     logger: LoggerFn? = QueryOptions.logger,
     shouldRetry: (Throwable) -> Boolean = QueryOptions.shouldRetry,
@@ -119,7 +118,7 @@ fun QueryOptions(
         override val pauseDurationAfter: ((Throwable) -> Duration?)? = pauseDurationAfter
         override val revalidateOnReconnect: Boolean = revalidateOnReconnect
         override val revalidateOnFocus: Boolean = revalidateOnFocus
-        override val onError: ((Throwable, QueryModel<*>, UniqueId) -> Unit)? = onError
+        override val onError: ((QueryError) -> Unit)? = onError
         override val keepAliveTime: Duration = keepAliveTime
         override val logger: LoggerFn? = logger
         override val shouldRetry: (Throwable) -> Boolean = shouldRetry
@@ -139,7 +138,7 @@ fun QueryOptions.copy(
     pauseDurationAfter: ((Throwable) -> Duration?)? = this.pauseDurationAfter,
     revalidateOnReconnect: Boolean = this.revalidateOnReconnect,
     revalidateOnFocus: Boolean = this.revalidateOnFocus,
-    onError: ((Throwable, QueryModel<*>, UniqueId) -> Unit)? = this.onError,
+    onError: ((QueryError) -> Unit)? = this.onError,
     keepAliveTime: Duration = this.keepAliveTime,
     logger: LoggerFn? = this.logger,
     shouldRetry: (Throwable) -> Boolean = this.shouldRetry,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrClient.kt
@@ -4,6 +4,8 @@
 package soil.query
 
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import soil.query.core.ErrorRecord
 
 /**
  * An all-in-one [SwrClient] integrating [MutationClient] and [QueryClient] for library users.
@@ -11,6 +13,14 @@ import kotlinx.coroutines.Job
  * Swr stands for "stall-while-revalidate".
  */
 interface SwrClient : MutationClient, QueryClient {
+
+    /**
+     * Provides a unified feedback mechanism for all Query/Mutation errors that occur within the client.
+     *
+     * For example, by collecting errors on the foreground screen,
+     * you can display an error message on the screen using a Toast or similar when an error occurs.
+     */
+    val errorRelay: Flow<ErrorRecord>
 
     /**
      * Executes side effects for queries.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/ErrorRecord.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/ErrorRecord.kt
@@ -1,0 +1,19 @@
+package soil.query.core
+
+/**
+ * Error information that can be received via a back-channel
+ * such as [ErrorRelay] or `onError` options for Query/Mutation.
+ */
+interface ErrorRecord {
+    /**
+     * The details of the error.
+     */
+    val exception: Throwable
+
+    /**
+     * Key information that caused the error.
+     *
+     * NOTE: Defining an ID with a custom interface, such as metadata, can be helpful when receiving error information.
+     */
+    val key: UniqueId
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/ErrorRecord.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/ErrorRecord.kt
@@ -1,3 +1,6 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package soil.query.core
 
 /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/ErrorRelay.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/ErrorRelay.kt
@@ -1,0 +1,132 @@
+package soil.query.core
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * An interface for relaying error information via a back-channel
+ * when an error occurs during execution, regardless of Query/Mutation.
+ */
+interface ErrorRelay {
+
+    /**
+     * Sends error information to the relay destination.
+     *
+     * @param error The error information.
+     */
+    fun send(error: ErrorRecord)
+
+    /**
+     * Provides a Flow for receiving error information.
+     */
+    fun receiveAsFlow(): Flow<ErrorRecord>
+
+    companion object {
+
+        /**
+         * Creates an ErrorRelay that relays error information to one of the destinations.
+         *
+         * NOTE: Only the latest error information is retained while there are no destinations.
+         *
+         * @param scope CoroutineScope for the relay.
+         * @param policy The relay policy for error information.
+         */
+        @Suppress("SpellCheckingInspection")
+        fun newAnycast(
+            scope: CoroutineScope,
+            policy: ErrorRelayPolicy = ErrorRelayPolicy.None
+        ): ErrorRelay = ErrorRelayBuiltInAnycast(scope, policy)
+    }
+}
+
+/**
+ * A policy for relaying error information.
+ */
+interface ErrorRelayPolicy {
+
+    /**
+     * Determines whether to suppress error information.
+     */
+    val shouldSuppressError: (ErrorRecord) -> Boolean
+
+    /**
+     * Determines whether the error information is equal.
+     */
+    val areErrorsEqual: (ErrorRecord, ErrorRecord) -> Boolean
+
+    /**
+     * A companion object that provides a default implementation of the ErrorRelayPolicy.
+     */
+    companion object None : ErrorRelayPolicy {
+        override val shouldSuppressError: (ErrorRecord) -> Boolean = { false }
+        override val areErrorsEqual: (ErrorRecord, ErrorRecord) -> Boolean = { _, _ -> false }
+    }
+}
+
+private typealias ErrorToken = String
+
+@Suppress("SpellCheckingInspection")
+internal class ErrorRelayBuiltInAnycast(
+    private val scope: CoroutineScope,
+    private val policy: ErrorRelayPolicy
+) : ErrorRelay {
+
+    private val mutex = Mutex()
+    private val upstream = Channel<ErrorRecord>(
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    private val downstream = Channel<ErrorToken>(
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    private var current: Pair<ErrorToken, ErrorRecord>? = null
+
+    init {
+        scope.launch {
+            for (error in upstream) {
+                val next = mutex.withLock {
+                    val unfulfilled = current
+                    if (unfulfilled != null && policy.areErrorsEqual(unfulfilled.second, error)) {
+                        return@withLock null
+                    }
+                    val token = uuid()
+                    current = token to error
+                    token
+                }
+                if (next != null) {
+                    downstream.send(next)
+                }
+            }
+        }
+    }
+
+    override fun send(error: ErrorRecord) {
+        if (policy.shouldSuppressError(error)) {
+            return
+        }
+        scope.launch { upstream.send(error) }
+    }
+
+    override fun receiveAsFlow(): Flow<ErrorRecord> = flow {
+        for (next in downstream) {
+            consume(next)?.let { emit(it) }
+        }
+    }
+
+    private suspend fun consume(next: ErrorToken): ErrorRecord? {
+        return mutex.withLock {
+            current?.let { (token, info) ->
+                if (token == next) {
+                    current = null
+                    return@withLock info
+                }
+            }
+            null
+        }
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/ErrorRelay.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/ErrorRelay.kt
@@ -1,3 +1,6 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package soil.query.core
 
 import kotlinx.coroutines.CoroutineScope


### PR DESCRIPTION
Tanstack Query and SWR have implemented a unified error feedback mechanism for the UI.

- https://tkdodo.eu/blog/react-query-error-handling
- https://swr.vercel.app/docs/error-handling#global-error-report

Similarly, We have implemented a mechanism to notify errors via a back-channel, separate from the error information that can be determined from the state of Query or Mutation.