### PR TITLE
Implements the QueryCachingStrategy

### DIFF
--- a/soil-query-compose/build.gradle.kts
+++ b/soil-query-compose/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
         commonMain.dependencies {
             api(projects.soilQueryCore)
             implementation(compose.runtime)
+            implementation(compose.runtimeSaveable)
         }
 
         commonTest.dependencies {

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
@@ -34,9 +34,7 @@ fun <T, S> rememberMutation(
     val scope = rememberCoroutineScope()
     val mutation = remember(key) { client.getMutation(key).also { it.launchIn(scope) } }
     val state by mutation.state.collectAsState()
-    return remember(mutation, state) {
-        state.toObject(mutation = mutation)
-    }
+    return state.toObject(mutation = mutation)
 }
 
 private fun <T, S> MutationState<T>.toObject(

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryCachingStrategy.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryCachingStrategy.kt
@@ -1,0 +1,151 @@
+package soil.query.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.flow.StateFlow
+import soil.query.InfiniteQueryRef
+import soil.query.QueryChunks
+import soil.query.QueryRef
+import soil.query.QueryState
+import soil.query.annotation.ExperimentalSoilQueryApi
+import soil.query.core.UniqueId
+import soil.query.core.isNone
+import soil.query.resume
+
+/**
+ * A mechanism to finely adjust the behavior of the query results on a component basis in Composable functions.
+ *
+ * In addition to the default behavior provided by Stale-While-Revalidate, two experimental strategies are now available:
+ *
+ * 1. Cache-First:
+ *  This strategy avoids requesting data re-fetch as long as valid cached data is available.
+ *  It prioritizes using the cached data over network requests.
+ *
+ * 2. Network-First:
+ *  This strategy maintains the initial loading state until data is re-fetched, regardless of the presence of valid cached data.
+ *  This ensures that the most up-to-date data is always displayed.
+ *
+ * If you want to customize further, please create a class implementing [QueryCachingStrategy].
+ * However, as this is an experimental API, the interface may change significantly in future versions.
+ *
+ * In future updates, we plan to provide additional options for more granular control over the behavior at the component level.
+ *
+ * Background:
+ * During in-app development, there are scenarios where returning cached data first can lead to issues.
+ * For example, if the externally updated data state is not accurately reflected on the screen, inconsistencies can occur.
+ * This is particularly problematic in processes that automatically redirect to other screens based on the data state.
+ *
+ * On the other hand, there are situations where data re-fetching should be suppressed to minimize data traffic.
+ * In such cases, setting a long staleTime in QueryOptions is not sufficient, as specific conditions for reducing data traffic may persist.
+ */
+@Stable
+interface QueryCachingStrategy {
+    @Composable
+    fun <T> collectAsState(query: QueryRef<T>): QueryState<T>
+
+    @Composable
+    fun <T, S> collectAsState(query: InfiniteQueryRef<T, S>): QueryState<QueryChunks<T, S>>
+
+    companion object Default : QueryCachingStrategy by StaleWhileRevalidate {
+
+        @Suppress("FunctionName")
+        @ExperimentalSoilQueryApi
+        fun CacheFirst(): QueryCachingStrategy = CacheFirst
+
+        @Suppress("FunctionName")
+        @ExperimentalSoilQueryApi
+        fun NetworkFirst(): QueryCachingStrategy = NetworkFirst
+    }
+}
+
+@Stable
+private object StaleWhileRevalidate : QueryCachingStrategy {
+    @Composable
+    override fun <T> collectAsState(query: QueryRef<T>): QueryState<T> {
+        return collectAsState(key = query.key.id, flow = query.state, resume = query::resume)
+    }
+
+    @Composable
+    override fun <T, S> collectAsState(query: InfiniteQueryRef<T, S>): QueryState<QueryChunks<T, S>> {
+        return collectAsState(key = query.key.id, flow = query.state, resume = query::resume)
+    }
+
+    @Composable
+    private inline fun <T> collectAsState(
+        key: UniqueId,
+        flow: StateFlow<QueryState<T>>,
+        crossinline resume: suspend () -> Unit
+    ): QueryState<T> {
+        val state by flow.collectAsState()
+        LaunchedEffect(key) {
+            resume()
+        }
+        return state
+    }
+}
+
+
+@Stable
+private object CacheFirst : QueryCachingStrategy {
+    @Composable
+    override fun <T> collectAsState(query: QueryRef<T>): QueryState<T> {
+        return collectAsState(query.key.id, query.state, query::resume)
+    }
+
+    @Composable
+    override fun <T, S> collectAsState(query: InfiniteQueryRef<T, S>): QueryState<QueryChunks<T, S>> {
+        return collectAsState(query.key.id, query.state, query::resume)
+    }
+
+    @Composable
+    private inline fun <T> collectAsState(
+        key: UniqueId,
+        flow: StateFlow<QueryState<T>>,
+        crossinline resume: suspend () -> Unit
+    ): QueryState<T> {
+        val state by flow.collectAsState()
+        LaunchedEffect(key) {
+            val currentValue = flow.value
+            if (currentValue.reply.isNone || currentValue.isInvalidated) {
+                resume()
+            }
+        }
+        return state
+    }
+}
+
+@Stable
+private object NetworkFirst : QueryCachingStrategy {
+    @Composable
+    override fun <T> collectAsState(query: QueryRef<T>): QueryState<T> {
+        return collectAsState(query.key.id, query.state, query::resume)
+    }
+
+    @Composable
+    override fun <T, S> collectAsState(query: InfiniteQueryRef<T, S>): QueryState<QueryChunks<T, S>> {
+        return collectAsState(query.key.id, query.state, query::resume)
+    }
+
+    @Composable
+    private inline fun <T> collectAsState(
+        key: UniqueId,
+        flow: StateFlow<QueryState<T>>,
+        crossinline resume: suspend () -> Unit
+    ): QueryState<T> {
+        var resumed by rememberSaveable(key) { mutableStateOf(false) }
+        val initialValue = if (resumed) flow.value else QueryState.initial()
+        val state = produceState(initialValue, key) {
+            resume()
+            resumed = true
+            flow.collect { value = it }
+        }
+        return state.value
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryCachingStrategy.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryCachingStrategy.kt
@@ -1,3 +1,6 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package soil.query.compose
 
 import androidx.compose.runtime.Composable

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationState.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationState.kt
@@ -20,6 +20,13 @@ data class MutationState<T> internal constructor(
     companion object {
 
         /**
+         * Creates a new [MutationState] with the [MutationStatus.Idle] status.
+         */
+        fun <T> initial(): MutationState<T> {
+            return MutationState()
+        }
+
+        /**
          * Creates a new [MutationState] with the [MutationStatus.Success] status.
          *
          * @param data The data to be stored in the state.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryRef.kt
@@ -3,8 +3,11 @@
 
 package soil.query
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.completeWith
 import kotlinx.coroutines.flow.StateFlow
 import soil.query.core.Actor
+import soil.query.core.awaitOrNull
 
 /**
  * A reference to an Query for [QueryKey].
@@ -30,12 +33,16 @@ interface QueryRef<T> : Actor {
  * setting [QueryModel.isInvalidated] to `true` until revalidation is completed.
  */
 suspend fun <T> QueryRef<T>.invalidate() {
-    send(QueryCommands.Invalidate(key, state.value.revision))
+    val deferred = CompletableDeferred<T>()
+    send(QueryCommands.Invalidate(key, state.value.revision, deferred::completeWith))
+    deferred.awaitOrNull()
 }
 
 /**
  * Resumes the Query.
  */
 suspend fun <T> QueryRef<T>.resume() {
-    send(QueryCommands.Connect(key, state.value.revision))
+    val deferred = CompletableDeferred<T>()
+    send(QueryCommands.Connect(key, state.value.revision, deferred::completeWith))
+    deferred.awaitOrNull()
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryState.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryState.kt
@@ -37,6 +37,13 @@ data class QueryState<T> internal constructor(
     companion object {
 
         /**
+         * Creates a new [QueryState] with the [QueryStatus.Pending] status.
+         */
+        fun <T> initial(): QueryState<T> {
+            return QueryState()
+        }
+
+        /**
          * Creates a new [QueryState] with the [QueryStatus.Success] status.
          *
          * @param data The data to be stored in the state.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCache.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCache.kt
@@ -392,7 +392,7 @@ class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutableClie
         return coroutineScope.launch {
             try {
                 withTimeoutOrNull(query.options.prefetchWindowTime) {
-                    query.prefetch()
+                    query.resume()
                 }
             } finally {
                 scope.cancel()
@@ -406,7 +406,7 @@ class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutableClie
         return coroutineScope.launch {
             try {
                 withTimeoutOrNull(query.options.prefetchWindowTime) {
-                    query.prefetch()
+                    query.resume()
                 }
             } finally {
                 scope.cancel()

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrInfiniteQuery.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrInfiniteQuery.kt
@@ -3,11 +3,8 @@
 
 package soil.query
 
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.completeWith
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
@@ -36,21 +33,5 @@ internal class SwrInfiniteQuery<T, S>(
             QueryEvent.Invalidate -> invalidate()
             QueryEvent.Resume -> resume()
         }
-    }
-}
-
-/**
- * Prefetches the Query.
- */
-internal suspend fun <T, S> InfiniteQueryRef<T, S>.prefetch(): Boolean {
-    val deferred = CompletableDeferred<QueryChunks<T, S>>()
-    send(InfiniteQueryCommands.Connect(key, state.value.revision, deferred::completeWith))
-    return try {
-        deferred.await()
-        true
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Throwable) {
-        false
     }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrQuery.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrQuery.kt
@@ -3,13 +3,10 @@
 
 package soil.query
 
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.completeWith
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlin.coroutines.cancellation.CancellationException
 
 internal class SwrQuery<T>(
     override val key: QueryKey<T>,
@@ -36,21 +33,5 @@ internal class SwrQuery<T>(
             QueryEvent.Invalidate -> invalidate()
             QueryEvent.Resume -> resume()
         }
-    }
-}
-
-/**
- * Prefetches the Query.
- */
-internal suspend fun <T> QueryRef<T>.prefetch(): Boolean {
-    val deferred = CompletableDeferred<T>()
-    send(QueryCommands.Connect(key, state.value.revision, deferred::completeWith))
-    return try {
-        deferred.await()
-        true
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Throwable) {
-        false
     }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/annotation/ExperimentalSoilQueryApi.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/annotation/ExperimentalSoilQueryApi.kt
@@ -1,0 +1,12 @@
+package soil.query.annotation
+
+@RequiresOptIn(message = "This API is experimental. It may be changed in the future without notice.")
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.TYPEALIAS,
+    AnnotationTarget.CONSTRUCTOR
+)
+annotation class ExperimentalSoilQueryApi

--- a/soil-query-core/src/commonMain/kotlin/soil/query/annotation/ExperimentalSoilQueryApi.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/annotation/ExperimentalSoilQueryApi.kt
@@ -1,3 +1,6 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package soil.query.annotation
 
 @RequiresOptIn(message = "This API is experimental. It may be changed in the future without notice.")

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/CoroutineExt.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/CoroutineExt.kt
@@ -3,6 +3,7 @@
 
 package soil.query.core
 
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.coroutineScope
@@ -57,5 +58,16 @@ internal fun <T> Flow<T>.chunkedWithTimeout(
                 tickerTimeout.cancel()
             }
         }
+    }
+}
+
+/**
+ * Returns null if an exception, including cancellation, occurs.
+ */
+internal suspend fun <T> Deferred<T>.awaitOrNull(): T? {
+    return try {
+        await()
+    } catch (e: Throwable) {
+        null
     }
 }


### PR DESCRIPTION
In addition to the default behavior provided by Stale-While-Revalidate, two experimental strategies are now available:

1. Cache-First: This strategy avoids requesting data re-fetch as long as valid cached data is available. It prioritizes using the cached data over network requests.

2. Network-First: This strategy maintains the initial loading state until data is re-fetched, regardless of the presence of valid cached data. This ensures that the most up-to-date data is always displayed.

To further customize the behavior, developers can create a class that implements the `QueryCachingStrategy` interface. However, please note that the experimental nature of this API means that the interface may undergo significant changes in future versions.

In future updates, we plan to provide additional options for more granular control over the behavior at the component level.