### PR TITLE
Change some classes to package scope internally.

### DIFF
--- a/soil-query-core/src/commonMain/kotlin/soil/query/Mutation.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/Mutation.kt
@@ -12,7 +12,7 @@ import soil.query.core.Actor
  *
  * @param T Type of the return value from the mutation.
  */
-interface Mutation<T> : Actor {
+internal interface Mutation<T> : Actor {
 
     /**
      * [State Flow][StateFlow] to receive the current state of the mutation.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/Query.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/Query.kt
@@ -13,7 +13,7 @@ import soil.query.core.Actor
  *
  * @param T Type of the return value from the query.
  */
-interface Query<T>: Actor {
+internal interface Query<T>: Actor {
 
     /**
      * [Shared Flow][SharedFlow] to receive query [events][QueryEvent].
@@ -34,7 +34,7 @@ interface Query<T>: Actor {
 /**
  * Events occurring in the query.
  */
-enum class QueryEvent {
+internal enum class QueryEvent {
     Invalidate,
     Resume
 }


### PR DESCRIPTION
To enhance the functionality of the library, the focus was initially placed on expanding the implementation of custom queries within various advanced packages. However, as the strategy for implementing these queries has not been finalized yet, the current approach will involve conducting a review of unnecessary public scopes. 