### PR TITLE
Replace `onPlaceholderData` with `onInitialData`

### DIFF
--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostKey.kt
@@ -4,8 +4,8 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import soil.playground.query.data.Post
 import soil.query.QueryId
+import soil.query.QueryInitialData
 import soil.query.QueryKey
-import soil.query.QueryPlaceholderData
 import soil.query.chunkedData
 import soil.query.receivers.ktor.buildKtorQueryKey
 
@@ -16,7 +16,7 @@ class GetPostKey(private val postId: Int) : QueryKey<Post> by buildKtorQueryKey(
     }
 ) {
 
-    override fun onPlaceholderData(): QueryPlaceholderData<Post> = {
+    override fun onInitialData(): QueryInitialData<Post> = {
         getInfiniteQueryData(GetPostsKey.Id())?.let {
             it.chunkedData.firstOrNull { post -> post.id == postId }
         }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserKey.kt
@@ -4,8 +4,8 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import soil.playground.query.data.User
 import soil.query.QueryId
+import soil.query.QueryInitialData
 import soil.query.QueryKey
-import soil.query.QueryPlaceholderData
 import soil.query.chunkedData
 import soil.query.receivers.ktor.buildKtorQueryKey
 
@@ -16,7 +16,7 @@ class GetUserKey(private val userId: Int) : QueryKey<User> by buildKtorQueryKey(
     }
 ) {
 
-    override fun onPlaceholderData(): QueryPlaceholderData<User> = {
+    override fun onInitialData(): QueryInitialData<User> = {
         getInfiniteQueryData(GetUsersKey.Id())?.let {
             it.chunkedData.firstOrNull { user -> user.id == userId }
         }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
@@ -87,7 +87,6 @@ private fun <T, S, U> QueryState<QueryChunks<T, S>>.toInfiniteObject(
             staleAt = staleAt,
             fetchStatus = fetchStatus,
             isInvalidated = isInvalidated,
-            isPlaceholderData = isPlaceholderData,
             refresh = query::invalidate,
             loadMore = query::loadMore,
             loadMoreParam = null
@@ -101,7 +100,6 @@ private fun <T, S, U> QueryState<QueryChunks<T, S>>.toInfiniteObject(
             staleAt = staleAt,
             fetchStatus = fetchStatus,
             isInvalidated = isInvalidated,
-            isPlaceholderData = isPlaceholderData,
             refresh = query::invalidate,
             loadMore = query::loadMore,
             loadMoreParam = query.key.loadMoreParam(reply.getOrThrow())
@@ -116,7 +114,6 @@ private fun <T, S, U> QueryState<QueryChunks<T, S>>.toInfiniteObject(
                 staleAt = staleAt,
                 fetchStatus = fetchStatus,
                 isInvalidated = isInvalidated,
-                isPlaceholderData = isPlaceholderData,
                 refresh = query::invalidate,
                 loadMore = query::loadMore,
                 loadMoreParam = null
@@ -130,7 +127,6 @@ private fun <T, S, U> QueryState<QueryChunks<T, S>>.toInfiniteObject(
                 staleAt = staleAt,
                 fetchStatus = fetchStatus,
                 isInvalidated = isInvalidated,
-                isPlaceholderData = isPlaceholderData,
                 refresh = query::invalidate,
                 loadMore = query::loadMore,
                 loadMoreParam = query.key.loadMoreParam(reply.getOrThrow())

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryObject.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryObject.kt
@@ -58,7 +58,6 @@ data class InfiniteQueryLoadingObject<T, S> internal constructor(
     override val staleAt: Long,
     override val fetchStatus: QueryFetchStatus,
     override val isInvalidated: Boolean,
-    override val isPlaceholderData: Boolean,
     override val refresh: suspend () -> Unit,
     override val loadMore: suspend (param: S) -> Unit,
     override val loadMoreParam: S?
@@ -83,7 +82,6 @@ data class InfiniteQueryLoadingErrorObject<T, S> internal constructor(
     override val staleAt: Long,
     override val fetchStatus: QueryFetchStatus,
     override val isInvalidated: Boolean,
-    override val isPlaceholderData: Boolean,
     override val refresh: suspend () -> Unit,
     override val loadMore: suspend (param: S) -> Unit,
     override val loadMoreParam: S?
@@ -108,7 +106,6 @@ data class InfiniteQuerySuccessObject<T, S> internal constructor(
     override val staleAt: Long,
     override val fetchStatus: QueryFetchStatus,
     override val isInvalidated: Boolean,
-    override val isPlaceholderData: Boolean,
     override val refresh: suspend () -> Unit,
     override val loadMore: suspend (param: S) -> Unit,
     override val loadMoreParam: S?
@@ -135,7 +132,6 @@ data class InfiniteQueryRefreshErrorObject<T, S> internal constructor(
     override val staleAt: Long,
     override val fetchStatus: QueryFetchStatus,
     override val isInvalidated: Boolean,
-    override val isPlaceholderData: Boolean,
     override val refresh: suspend () -> Unit,
     override val loadMore: suspend (param: S) -> Unit,
     override val loadMoreParam: S?

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
@@ -83,7 +83,6 @@ private fun <T, U> QueryState<T>.toObject(
             staleAt = staleAt,
             fetchStatus = fetchStatus,
             isInvalidated = isInvalidated,
-            isPlaceholderData = isPlaceholderData,
             refresh = query::invalidate
         )
 
@@ -95,7 +94,6 @@ private fun <T, U> QueryState<T>.toObject(
             staleAt = staleAt,
             fetchStatus = fetchStatus,
             isInvalidated = isInvalidated,
-            isPlaceholderData = isPlaceholderData,
             refresh = query::invalidate
         )
 
@@ -108,7 +106,6 @@ private fun <T, U> QueryState<T>.toObject(
                 staleAt = staleAt,
                 fetchStatus = fetchStatus,
                 isInvalidated = isInvalidated,
-                isPlaceholderData = isPlaceholderData,
                 refresh = query::invalidate
             )
         } else {
@@ -120,7 +117,6 @@ private fun <T, U> QueryState<T>.toObject(
                 errorUpdatedAt = errorUpdatedAt,
                 fetchStatus = fetchStatus,
                 isInvalidated = isInvalidated,
-                isPlaceholderData = isPlaceholderData,
                 refresh = query::invalidate
             )
         }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryObject.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryObject.kt
@@ -46,7 +46,6 @@ data class QueryLoadingObject<T> internal constructor(
     override val staleAt: Long,
     override val fetchStatus: QueryFetchStatus,
     override val isInvalidated: Boolean,
-    override val isPlaceholderData: Boolean,
     override val refresh: suspend () -> Unit
 ) : QueryObject<T> {
     override val status: QueryStatus = QueryStatus.Pending
@@ -67,7 +66,6 @@ data class QueryLoadingErrorObject<T> internal constructor(
     override val staleAt: Long,
     override val fetchStatus: QueryFetchStatus,
     override val isInvalidated: Boolean,
-    override val isPlaceholderData: Boolean,
     override val refresh: suspend () -> Unit
 ) : QueryObject<T> {
     override val status: QueryStatus = QueryStatus.Failure
@@ -88,7 +86,6 @@ data class QuerySuccessObject<T> internal constructor(
     override val staleAt: Long,
     override val fetchStatus: QueryFetchStatus,
     override val isInvalidated: Boolean,
-    override val isPlaceholderData: Boolean,
     override val refresh: suspend () -> Unit
 ) : QueryObject<T> {
     override val status: QueryStatus = QueryStatus.Success
@@ -112,7 +109,6 @@ data class QueryRefreshErrorObject<T> internal constructor(
     override val staleAt: Long,
     override val fetchStatus: QueryFetchStatus,
     override val isInvalidated: Boolean,
-    override val isPlaceholderData: Boolean,
     override val refresh: suspend () -> Unit
 ) : QueryObject<T> {
     override val status: QueryStatus = QueryStatus.Failure

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommands.kt
@@ -37,7 +37,7 @@ sealed class InfiniteQueryCommands<T, S> : QueryCommand<QueryChunks<T, S>> {
             }
             ctx.dispatch(QueryAction.Fetching())
             val chunks = ctx.state.reply.getOrNull()
-            if (chunks.isNullOrEmpty() || ctx.state.isPlaceholderData) {
+            if (chunks.isNullOrEmpty()) {
                 ctx.dispatchFetchChunksResult(key, key.initialParam(), callback)
             } else {
                 ctx.dispatchRevalidateChunksResult(key, chunks, callback)
@@ -66,7 +66,7 @@ sealed class InfiniteQueryCommands<T, S> : QueryCommand<QueryChunks<T, S>> {
             }
             ctx.dispatch(QueryAction.Fetching(isInvalidated = true))
             val chunks = ctx.state.reply.getOrNull()
-            if (chunks.isNullOrEmpty() || ctx.state.isPlaceholderData) {
+            if (chunks.isNullOrEmpty()) {
                 ctx.dispatchFetchChunksResult(key, key.initialParam(), callback)
             } else {
                 ctx.dispatchRevalidateChunksResult(key, chunks, callback)

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryKey.kt
@@ -48,15 +48,6 @@ interface InfiniteQueryKey<T, S> {
     fun onConfigureOptions(): QueryOptionsOverride? = null
 
     /**
-     * Function to specify placeholder data.
-     *
-     * You can specify placeholder data instead of the initial loading state.
-     *
-     * @see QueryPlaceholderData
-     */
-    fun onPlaceholderData(): QueryPlaceholderData<QueryChunks<T, S>>? = null
-
-    /**
      * Function to convert specific exceptions as data.
      *
      * Depending on the type of exception that occurred during data retrieval, it is possible to recover it as normal data.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryAction.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryAction.kt
@@ -88,8 +88,7 @@ fun <T> createQueryReducer(): QueryReducer<T> = { state, action ->
                 staleAt = action.dataStaleAt,
                 status = QueryStatus.Success,
                 fetchStatus = QueryFetchStatus.Idle,
-                isInvalidated = false,
-                isPlaceholderData = false
+                isInvalidated = false
             )
         }
 

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
@@ -48,7 +48,7 @@ interface QueryClient {
 /**
  * Interface for directly accessing retrieved [Query] data by [QueryClient].
  *
- * [QueryPlaceholderData] is designed to calculate initial data from other [Query].
+ * [QueryInitialData] is designed to calculate initial data from other [Query].
  * This is useful when the type included in the list on the overview screen matches the type of content on the detailed screen.
  */
 interface QueryReadonlyClient {
@@ -123,7 +123,7 @@ interface QueryMutableClient : QueryReadonlyClient {
     fun <U : UniqueId> resumeQueriesBy(vararg ids: U)
 }
 
-typealias QueryPlaceholderData<T> = QueryReadonlyClient.() -> T?
+typealias QueryInitialData<T> = QueryReadonlyClient.() -> T?
 typealias QueryEffect = QueryMutableClient.() -> Unit
 
 typealias QueryRecoverData<T> = (error: Throwable) -> T

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommand.kt
@@ -51,7 +51,6 @@ fun <T> QueryCommand.Context<T>.shouldFetch(revision: String? = null): Boolean {
         return false
     }
     return state.isInvalidated
-        || state.isPlaceholderData
         || state.isPending
         || state.isStaled()
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
@@ -39,21 +39,21 @@ interface QueryKey<T> {
     fun onConfigureOptions(): QueryOptionsOverride? = null
 
     /**
-     * Function to specify placeholder data.
+     * Function to specify initial data.
      *
-     * You can specify placeholder data instead of the initial loading state.
+     * You can specify initial data instead of the initial loading state.
      *
      * ```kotlin
-     * override fun onPlaceholderData(): QueryPlaceholderData<User> = {
+     * override fun onInitialData(): QueryInitialData<User> = {
      *     getInfiniteQueryData(GetUsersKey.Id())?.let {
      *         it.chunkedData.firstOrNull { user -> user.id == userId }
      *     }
      * }
      * ```
      *
-     * @see QueryPlaceholderData
+     * @see QueryInitialData
      */
-    fun onPlaceholderData(): QueryPlaceholderData<T>? = null
+    fun onInitialData(): QueryInitialData<T>? = null
 
     /**
      * Function to convert specific exceptions as data.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryModel.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryModel.kt
@@ -37,11 +37,6 @@ interface QueryModel<out T> : DataModel<T> {
     val isInvalidated: Boolean
 
     /**
-     * Returns `true` if the query is placeholder data, `false` otherwise.
-     */
-    val isPlaceholderData: Boolean
-
-    /**
      * The revision of the currently snapshot.
      */
     val revision: String get() = "d-$replyUpdatedAt/e-$errorUpdatedAt"

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryState.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryState.kt
@@ -17,8 +17,7 @@ data class QueryState<T> internal constructor(
     override val staleAt: Long = 0,
     override val status: QueryStatus = QueryStatus.Pending,
     override val fetchStatus: QueryFetchStatus = QueryFetchStatus.Idle,
-    override val isInvalidated: Boolean = false,
-    override val isPlaceholderData: Boolean = false
+    override val isInvalidated: Boolean = false
 ) : QueryModel<T> {
 
     /**


### PR DESCRIPTION
I have renamed `onPlaceholderData` to `onInitialData` and shifted its role to that of an initial data set. We have decided to redesign the placeholder to be applied on a component basis in the future.

## Background

In the TanStack Query, which we reference as a benchmark, it is designed to be used differently according to the application.

- [Initial Query Data](https://tanstack.com/query/latest/docs/framework/react/guides/initial-query-data)
- [Placeholder Query Data](https://tanstack.com/query/latest/docs/framework/react/guides/placeholder-query-data)

The `onPlaceholderData` implemented in Soil Query did not align perfectly with either, having a position somewhat in between. From a usability perspective, it was deemed preferable to align the role more closely with Initial Query Data, and to prepare a new implementation for the placeholder.

| Feature                     | Scope                             | Cache |
|-----------------------------|-----------------------------------|-------|
| Soil -  onPlaceholderData   | cache level                            | skip  |
| TanStack -  initialData     | cache level       | save  |
| TanStack -  placeholderData | observer level                    | -  |
