### PR TITLE
Change XxxRef class to interface for better testability.

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
@@ -15,6 +15,9 @@ import soil.query.QueryChunks
 import soil.query.QueryClient
 import soil.query.QueryState
 import soil.query.QueryStatus
+import soil.query.invalidate
+import soil.query.loadMore
+import soil.query.resume
 
 /**
  * Remember a [InfiniteQueryObject] and subscribes to the query state of [key].
@@ -34,7 +37,7 @@ fun <T, S> rememberInfiniteQuery(
     val query = remember(key) { client.getInfiniteQuery(key).also { it.launchIn(scope) } }
     val state by query.state.collectAsState()
     LaunchedEffect(query) {
-        query.start()
+        query.resume()
     }
     return remember(query, state) {
         state.toInfiniteObject(query = query, select = { it })
@@ -61,7 +64,7 @@ fun <T, S, U> rememberInfiniteQuery(
     val query = remember(key) { client.getInfiniteQuery(key).also { it.launchIn(scope) } }
     val state by query.state.collectAsState()
     LaunchedEffect(query) {
-        query.start()
+        query.resume()
     }
     return remember(query, state) {
         state.toInfiniteObject(query = query, select = select)

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
@@ -13,6 +13,9 @@ import soil.query.MutationKey
 import soil.query.MutationRef
 import soil.query.MutationState
 import soil.query.MutationStatus
+import soil.query.mutate
+import soil.query.mutateAsync
+import soil.query.reset
 
 /**
  * Remember a [MutationObject] and subscribes to the mutation state of [key].

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
@@ -14,6 +14,8 @@ import soil.query.QueryKey
 import soil.query.QueryRef
 import soil.query.QueryState
 import soil.query.QueryStatus
+import soil.query.invalidate
+import soil.query.resume
 
 /**
  * Remember a [QueryObject] and subscribes to the query state of [key].
@@ -32,7 +34,7 @@ fun <T> rememberQuery(
     val query = remember(key) { client.getQuery(key).also { it.launchIn(scope) } }
     val state by query.state.collectAsState()
     LaunchedEffect(query) {
-        query.start()
+        query.resume()
     }
     return remember(query, state) {
         state.toObject(query = query, select = { it })
@@ -59,7 +61,7 @@ fun <T, U> rememberQuery(
     val query = remember(key) { client.getQuery(key).also { it.launchIn(scope) } }
     val state by query.state.collectAsState()
     LaunchedEffect(query) {
-        query.start()
+        query.resume()
     }
     return remember(query, state) {
         state.toObject(query = query, select = select)

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryRef.kt
@@ -3,79 +3,47 @@
 
 package soil.query
 
-import kotlinx.coroutines.CompletableDeferred
-import soil.query.core.toResultCallback
-import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.flow.StateFlow
+import soil.query.core.Actor
 
 /**
- * A reference to an [Query] for [InfiniteQueryKey].
+ * A reference to an Query for [InfiniteQueryKey].
  *
  * @param T Type of data to retrieve.
  * @param S Type of parameter.
- * @property key Instance of a class implementing [InfiniteQueryKey].
- * @param query Transparently referenced [Query].
- * @constructor Creates an [InfiniteQueryRef].
  */
