### PR TITLE
CompositionLocal has been split up to improve testability.

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
@@ -25,13 +25,13 @@ import soil.query.resume
  * @param T Type of data to retrieve.
  * @param S Type of parameter.
  * @param key The [InfiniteQueryKey] for managing [query][soil.query.Query] associated with [id][soil.query.InfiniteQueryId].
- * @param client The [QueryClient] to resolve [key]. By default, it uses the [LocalSwrClient].
+ * @param client The [QueryClient] to resolve [key]. By default, it uses the [LocalQueryClient].
  * @return A [InfiniteQueryObject] each the query state changed.
  */
 @Composable
 fun <T, S> rememberInfiniteQuery(
     key: InfiniteQueryKey<T, S>,
-    client: QueryClient = LocalSwrClient.current
+    client: QueryClient = LocalQueryClient.current
 ): InfiniteQueryObject<QueryChunks<T, S>, S> {
     val scope = rememberCoroutineScope()
     val query = remember(key) { client.getInfiniteQuery(key).also { it.launchIn(scope) } }
@@ -51,14 +51,14 @@ fun <T, S> rememberInfiniteQuery(
  * @param S Type of parameter.
  * @param key The [InfiniteQueryKey] for managing [query][soil.query.Query] associated with [id][soil.query.InfiniteQueryId].
  * @param select A function to select data from [QueryChunks].
- * @param client The [QueryClient] to resolve [key]. By default, it uses the [LocalSwrClient].
+ * @param client The [QueryClient] to resolve [key]. By default, it uses the [LocalQueryClient].
  * @return A [InfiniteQueryObject] with selected data each the query state changed.
  */
 @Composable
 fun <T, S, U> rememberInfiniteQuery(
     key: InfiniteQueryKey<T, S>,
     select: (chunks: QueryChunks<T, S>) -> U,
-    client: QueryClient = LocalSwrClient.current
+    client: QueryClient = LocalQueryClient.current
 ): InfiniteQueryObject<U, S> {
     val scope = rememberCoroutineScope()
     val query = remember(key) { client.getInfiniteQuery(key).also { it.launchIn(scope) } }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
@@ -23,13 +23,13 @@ import soil.query.reset
  * @param T Type of the return value from the mutation.
  * @param S Type of the variable to be mutated.
  * @param key The [MutationKey] for managing [mutation][soil.query.Mutation] associated with [id][soil.query.MutationId].
- * @param client The [MutationClient] to resolve [key]. By default, it uses the [LocalSwrClient].
+ * @param client The [MutationClient] to resolve [key]. By default, it uses the [LocalMutationClient].
  * @return A [MutationObject] each the mutation state changed.
  */
 @Composable
 fun <T, S> rememberMutation(
     key: MutationKey<T, S>,
-    client: MutationClient = LocalSwrClient.current
+    client: MutationClient = LocalMutationClient.current
 ): MutationObject<T, S> {
     val scope = rememberCoroutineScope()
     val mutation = remember(key) { client.getMutation(key).also { it.launchIn(scope) } }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
@@ -22,13 +22,13 @@ import soil.query.resume
  *
  * @param T Type of data to retrieve.
  * @param key The [QueryKey] for managing [query][soil.query.Query].
- * @param client The [QueryClient] to resolve [key]. By default, it uses the [LocalSwrClient].
+ * @param client The [QueryClient] to resolve [key]. By default, it uses the [LocalQueryClient].
  * @return A [QueryObject] each the query state changed.
  */
 @Composable
 fun <T> rememberQuery(
     key: QueryKey<T>,
-    client: QueryClient = LocalSwrClient.current
+    client: QueryClient = LocalQueryClient.current
 ): QueryObject<T> {
     val scope = rememberCoroutineScope()
     val query = remember(key) { client.getQuery(key).also { it.launchIn(scope) } }
@@ -48,14 +48,14 @@ fun <T> rememberQuery(
  * @param U Type of selected data.
  * @param key The [QueryKey] for managing [query][soil.query.Query].
  * @param select A function to select data from [T].
- * @param client The [QueryClient] to resolve [key]. By default, it uses the [LocalSwrClient].
+ * @param client The [QueryClient] to resolve [key]. By default, it uses the [LocalQueryClient].
  * @return A [QueryObject] with selected data each the query state changed.
  */
 @Composable
 fun <T, U> rememberQuery(
     key: QueryKey<T>,
     select: (T) -> U,
-    client: QueryClient = LocalSwrClient.current
+    client: QueryClient = LocalQueryClient.current
 ): QueryObject<U> {
     val scope = rememberCoroutineScope()
     val query = remember(key) { client.getQuery(key).also { it.launchIn(scope) } }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SwrClientProvider.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SwrClientProvider.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.staticCompositionLocalOf
+import soil.query.MutationClient
+import soil.query.QueryClient
 import soil.query.SwrClient
 import soil.query.core.uuid
 
@@ -21,7 +23,11 @@ fun SwrClientProvider(
     client: SwrClient,
     content: @Composable () -> Unit
 ) {
-    CompositionLocalProvider(LocalSwrClient provides client) {
+    CompositionLocalProvider(
+        LocalSwrClient provides client,
+        LocalQueryClient provides client,
+        LocalMutationClient provides client
+    ) {
         content()
     }
     DisposableEffect(client) {
@@ -38,4 +44,18 @@ fun SwrClientProvider(
  */
 val LocalSwrClient = staticCompositionLocalOf<SwrClient> {
     error("CompositionLocal 'SwrClient' not present")
+}
+
+/**
+ * CompositionLocal for [QueryClient].
+ */
+val LocalQueryClient = staticCompositionLocalOf<QueryClient> {
+    error("CompositionLocal 'QueryClient' not present")
+}
+
+/**
+ * CompositionLocal for [MutationClient].
+ */
+val LocalMutationClient = staticCompositionLocalOf<MutationClient> {
+    error("CompositionLocal 'MutationClient' not present")
 }


### PR DESCRIPTION
Switch the reference destination of Query and Mutation. All are set by SwrClientProvider at the same time.

- LocalSwrClient
- LocalQueryClient (new)
- LocalMutationClient (new)