### PR TITLE
Improve the state-based model for type safety in the internal code.

### DIFF
--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Catch.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Catch.kt
@@ -7,19 +7,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import soil.query.QueryModel
+import soil.query.core.DataModel
 import soil.query.core.uuid
 
 /**
- * Catch for a [QueryModel] to be rejected.
+ * Catch for a [DataModel] to be rejected.
  *
- * @param state The [QueryModel] to catch.
+ * @param state The [DataModel] to catch.
  * @param isEnabled Whether to catch the error.
  * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
  */
 @Composable
 fun Catch(
-    state: QueryModel<*>,
+    state: DataModel<*>,
     isEnabled: Boolean = true,
     content: @Composable CatchScope.(err: Throwable) -> Unit = { Throw(error = it) }
 ) {
@@ -32,17 +32,17 @@ fun Catch(
 }
 
 /**
- * Catch for any [QueryModel]s to be rejected.
+ * Catch for any [DataModel]s to be rejected.
  *
- * @param state1 The first [QueryModel] to catch.
- * @param state2 The second [QueryModel] to catch.
+ * @param state1 The first [DataModel] to catch.
+ * @param state2 The second [DataModel] to catch.
  * @param isEnabled Whether to catch the error.
  * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
  */
 @Composable
 fun Catch(
-    state1: QueryModel<*>,
-    state2: QueryModel<*>,
+    state1: DataModel<*>,
+    state2: DataModel<*>,
     isEnabled: Boolean = true,
     content: @Composable CatchScope.(err: Throwable) -> Unit = { Throw(error = it) }
 ) {
@@ -56,19 +56,19 @@ fun Catch(
 }
 
 /**
- * Catch for any [QueryModel]s to be rejected.
+ * Catch for any [DataModel]s to be rejected.
  *
- * @param state1 The first [QueryModel] to catch.
- * @param state2 The second [QueryModel] to catch.
- * @param state3 The third [QueryModel] to catch.
+ * @param state1 The first [DataModel] to catch.
+ * @param state2 The second [DataModel] to catch.
+ * @param state3 The third [DataModel] to catch.
  * @param isEnabled Whether to catch the error.
  * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
  */
 @Composable
 fun Catch(
-    state1: QueryModel<*>,
-    state2: QueryModel<*>,
-    state3: QueryModel<*>,
+    state1: DataModel<*>,
+    state2: DataModel<*>,
+    state3: DataModel<*>,
     isEnabled: Boolean = true,
     content: @Composable CatchScope.(err: Throwable) -> Unit = { Throw(error = it) }
 ) {
@@ -83,15 +83,15 @@ fun Catch(
 }
 
 /**
- * Catch for any [QueryModel]s to be rejected.
+ * Catch for any [DataModel]s to be rejected.
  *
- * @param states The [QueryModel]s to catch.
+ * @param states The [DataModel]s to catch.
  * @param isEnabled Whether to catch the error.
  * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
  */
 @Composable
 fun Catch(
-    vararg states: QueryModel<*>,
+    vararg states: DataModel<*>,
     isEnabled: Boolean = true,
     content: @Composable CatchScope.(err: Throwable) -> Unit = { Throw(error = it) }
 ) {
@@ -104,16 +104,16 @@ fun Catch(
 }
 
 /**
- * Catch for a [QueryModel] to be rejected.
+ * Catch for a [DataModel] to be rejected.
  *
- * @param state The [QueryModel] to catch.
+ * @param state The [DataModel] to catch.
  * @param filterIsInstance A function to filter the error.
  * @param isEnabled Whether to catch the error.
  * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
  */
 @Composable
 fun <T : Throwable> Catch(
-    state: QueryModel<*>,
+    state: DataModel<*>,
     filterIsInstance: (err: Throwable) -> T?,
     isEnabled: Boolean = true,
     content: @Composable CatchScope.(err: T) -> Unit = { Throw(error = it) }
@@ -125,18 +125,18 @@ fun <T : Throwable> Catch(
 }
 
 /**
- * Catch for any [QueryModel]s to be rejected.
+ * Catch for any [DataModel]s to be rejected.
  *
- * @param state1 The first [QueryModel] to catch.
- * @param state2 The second [QueryModel] to catch.
+ * @param state1 The first [DataModel] to catch.
+ * @param state2 The second [DataModel] to catch.
  * @param filterIsInstance A function to filter the error.
  * @param isEnabled Whether to catch the error.
  * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
  */
 @Composable
 fun <T : Throwable> Catch(
-    state1: QueryModel<*>,
-    state2: QueryModel<*>,
+    state1: DataModel<*>,
+    state2: DataModel<*>,
     filterIsInstance: (err: Throwable) -> T?,
     isEnabled: Boolean = true,
     content: @Composable CatchScope.(err: T) -> Unit = { Throw(error = it) }
@@ -151,20 +151,20 @@ fun <T : Throwable> Catch(
 }
 
 /**
- * Catch for any [QueryModel]s to be rejected.
+ * Catch for any [DataModel]s to be rejected.
  *
- * @param state1 The first [QueryModel] to catch.
- * @param state2 The second [QueryModel] to catch.
- * @param state3 The third [QueryModel] to catch.
+ * @param state1 The first [DataModel] to catch.
+ * @param state2 The second [DataModel] to catch.
+ * @param state3 The third [DataModel] to catch.
  * @param filterIsInstance A function to filter the error.
  * @param isEnabled Whether to catch the error.
  * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
  */
 @Composable
 fun <T : Throwable> Catch(
-    state1: QueryModel<*>,
-    state2: QueryModel<*>,
-    state3: QueryModel<*>,
+    state1: DataModel<*>,
+    state2: DataModel<*>,
+    state3: DataModel<*>,
     filterIsInstance: (err: Throwable) -> T?,
     isEnabled: Boolean = true,
     content: @Composable CatchScope.(err: T) -> Unit = { Throw(error = it) }
@@ -179,16 +179,16 @@ fun <T : Throwable> Catch(
 }
 
 /**
- * Catch for any [QueryModel]s to be rejected.
+ * Catch for any [DataModel]s to be rejected.
  *
- * @param states The [QueryModel]s to catch.
+ * @param states The [DataModel]s to catch.
  * @param filterIsInstance A function to filter the error.
  * @param isEnabled Whether to catch the error.
  * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
  */
 @Composable
 fun <T : Throwable> Catch(
-    vararg states: QueryModel<*>,
+    vararg states: DataModel<*>,
     filterIsInstance: (err: Throwable) -> T?,
     isEnabled: Boolean = true,
     content: @Composable CatchScope.(err: T) -> Unit = { Throw(error = it) }

--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Loadable.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Loadable.kt
@@ -5,9 +5,8 @@ package soil.query.compose.runtime
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
-import soil.query.QueryFetchStatus
-import soil.query.QueryModel
-import soil.query.QueryStatus
+import soil.query.core.DataModel
+import soil.query.core.Reply
 import soil.query.core.epoch
 
 /**
@@ -19,22 +18,19 @@ import soil.query.core.epoch
  * @param T The type of the value that has been loaded.
  */
 @Stable
-sealed class Loadable<out T> : QueryModel<T> {
+sealed class Loadable<out T> : DataModel<T> {
+
+    override fun isAwaited(): Boolean = this == Pending
 
     /**
      * Represents the state of a value that is being loaded.
      */
     @Immutable
     data object Pending : Loadable<Nothing>() {
-        override val data: Nothing get() = error("Pending")
-        override val dataUpdatedAt: Long = 0
-        override val dataStaleAt: Long = 0
+        override val reply: Reply<Nothing> = Reply.None
+        override val replyUpdatedAt: Long = 0
         override val error: Throwable? = null
         override val errorUpdatedAt: Long = 0
-        override val status: QueryStatus = QueryStatus.Pending
-        override val fetchStatus: QueryFetchStatus = QueryFetchStatus.Fetching
-        override val isInvalidated: Boolean = false
-        override val isPlaceholderData: Boolean = false
     }
 
     /**
@@ -42,16 +38,12 @@ sealed class Loadable<out T> : QueryModel<T> {
      */
     @Immutable
     data class Fulfilled<T>(
-        override val data: T
+        val data: T
     ) : Loadable<T>() {
-        override val dataUpdatedAt: Long = epoch()
-        override val dataStaleAt: Long = Long.MAX_VALUE
+        override val reply: Reply<T> = Reply.some(data)
+        override val replyUpdatedAt: Long = epoch()
         override val error: Throwable? = null
         override val errorUpdatedAt: Long = 0
-        override val status: QueryStatus = QueryStatus.Success
-        override val fetchStatus: QueryFetchStatus = QueryFetchStatus.Idle
-        override val isInvalidated: Boolean = false
-        override val isPlaceholderData: Boolean = false
     }
 
     /**
@@ -61,13 +53,8 @@ sealed class Loadable<out T> : QueryModel<T> {
     data class Rejected(
         override val error: Throwable
     ) : Loadable<Nothing>() {
-        override val data: Nothing get() = error("Rejected")
-        override val dataUpdatedAt: Long = 0
-        override val dataStaleAt: Long = 0
+        override val reply: Reply<Nothing> = Reply.None
+        override val replyUpdatedAt: Long = 0
         override val errorUpdatedAt: Long = epoch()
-        override val status: QueryStatus = QueryStatus.Failure
-        override val fetchStatus: QueryFetchStatus = QueryFetchStatus.Idle
-        override val isInvalidated: Boolean = false
-        override val isPlaceholderData: Boolean = false
     }
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryObject.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryObject.kt
@@ -8,6 +8,9 @@ import androidx.compose.runtime.Stable
 import soil.query.QueryFetchStatus
 import soil.query.QueryModel
 import soil.query.QueryStatus
+import soil.query.core.Reply
+import soil.query.core.getOrNull
+import soil.query.core.getOrThrow
 
 /**
  * A InfiniteQueryObject represents [QueryModel]s interface for infinite fetching data using a retrieval method known as "infinite scroll."
@@ -17,6 +20,11 @@ import soil.query.QueryStatus
  */
 @Stable
 sealed interface InfiniteQueryObject<out T, S> : QueryModel<T> {
+
+    /**
+     * The return value from the data source. (Backward compatibility with QueryModel)
+     */
+    val data: T?
 
     /**
      * Refreshes the data.
@@ -42,12 +50,12 @@ sealed interface InfiniteQueryObject<out T, S> : QueryModel<T> {
  * @constructor Creates a [InfiniteQueryLoadingObject].
  */
 @Immutable
-data class InfiniteQueryLoadingObject<T, S>(
-    override val data: T?,
-    override val dataUpdatedAt: Long,
-    override val dataStaleAt: Long,
+data class InfiniteQueryLoadingObject<T, S> internal constructor(
+    override val reply: Reply<T>,
+    override val replyUpdatedAt: Long,
     override val error: Throwable?,
     override val errorUpdatedAt: Long,
+    override val staleAt: Long,
     override val fetchStatus: QueryFetchStatus,
     override val isInvalidated: Boolean,
     override val isPlaceholderData: Boolean,
@@ -56,6 +64,7 @@ data class InfiniteQueryLoadingObject<T, S>(
     override val loadMoreParam: S?
 ) : InfiniteQueryObject<T, S> {
     override val status: QueryStatus = QueryStatus.Pending
+    override val data: T? get() = reply.getOrNull()
 }
 
 /**
@@ -66,12 +75,12 @@ data class InfiniteQueryLoadingObject<T, S>(
  * @constructor Creates a [InfiniteQueryLoadingErrorObject].
  */
 @Immutable
-data class InfiniteQueryLoadingErrorObject<T, S>(
-    override val data: T?,
-    override val dataUpdatedAt: Long,
-    override val dataStaleAt: Long,
+data class InfiniteQueryLoadingErrorObject<T, S> internal constructor(
+    override val reply: Reply<T>,
+    override val replyUpdatedAt: Long,
     override val error: Throwable,
     override val errorUpdatedAt: Long,
+    override val staleAt: Long,
     override val fetchStatus: QueryFetchStatus,
     override val isInvalidated: Boolean,
     override val isPlaceholderData: Boolean,
@@ -80,6 +89,7 @@ data class InfiniteQueryLoadingErrorObject<T, S>(
     override val loadMoreParam: S?
 ) : InfiniteQueryObject<T, S> {
     override val status: QueryStatus = QueryStatus.Failure
+    override val data: T? get() = reply.getOrNull()
 }
 
 /**
@@ -90,12 +100,12 @@ data class InfiniteQueryLoadingErrorObject<T, S>(
  * @constructor Creates a [InfiniteQuerySuccessObject].
  */
 @Immutable
-data class InfiniteQuerySuccessObject<T, S>(
-    override val data: T,
-    override val dataUpdatedAt: Long,
-    override val dataStaleAt: Long,
+data class InfiniteQuerySuccessObject<T, S> internal constructor(
+    override val reply: Reply<T>,
+    override val replyUpdatedAt: Long,
     override val error: Throwable?,
     override val errorUpdatedAt: Long,
+    override val staleAt: Long,
     override val fetchStatus: QueryFetchStatus,
     override val isInvalidated: Boolean,
     override val isPlaceholderData: Boolean,
@@ -104,6 +114,7 @@ data class InfiniteQuerySuccessObject<T, S>(
     override val loadMoreParam: S?
 ) : InfiniteQueryObject<T, S> {
     override val status: QueryStatus = QueryStatus.Success
+    override val data: T get() = reply.getOrThrow()
 }
 
 /**
@@ -116,12 +127,12 @@ data class InfiniteQuerySuccessObject<T, S>(
  * @constructor Creates a [InfiniteQueryRefreshErrorObject].
  */
 @Immutable
-data class InfiniteQueryRefreshErrorObject<T, S>(
-    override val data: T,
-    override val dataUpdatedAt: Long,
-    override val dataStaleAt: Long,
+data class InfiniteQueryRefreshErrorObject<T, S> internal constructor(
+    override val reply: Reply<T>,
+    override val replyUpdatedAt: Long,
     override val error: Throwable,
     override val errorUpdatedAt: Long,
+    override val staleAt: Long,
     override val fetchStatus: QueryFetchStatus,
     override val isInvalidated: Boolean,
     override val isPlaceholderData: Boolean,
@@ -130,4 +141,5 @@ data class InfiniteQueryRefreshErrorObject<T, S>(
     override val loadMoreParam: S?
 ) : InfiniteQueryObject<T, S> {
     override val status: QueryStatus = QueryStatus.Failure
+    override val data: T get() = reply.getOrThrow()
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
@@ -39,14 +39,13 @@ fun <T, S> rememberMutation(
     }
 }
 
-@Suppress("UNCHECKED_CAST")
 private fun <T, S> MutationState<T>.toObject(
     mutation: MutationRef<T, S>,
 ): MutationObject<T, S> {
     return when (status) {
         MutationStatus.Idle -> MutationIdleObject(
-            data = data,
-            dataUpdatedAt = dataUpdatedAt,
+            reply = reply,
+            replyUpdatedAt = replyUpdatedAt,
             error = error,
             errorUpdatedAt = errorUpdatedAt,
             mutatedCount = mutatedCount,
@@ -56,8 +55,8 @@ private fun <T, S> MutationState<T>.toObject(
         )
 
         MutationStatus.Pending -> MutationLoadingObject(
-            data = data,
-            dataUpdatedAt = dataUpdatedAt,
+            reply = reply,
+            replyUpdatedAt = replyUpdatedAt,
             error = error,
             errorUpdatedAt = errorUpdatedAt,
             mutatedCount = mutatedCount,
@@ -67,8 +66,8 @@ private fun <T, S> MutationState<T>.toObject(
         )
 
         MutationStatus.Success -> MutationSuccessObject(
-            data = data as T,
-            dataUpdatedAt = dataUpdatedAt,
+            reply = reply,
+            replyUpdatedAt = replyUpdatedAt,
             error = error,
             errorUpdatedAt = errorUpdatedAt,
             mutatedCount = mutatedCount,
@@ -78,9 +77,9 @@ private fun <T, S> MutationState<T>.toObject(
         )
 
         MutationStatus.Failure -> MutationErrorObject(
-            data = data,
-            dataUpdatedAt = dataUpdatedAt,
-            error = error as Throwable,
+            reply = reply,
+            replyUpdatedAt = replyUpdatedAt,
+            error = checkNotNull(error),
             errorUpdatedAt = errorUpdatedAt,
             mutatedCount = mutatedCount,
             mutate = mutation::mutate,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommand.kt
@@ -5,6 +5,7 @@ package soil.query
 
 import soil.query.core.RetryFn
 import soil.query.core.exponentialBackOff
+import soil.query.core.getOrElse
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
@@ -82,7 +83,7 @@ suspend inline fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.dispatchFetchC
 ) {
     fetch(key, variable)
         .map { QueryChunk(it, variable) }
-        .map { chunk -> state.data.orEmpty() + chunk }
+        .map { chunk -> state.reply.getOrElse { emptyList() } + chunk }
         .run { key.onRecoverData()?.let(::recoverCatching) ?: this }
         .onSuccess(::dispatchFetchSuccess)
         .onFailure(::dispatchFetchFailure)

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationAction.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationAction.kt
@@ -3,6 +3,8 @@
 
 package soil.query
 
+import soil.query.core.Reply
+
 /**
  * Mutation actions are used to update the [mutation state][MutationState].
  *
@@ -53,8 +55,8 @@ fun <T> createMutationReducer(): MutationReducer<T> = { state, action ->
     when (action) {
         is MutationAction.Reset -> {
             state.copy(
-                data = null,
-                dataUpdatedAt = 0,
+                reply = Reply.none(),
+                replyUpdatedAt = 0,
                 error = null,
                 errorUpdatedAt = 0,
                 status = MutationStatus.Idle,
@@ -71,8 +73,8 @@ fun <T> createMutationReducer(): MutationReducer<T> = { state, action ->
         is MutationAction.MutateSuccess -> {
             state.copy(
                 status = MutationStatus.Success,
-                data = action.data,
-                dataUpdatedAt = action.dataUpdatedAt,
+                reply = Reply(action.data),
+                replyUpdatedAt = action.dataUpdatedAt,
                 error = null,
                 errorUpdatedAt = action.dataUpdatedAt,
                 mutatedCount = state.mutatedCount + 1

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationError.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationError.kt
@@ -25,7 +25,7 @@ class MutationError @PublishedApi internal constructor(
                 message=${exception.message},
                 key=$key,
                 model={
-                    dataUpdatedAt=${model.dataUpdatedAt},
+                    replyUpdatedAt=${model.replyUpdatedAt},
                     errorUpdatedAt=${model.errorUpdatedAt},
                     status=${model.status},
                     mutatedCount=${model.mutatedCount},

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationModel.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationModel.kt
@@ -3,6 +3,7 @@
 
 package soil.query
 
+import soil.query.core.DataModel
 import kotlin.math.max
 
 /**
@@ -12,27 +13,7 @@ import kotlin.math.max
  *
  * @param T Type of the return value from the mutation.
  */
-interface MutationModel<out T> {
-
-    /**
-     * The return value from the mutation.
-     */
-    val data: T?
-
-    /**
-     * The timestamp when the data was updated.
-     */
-    val dataUpdatedAt: Long
-
-    /**
-     * The error that occurred.
-     */
-    val error: Throwable?
-
-    /**
-     * The timestamp when the error occurred.
-     */
-    val errorUpdatedAt: Long
+interface MutationModel<out T> : DataModel<T> {
 
     /**
      * The status of the mutation.
@@ -47,12 +28,12 @@ interface MutationModel<out T> {
     /**
      * The revision of the currently snapshot.
      */
-    val revision: String get() = "d-$dataUpdatedAt/e-$errorUpdatedAt"
+    val revision: String get() = "d-$replyUpdatedAt/e-$errorUpdatedAt"
 
     /**
      * The timestamp when the mutation was submitted.
      */
-    val submittedAt: Long get() = max(dataUpdatedAt, errorUpdatedAt)
+    val submittedAt: Long get() = max(replyUpdatedAt, errorUpdatedAt)
 
     /**
      * Returns `true` if the mutation is idle, `false` otherwise.
@@ -78,6 +59,15 @@ interface MutationModel<out T> {
      * Returns `true` if the mutation has been mutated, `false` otherwise.
      */
     val isMutated: Boolean get() = mutatedCount > 0
+
+    /**
+     * Returns true if the [MutationModel] is awaited.
+     *
+     * @see DataModel.isAwaited
+     */
+    override fun isAwaited(): Boolean {
+        return isPending
+    }
 }
 
 /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationState.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationState.kt
@@ -3,14 +3,15 @@
 
 package soil.query
 
+import soil.query.core.Reply
 import soil.query.core.epoch
 
 /**
  * State for managing the execution result of [Mutation].
  */
-data class MutationState<out T> internal constructor(
-    override val data: T? = null,
-    override val dataUpdatedAt: Long = 0,
+data class MutationState<T> internal constructor(
+    override val reply: Reply<T> = Reply.None,
+    override val replyUpdatedAt: Long = 0,
     override val error: Throwable? = null,
     override val errorUpdatedAt: Long = 0,
     override val status: MutationStatus = MutationStatus.Idle,
@@ -31,8 +32,8 @@ data class MutationState<out T> internal constructor(
             mutatedCount: Int = 1
         ): MutationState<T> {
             return MutationState(
-                data = data,
-                dataUpdatedAt = dataUpdatedAt,
+                reply = Reply(data),
+                replyUpdatedAt = dataUpdatedAt,
                 status = MutationStatus.Success,
                 mutatedCount = mutatedCount
             )

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryAction.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryAction.kt
@@ -3,6 +3,8 @@
 
 package soil.query
 
+import soil.query.core.Reply
+
 /**
  * Query actions are used to update the [query state][QueryState].
  *
@@ -79,11 +81,11 @@ fun <T> createQueryReducer(): QueryReducer<T> = { state, action ->
 
         is QueryAction.FetchSuccess -> {
             state.copy(
-                data = action.data,
-                dataUpdatedAt = action.dataUpdatedAt,
-                dataStaleAt = action.dataStaleAt,
+                reply = Reply(action.data),
+                replyUpdatedAt = action.dataUpdatedAt,
                 error = null,
                 errorUpdatedAt = action.dataUpdatedAt,
+                staleAt = action.dataStaleAt,
                 status = QueryStatus.Success,
                 fetchStatus = QueryFetchStatus.Idle,
                 isInvalidated = false,
@@ -108,8 +110,8 @@ fun <T> createQueryReducer(): QueryReducer<T> = { state, action ->
 
         is QueryAction.ForceUpdate -> {
             state.copy(
-                data = action.data,
-                dataUpdatedAt = action.dataUpdatedAt
+                reply = Reply(action.data),
+                replyUpdatedAt = action.dataUpdatedAt
             )
         }
     }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryError.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryError.kt
@@ -25,11 +25,11 @@ class QueryError @PublishedApi internal constructor(
                 message=${exception.message},
                 key=$key,
                 model={
-                    dataUpdatedAt=${model.dataUpdatedAt},
-                    dataStaleAt=${model.dataStaleAt},
+                    replyUpdatedAt=${model.replyUpdatedAt},
                     errorUpdatedAt=${model.errorUpdatedAt},
+                    staleAt=${model.staleAt},
                     status=${model.status},
-                    isInvalidated=${model.isInvalidated},
+                    isInvalidated=${model.isInvalidated}
                 }
             )
         """.trimIndent()

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/DataModel.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/DataModel.kt
@@ -1,0 +1,32 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+interface DataModel<out T> {
+
+    /**
+     * The return value from the data source.
+     */
+    val reply: Reply<T>
+
+    /**
+     * The timestamp when the data was updated.
+     */
+    val replyUpdatedAt: Long
+
+    /**
+     * The error that occurred.
+     */
+    val error: Throwable?
+
+    /**
+     * The timestamp when the error occurred.
+     */
+    val errorUpdatedAt: Long
+
+    /**
+     * Returns true if the [DataModel] is awaited.
+     */
+    fun isAwaited(): Boolean
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/Reply.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/Reply.kt
@@ -1,0 +1,101 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+/**
+ * Represents a reply from a query or mutation.
+ *
+ * [None] indicates that there is no reply yet.
+ */
+sealed interface Reply<out T> {
+    data object None : Reply<Nothing>
+    data class Some<out T> internal constructor(val value: T) : Reply<T>
+
+    companion object {
+        internal inline operator fun <T> invoke(value: T): Reply<T> = Some(value)
+
+        fun <T> none(): Reply<T> = None
+        fun <T> some(value: T): Reply<T> = Some(value)
+    }
+}
+
+/**
+ * Returns true if the reply is [Reply.None].
+ */
+val <T> Reply<T>.isNone: Boolean get() = this is Reply.None
+
+/**
+ * Returns the value of the [Reply.Some] instance, or throws an error if there is no reply yet ([Reply.None]).
+ */
+fun <T> Reply<T>.getOrThrow(): T = when (this) {
+    is Reply.None -> error("Reply is none.")
+    is Reply.Some -> value
+}
+
+/**
+ * Returns the value of the [Reply.Some] instance, or null if there is no reply yet ([Reply.None]).
+ */
+fun <T> Reply<T>.getOrNull(): T? = when (this) {
+    is Reply.None -> null
+    is Reply.Some -> value
+}
+
+/**
+ * Returns the value of the [Reply.Some] instance, or the result of the [default] function if there is no reply yet ([Reply.None]).
+ */
+fun <T> Reply<T>.getOrElse(default: () -> T): T = when (this) {
+    is Reply.None -> default()
+    is Reply.Some -> value
+}
+
+/**
+ * Transforms the value of the [Reply.Some] instance using the provided [transform] function,
+ * or returns [Reply.None] if there is no reply yet ([Reply.None]).
+ */
+inline fun <T, R> Reply<T>.map(transform: (T) -> R): Reply<R> = when (this) {
+    is Reply.None -> Reply.none()
+    is Reply.Some -> Reply.some(transform(value))
+}
+
+/**
+ * Combines two [Reply] instances using the provided [transform] function.
+ * If either [Reply] has no reply yet ([Reply.None]), returns [Reply.None].
+ */
+inline fun <T1, T2, R> Reply.Companion.combine(
+    r1: Reply<T1>,
+    r2: Reply<T2>,
+    transform: (T1, T2) -> R
+): Reply<R> {
+    return when {
+        r1.isNone || r2.isNone -> none()
+        else -> some(
+            transform(
+                r1.getOrThrow(),
+                r2.getOrThrow()
+            )
+        )
+    }
+}
+
+/**
+ * Combines three [Reply] instances using the provided [transform] function.
+ * If any [Reply] has no reply yet ([Reply.None]), returns [Reply.None].
+ */
+inline fun <T1, T2, T3, R> Reply.Companion.combine(
+    r1: Reply<T1>,
+    r2: Reply<T2>,
+    r3: Reply<T3>,
+    transform: (T1, T2, T3) -> R
+): Reply<R> {
+    return when {
+        r1.isNone || r2.isNone || r3.isNone -> none()
+        else -> some(
+            transform(
+                r1.getOrThrow(),
+                r2.getOrThrow(),
+                r3.getOrThrow()
+            )
+        )
+    }
+}

--- a/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientTest.kt
+++ b/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientTest.kt
@@ -24,6 +24,7 @@ import soil.query.SwrCachePolicy
 import soil.query.buildInfiniteQueryKey
 import soil.query.buildMutationKey
 import soil.query.buildQueryKey
+import soil.query.core.getOrThrow
 import soil.query.mutate
 import soil.testing.UnitTest
 import kotlin.test.Test
@@ -48,7 +49,7 @@ class TestSwrClientTest : UnitTest() {
         val key = ExampleMutationKey()
         val mutation = testClient.getMutation(key).also { it.launchIn(backgroundScope) }
         mutation.mutate(0)
-        assertEquals("Hello, World!", mutation.state.value.data)
+        assertEquals("Hello, World!", mutation.state.value.reply.getOrThrow())
     }
 
     @Test
@@ -67,7 +68,7 @@ class TestSwrClientTest : UnitTest() {
         val key = ExampleQueryKey()
         val query = testClient.getQuery(key).also { it.launchIn(backgroundScope) }
         query.test()
-        assertEquals("Hello, World!", query.state.value.data)
+        assertEquals("Hello, World!", query.state.value.reply.getOrThrow())
     }
 
     @Test
@@ -86,7 +87,7 @@ class TestSwrClientTest : UnitTest() {
         val key = ExampleInfiniteQueryKey()
         val query = testClient.getInfiniteQuery(key).also { it.launchIn(backgroundScope) }
         query.test()
-        assertEquals("Hello, World!", query.state.value.data?.first()?.data)
+        assertEquals("Hello, World!", query.state.value.reply.getOrThrow().first().data)
     }
 }
 


### PR DESCRIPTION
There was an issue in the Soil Query code where forced unwrapping was being used, which was addressed in PR #57 recently. In this PR, I have revisited the handling of nullable data types, identified as the root cause, and introduced a new `Reply<T>` type to eliminate the mismatch between `T?` and the type definition expected by users.

Since the existing `data` property is likely referenced by users, the Reply model has been defined under a different property name to maintain backward compatibility.

- data  (unchanged)
- dataUpdatedAt -> replyUpdatedAt  (change)
- dataStaleAt -> staleAt (change)
- reply (new)

refs: #57