-class InfiniteQueryRef<T, S>(
-    val key: InfiniteQueryKey<T, S>,
-    val options: QueryOptions,
-    query: Query<QueryChunks<T, S>>
-) : Query<QueryChunks<T, S>> by query {
+interface InfiniteQueryRef<T, S> : Actor {
+
+    val key: InfiniteQueryKey<T, S>
+    val options: QueryOptions
+    val state: StateFlow<QueryState<QueryChunks<T, S>>>
 
     /**
-     * Starts the [Query].
-     *
-     * This function must be invoked when a new mount point (subscriber) is added.
+     * Sends a [QueryCommand] to the Actor.
      */
-    suspend fun start() {
-        command.send(InfiniteQueryCommands.Connect(key))
-        event.collect(::handleEvent)
-    }
+    suspend fun send(command: QueryCommand<QueryChunks<T, S>>)
+}
 
-    /**
-     * Prefetches the [Query].
-     */
-    suspend fun prefetch(): Boolean {
-        val deferred = CompletableDeferred<QueryChunks<T, S>>()
-        command.send(InfiniteQueryCommands.Connect(key, state.value.revision, deferred.toResultCallback()))
-        return try {
-            deferred.await()
-            true
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            false
-        }
-    }
+/**
+ * Invalidates the Query.
+ *
+ * Calling this function will invalidate the retrieved data of the Query,
+ * setting [QueryModel.isInvalidated] to `true` until revalidation is completed.
+ */
+suspend fun <T, S> InfiniteQueryRef<T, S>.invalidate() {
+    send(InfiniteQueryCommands.Invalidate(key, state.value.revision))
+}
 
-    /**
-     * Invalidates the [Query].
-     *
-     * Calling this function will invalidate the retrieved data of the [Query],
-     * setting [QueryModel.isInvalidated] to `true` until revalidation is completed.
-     */
-    suspend fun invalidate() {
-        command.send(InfiniteQueryCommands.Invalidate(key, state.value.revision))
-    }
+/**
+ * Resumes the Query.
+ */
+suspend fun <T, S> InfiniteQueryRef<T, S>.resume() {
+    send(InfiniteQueryCommands.Connect(key, state.value.revision))
+}
 
-    /**
-     * Resumes the [Query].
-     */
-    private suspend fun resume() {
-        command.send(InfiniteQueryCommands.Connect(key, state.value.revision))
-    }
-
-    /**
-     * Fetches data for the [InfiniteQueryKey] using the value of [param].
-     */
-    suspend fun loadMore(param: S) {
-        command.send(InfiniteQueryCommands.LoadMore(key, param))
-    }
-
-    private suspend fun handleEvent(e: QueryEvent) {
-        when (e) {
-            QueryEvent.Invalidate -> invalidate()
-            QueryEvent.Resume -> resume()
-        }
-    }
+/**
+ * Fetches data for the [InfiniteQueryKey] using the value of [param].
+ */
+suspend fun <T, S> InfiniteQueryRef<T, S>.loadMore(param: S) {
+    send(InfiniteQueryCommands.LoadMore(key, param))
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryRef.kt
@@ -3,71 +3,39 @@
 
 package soil.query
 
-import kotlinx.coroutines.CompletableDeferred
-import soil.query.core.toResultCallback
-import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.flow.StateFlow
+import soil.query.core.Actor
 
 /**
- * A reference to an [Query] for [QueryKey].
+ * A reference to an Query for [QueryKey].
  *
  * @param T Type of data to retrieve.
- * @property key Instance of a class implementing [QueryKey].
- * @param query Transparently referenced [Query].
- * @constructor Creates an [QueryRef]
  */
-class QueryRef<T>(
-    val key: QueryKey<T>,
-    val options: QueryOptions,
-    query: Query<T>
-) : Query<T> by query {
+interface QueryRef<T> : Actor {
+
+    val key: QueryKey<T>
+    val options: QueryOptions
+    val state: StateFlow<QueryState<T>>
 
     /**
-     * Starts the [Query].
-     *
-     * This function must be invoked when a new mount point (subscriber) is added.
+     * Sends a [QueryCommand] to the Actor.
      */
-    suspend fun start() {
-        command.send(QueryCommands.Connect(key))
-        event.collect(::handleEvent)
-    }
+    suspend fun send(command: QueryCommand<T>)
+}
 
-    /**
-     * Prefetches the [Query].
-     */
-    suspend fun prefetch(): Boolean {
-        val deferred = CompletableDeferred<T>()
-        command.send(QueryCommands.Connect(key, state.value.revision, deferred.toResultCallback()))
-        return try {
-            deferred.await()
-            true
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            false
-        }
-    }
+/**
+ * Invalidates the Query.
+ *
+ * Calling this function will invalidate the retrieved data of the Query,
+ * setting [QueryModel.isInvalidated] to `true` until revalidation is completed.
+ */
+suspend fun <T> QueryRef<T>.invalidate() {
+    send(QueryCommands.Invalidate(key, state.value.revision))
+}
 
-    /**
-     * Invalidates the [Query].
-     *
-     * Calling this function will invalidate the retrieved data of the [Query],
-     * setting [QueryModel.isInvalidated] to `true` until revalidation is completed.
-     */
-    suspend fun invalidate() {
-        command.send(QueryCommands.Invalidate(key, state.value.revision))
-    }
-
-    /**
-     * Resumes the [Query].
-     */
-    internal suspend fun resume() {
-        command.send(QueryCommands.Connect(key, state.value.revision))
-    }
-
-    private suspend fun handleEvent(e: QueryEvent) {
-        when (e) {
-            QueryEvent.Invalidate -> invalidate()
-            QueryEvent.Resume -> resume()
-        }
-    }
+/**
+ * Resumes the Query.
+ */
+suspend fun <T> QueryRef<T>.resume() {
+    send(QueryCommands.Connect(key, state.value.revision))
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCache.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCache.kt
@@ -212,7 +212,7 @@ class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutableClie
                 initialValue = MutationState<T>()
             ).also { mutationStore[id] = it }
         }
-        return MutationRef(
+        return SwrMutation(
             key = key,
             options = options,
             mutation = mutation
@@ -287,10 +287,10 @@ class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutableClie
                 initialValue = queryCache[key.id] as? QueryState<T> ?: newQueryState(key)
             ).also { queryStore[id] = it }
         }
-        return QueryRef(
+        return SwrQuery(
             key = key,
-            query = query,
-            options = options
+            options = options,
+            query = query
         )
     }
 
@@ -387,10 +387,10 @@ class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutableClie
                 initialValue = queryCache[id] as? QueryState<QueryChunks<T, S>> ?: newInfiniteQueryState(key)
             ).also { queryStore[id] = it }
         }
-        return InfiniteQueryRef(
+        return SwrInfiniteQuery(
             key = key,
-            query = query,
-            options = options
+            options = options,
+            query = query
         )
     }
 
