### PR TITLE
Add preview clients

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
@@ -1,0 +1,51 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.tooling
+
+import androidx.compose.runtime.Stable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import soil.query.MutationClient
+import soil.query.MutationCommand
+import soil.query.MutationKey
+import soil.query.MutationOptions
+import soil.query.MutationRef
+import soil.query.MutationState
+import soil.query.core.UniqueId
+
+/**
+ * Usage:
+ * ```kotlin
+ * val client = MutationPreviewClient(
+ *   previewData = mapOf(
+ *      MyMutationId to MutationState.success("data"),
+ *      ..
+ *   )
+ * )
+ * ```
+ */
+@Stable
+class MutationPreviewClient(
+    private val previewData: Map<UniqueId, MutationState<*>>,
+    override val defaultMutationOptions: MutationOptions = MutationOptions
+) : MutationClient {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T, S> getMutation(key: MutationKey<T, S>): MutationRef<T, S> {
+        val state = previewData[key.id] as? MutationState<T> ?: MutationState.initial()
+        val options = key.onConfigureOptions()?.invoke(defaultMutationOptions) ?: defaultMutationOptions
+        return SnapshotMutation(key, options, MutableStateFlow(state))
+    }
+
+    private class SnapshotMutation<T, S>(
+        override val key: MutationKey<T, S>,
+        override val options: MutationOptions,
+        override val state: StateFlow<MutationState<T>>
+    ) : MutationRef<T, S> {
+        override fun launchIn(scope: CoroutineScope): Job = Job()
+        override suspend fun send(command: MutationCommand<T>) = Unit
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
@@ -1,0 +1,74 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.tooling
+
+import androidx.compose.runtime.Stable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import soil.query.InfiniteQueryKey
+import soil.query.InfiniteQueryRef
+import soil.query.QueryChunks
+import soil.query.QueryClient
+import soil.query.QueryCommand
+import soil.query.QueryKey
+import soil.query.QueryOptions
+import soil.query.QueryRef
+import soil.query.QueryState
+import soil.query.core.UniqueId
+
+/**
+ * Usage:
+ * ```kotlin
+ * val client = QueryPreviewClient(
+ *   previewData = mapOf(
+ *      MyQueryId to QueryState.success("data"),
+ *      ..
+ *   )
+ * )
+ * ```
+ */
+@Stable
+class QueryPreviewClient(
+    private val previewData: Map<UniqueId, QueryState<*>>,
+    override val defaultQueryOptions: QueryOptions = QueryOptions
+) : QueryClient {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getQuery(key: QueryKey<T>): QueryRef<T> {
+        val state = previewData[key.id] as? QueryState<T> ?: QueryState.initial()
+        val options = key.onConfigureOptions()?.invoke(defaultQueryOptions) ?: defaultQueryOptions
+        return SnapshotQuery(key, options, MutableStateFlow(state))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T, S> getInfiniteQuery(key: InfiniteQueryKey<T, S>): InfiniteQueryRef<T, S> {
+        val state = previewData[key.id] as? QueryState<QueryChunks<T, S>> ?: QueryState.initial()
+        val options = key.onConfigureOptions()?.invoke(defaultQueryOptions) ?: defaultQueryOptions
+        return SnapshotInfiniteQuery(key, options, MutableStateFlow(state))
+    }
+
+    override fun <T> prefetchQuery(key: QueryKey<T>): Job = Job()
+
+    override fun <T, S> prefetchInfiniteQuery(key: InfiniteQueryKey<T, S>): Job = Job()
+
+    private class SnapshotQuery<T>(
+        override val key: QueryKey<T>,
+        override val options: QueryOptions,
+        override val state: StateFlow<QueryState<T>>
+    ) : QueryRef<T> {
+        override fun launchIn(scope: CoroutineScope): Job = Job()
+        override suspend fun send(command: QueryCommand<T>) = Unit
+    }
+
+    private class SnapshotInfiniteQuery<T, S>(
+        override val key: InfiniteQueryKey<T, S>,
+        override val options: QueryOptions,
+        override val state: StateFlow<QueryState<QueryChunks<T, S>>>
+    ) : InfiniteQueryRef<T, S> {
+        override fun launchIn(scope: CoroutineScope): Job = Job()
+        override suspend fun send(command: QueryCommand<QueryChunks<T, S>>) = Unit
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SwrPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SwrPreviewClient.kt
@@ -1,0 +1,35 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.tooling
+
+import androidx.compose.runtime.Stable
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import soil.query.MutationClient
+import soil.query.QueryClient
+import soil.query.QueryEffect
+import soil.query.SwrClient
+import soil.query.core.ErrorRecord
+
+/**
+ * Provides the ability to preview specific queries and mutations for composable previews.
+ *
+ * ```
+ * val client = SwrPreviewClient(..)
+ * SwrClientProvider(client = client) {
+ *   // Composable previews
+ * }
+ * ```
+ */
+@Stable
+class SwrPreviewClient(
+    queryPreviewClient: QueryPreviewClient = QueryPreviewClient(emptyMap()),
+    mutationPreviewClient: MutationPreviewClient = MutationPreviewClient(emptyMap()),
+    override val errorRelay: Flow<ErrorRecord> = flow { }
+) : SwrClient, QueryClient by queryPreviewClient, MutationClient by mutationPreviewClient {
+    override fun perform(sideEffects: QueryEffect): Job = Job()
+    override fun onMount(id: String) = Unit
+    override fun onUnmount(id: String) = Unit
+}


### PR DESCRIPTION
Provides the ability to preview specific queries and mutations for composable previews.