### PR TITLE
Improve the readability of the SwrCache class

### DIFF
--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePolicy.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePolicy.kt
@@ -1,0 +1,121 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import soil.query.core.BatchScheduler
+import soil.query.core.ErrorRelay
+import soil.query.core.MemoryPressure
+import soil.query.core.NetworkConnectivity
+import soil.query.core.WindowVisibility
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Policy for the [SwrCache].
+ */
+class SwrCachePolicy(
+
+    /**
+     * [CoroutineScope] for coroutines executed on the [SwrCache].
+     *
+     * **Note:**
+     * The [SwrCache] internals are not thread-safe.
+     * Always use a scoped implementation such as [SwrCacheScope] or [kotlinx.coroutines.MainScope] with limited concurrency.
+     */
+    val coroutineScope: CoroutineScope,
+
+    /**
+     * [CoroutineDispatcher] for the main thread.
+     *
+     * **Note:**
+     * Some processes are safely synchronized with the caller using the main thread.
+     * When unit testing, please replace it with a test Dispatcher.
+     */
+    val mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
+
+    /**
+     * Default [MutationOptions] applied to [Mutation].
+     */
+    val mutationOptions: MutationOptions = MutationOptions,
+
+    /**
+     * Extension receiver for referencing external instances needed when executing [mutate][MutationKey.mutate].
+     */
+    val mutationReceiver: MutationReceiver = MutationReceiver,
+
+    /**
+     * Default [QueryOptions] applied to [Query].
+     */
+    val queryOptions: QueryOptions = QueryOptions,
+
+    /**
+     * Extension receiver for referencing external instances needed when executing [fetch][QueryKey.fetch].
+     */
+    val queryReceiver: QueryReceiver = QueryReceiver,
+
+    /**
+     * Management of cached data for inactive [Query] instances.
+     */
+    val queryCache: QueryCache = QueryCache(),
+
+    /**
+     * Scheduler for batching tasks.
+     *
+     * **Note:**
+     * This is used for internal processes such as moving inactive query caches.
+     * Please avoid changing this unless you need to substitute it for testing purposes.
+     */
+    val batchScheduler: BatchScheduler = BatchScheduler.default(mainDispatcher),
+
+    /**
+     * Specify the mechanism of [ErrorRelay] when using [SwrClient.errorRelay].
+     */
+    val errorRelay: ErrorRelay? = null,
+
+    /**
+     * Receiving events of memory pressure.
+     */
+    val memoryPressure: MemoryPressure = MemoryPressure,
+
+    /**
+     * Receiving events of network connectivity.
+     */
+    val networkConnectivity: NetworkConnectivity = NetworkConnectivity,
+
+    /**
+     * The delay time to resume queries after network connectivity is reconnected.
+     *
+     * **Note:**
+     * This setting is only effective when [networkConnectivity] is available.
+     */
+    val networkResumeAfterDelay: Duration = 2.seconds,
+
+    /**
+     * The specified filter to resume queries after network connectivity is reconnected.
+     *
+     * **Note:**
+     * This setting is only effective when [networkConnectivity] is available.
+     */
+    val networkResumeQueriesFilter: ResumeQueriesFilter = ResumeQueriesFilter(
+        predicate = { it.isFailure }
+    ),
+
+    /**
+     * Receiving events of window visibility.
+     */
+    val windowVisibility: WindowVisibility = WindowVisibility,
+
+    /**
+     * The specified filter to resume queries after window visibility is refocused.
+     *
+     * **Note:**
+     * This setting is only effective when [windowVisibility] is available.
+     */
+    val windowResumeQueriesFilter: ResumeQueriesFilter = ResumeQueriesFilter(
+        predicate = { it.isStaled() }
+    )
+)

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/BatchScheduler.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/BatchScheduler.kt
@@ -1,0 +1,75 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Scheduler for batching tasks.
+ */
+interface BatchScheduler {
+
+    /**
+     * Start the scheduler.
+     */
+    fun start(scope: CoroutineScope): Job
+
+    /**
+     * Post a task to the scheduler.
+     */
+    suspend fun post(task: BatchTask)
+
+    companion object {
+
+        /**
+         * Create a new [BatchScheduler] with built-in scheduler implementation.
+         *
+         * @param dispatcher Coroutine dispatcher for the main thread.
+         * @param interval Interval for batching tasks.
+         * @param chunkSize Maximum number of tasks to execute in a batch.
+         */
+        fun default(
+            dispatcher: CoroutineDispatcher = Dispatchers.Main,
+            interval: Duration = 500.milliseconds,
+            chunkSize: Int = 10
+        ): BatchScheduler {
+            return DefaultBatchScheduler(dispatcher, interval, chunkSize)
+        }
+    }
+}
+
+typealias BatchTask = () -> Unit
+
+internal class DefaultBatchScheduler(
+    private val dispatcher: CoroutineDispatcher,
+    private val interval: Duration,
+    private val chunkSize: Int
+) : BatchScheduler {
+
+    private val batchFlow: MutableSharedFlow<BatchTask> = MutableSharedFlow()
+
+    override fun start(scope: CoroutineScope): Job {
+        return batchFlow
+            .chunkedWithTimeout(size = chunkSize, duration = interval)
+            .onEach { tasks ->
+                withContext(dispatcher) {
+                    tasks.forEach { it() }
+                }
+            }
+            .launchIn(scope)
+    }
+
+    override suspend fun post(task: BatchTask) {
+        batchFlow.emit(task)
+    }
+}


### PR DESCRIPTION
The scheduling logic for batch tasks, originally implemented in the `SwrCache` class, has been extracted into a new class called `BatchScheduler`. This separation of concerns allows for better maintainability and reusability of code.

Additionally, the `SwrCachePolicy` class has been moved to its own file. This separation of classes into individual files makes the codebase more navigable and easier to understand.

refs: #44