@@ -621,8 +621,8 @@ class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutableClie
         override val command: SendChannel<MutationCommand<T>>
     ) : Mutation<T> {
 
-        override fun launchIn(scope: CoroutineScope) {
-            actor.launchIn(scope)
+        override fun launchIn(scope: CoroutineScope): Job {
+            return actor.launchIn(scope)
         }
 
         fun close() {
@@ -651,8 +651,8 @@ class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutableClie
         override val command: SendChannel<QueryCommand<T>>
     ) : Query<T> {
 
-        override fun launchIn(scope: CoroutineScope) {
-            actor.launchIn(scope)
+        override fun launchIn(scope: CoroutineScope): Job {
+            return actor.launchIn(scope)
         }
 
         fun close() {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrInfiniteQuery.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrInfiniteQuery.kt
@@ -1,0 +1,56 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import soil.query.core.toResultCallback
+
+internal class SwrInfiniteQuery<T, S>(
+    override val key: InfiniteQueryKey<T, S>,
+    override val options: QueryOptions,
+    private val query: Query<QueryChunks<T, S>>
+) : InfiniteQueryRef<T, S> {
+
+    override val state: StateFlow<QueryState<QueryChunks<T, S>>>
+        get() = query.state
+
+    override fun launchIn(scope: CoroutineScope): Job {
+        return scope.launch {
+            query.launchIn(this)
+            query.event.collect(::handleEvent)
+        }
+    }
+
+    override suspend fun send(command: QueryCommand<QueryChunks<T, S>>) {
+        query.command.send(command)
+    }
+
+    private suspend fun handleEvent(e: QueryEvent) {
+        when (e) {
+            QueryEvent.Invalidate -> invalidate()
+            QueryEvent.Resume -> resume()
+        }
+    }
+}
+
+/**
+ * Prefetches the Query.
+ */
+internal suspend fun <T, S> InfiniteQueryRef<T, S>.prefetch(): Boolean {
+    val deferred = CompletableDeferred<QueryChunks<T, S>>()
+    send(InfiniteQueryCommands.Connect(key, state.value.revision, deferred.toResultCallback()))
+    return try {
+        deferred.await()
+        true
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        false
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrMutation.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrMutation.kt
@@ -1,0 +1,26 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.StateFlow
+
+internal class SwrMutation<T, S>(
+    override val key: MutationKey<T, S>,
+    override val options: MutationOptions,
+    private val mutation: Mutation<T>
+) : MutationRef<T, S> {
+
+    override val state: StateFlow<MutationState<T>>
+        get() = mutation.state
+
+    override fun launchIn(scope: CoroutineScope): Job {
+        return mutation.launchIn(scope)
+    }
+
+    override suspend fun send(command: MutationCommand<T>) {
+        mutation.command.send(command)
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrQuery.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrQuery.kt
@@ -1,0 +1,56 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import soil.query.core.toResultCallback
+import kotlin.coroutines.cancellation.CancellationException
+
+internal class SwrQuery<T>(
+    override val key: QueryKey<T>,
+    override val options: QueryOptions,
+    private val query: Query<T>
+) : QueryRef<T> {
+
+    override val state: StateFlow<QueryState<T>>
+        get() = query.state
+
+    override fun launchIn(scope: CoroutineScope): Job {
+        return scope.launch {
+            query.launchIn(this)
+            query.event.collect(::handleEvent)
+        }
+    }
+
+    override suspend fun send(command: QueryCommand<T>) {
+        query.command.send(command)
+    }
+
+    private suspend fun handleEvent(e: QueryEvent) {
+        when (e) {
+            QueryEvent.Invalidate -> invalidate()
+            QueryEvent.Resume -> resume()
+        }
+    }
+}
+
+/**
+ * Prefetches the Query.
+ */
+internal suspend fun <T> QueryRef<T>.prefetch(): Boolean {
+    val deferred = CompletableDeferred<T>()
+    send(QueryCommands.Connect(key, state.value.revision, deferred.toResultCallback()))
+    return try {
+        deferred.await()
+        true
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        false
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/Actor.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/Actor.kt
@@ -28,7 +28,7 @@ interface Actor {
      *
      * @param scope The scope in which the actor will run
      */
-    fun launchIn(scope: CoroutineScope)
+    fun launchIn(scope: CoroutineScope): Job
 }
 
 internal typealias ActorSequenceNumber = Int
@@ -48,9 +48,9 @@ internal class ActorBlockRunner(
     private var runningJob: Job? = null
     private var cancellationJob: Job? = null
 
-    override fun launchIn(scope: CoroutineScope) {
+    override fun launchIn(scope: CoroutineScope): Job {
         seq++
-        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+        return scope.launch(start = CoroutineStart.UNDISPATCHED) {
             cancellationJob?.cancelAndJoin()
             cancellationJob = null
             suspendCancellableCoroutine { continuation ->


### PR DESCRIPTION
The implementation of XxxRef, which previously returned concrete classes directly from the Query and Mutation client interfaces,　has been switched to returning them via an interface.

- QueryRef
- InfiniteQueryRef
- MutationRef

This makes it easier to create mocks for previews and tests.