### PR TITLE
Refactor Command Type for Simplicity

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import soil.query.InfiniteQueryCommand
 import soil.query.InfiniteQueryKey
 import soil.query.InfiniteQueryRef
 import soil.query.QueryChunks
@@ -69,6 +70,6 @@ class QueryPreviewClient(
         override val state: StateFlow<QueryState<QueryChunks<T, S>>>
     ) : InfiniteQueryRef<T, S> {
         override fun launchIn(scope: CoroutineScope): Job = Job()
-        override suspend fun send(command: QueryCommand<QueryChunks<T, S>>) = Unit
+        override suspend fun send(command: InfiniteQueryCommand<T, S>) = Unit
     }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommand.kt
@@ -9,6 +9,14 @@ import soil.query.core.getOrElse
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
+ * Query command for [InfiniteQueryKey].
+ *
+ * @param T Type of data to retrieve.
+ * @param S Type of parameter.
+ */
+interface InfiniteQueryCommand<T, S> : QueryCommand<QueryChunks<T, S>>
+
+/**
  * Fetches data for the [InfiniteQueryKey] using the value of [variable].
  *
  * @receiver [QueryCommand.Context] for [InfiniteQueryKey].

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommands.kt
@@ -8,13 +8,7 @@ import soil.query.core.getOrNull
 import soil.query.core.vvv
 import kotlin.coroutines.cancellation.CancellationException
 
-/**
- * Query command for [InfiniteQueryKey].
- *
- * @param T Type of data to retrieve.
- * @param S Type of parameter.
- */
-sealed class InfiniteQueryCommands<T, S> : QueryCommand<QueryChunks<T, S>> {
+object InfiniteQueryCommands {
 
     /**
      * Performs data fetching and validation based on the current data state.
@@ -24,11 +18,11 @@ sealed class InfiniteQueryCommands<T, S> : QueryCommand<QueryChunks<T, S>> {
      * @param key Instance of a class implementing [InfiniteQueryKey].
      * @param revision The revision of the data to be fetched.
      */
-    data class Connect<T, S>(
+    class Connect<T, S>(
         val key: InfiniteQueryKey<T, S>,
         val revision: String? = null,
         val callback: QueryCallback<QueryChunks<T, S>>? = null
-    ) : InfiniteQueryCommands<T, S>() {
+    ) : InfiniteQueryCommand<T, S> {
         override suspend fun handle(ctx: QueryCommand.Context<QueryChunks<T, S>>) {
             if (!ctx.shouldFetch(revision)) {
                 ctx.options.vvv(key.id) { "skip fetch(shouldFetch=false)" }
@@ -53,11 +47,11 @@ sealed class InfiniteQueryCommands<T, S> : QueryCommand<QueryChunks<T, S>> {
      * @param key Instance of a class implementing [InfiniteQueryKey].
      * @param revision The revision of the data to be invalidated.
      */
-    data class Invalidate<T, S>(
+    class Invalidate<T, S>(
         val key: InfiniteQueryKey<T, S>,
         val revision: String,
         val callback: QueryCallback<QueryChunks<T, S>>? = null
-    ) : InfiniteQueryCommands<T, S>() {
+    ) : InfiniteQueryCommand<T, S> {
         override suspend fun handle(ctx: QueryCommand.Context<QueryChunks<T, S>>) {
             if (ctx.state.revision != revision) {
                 ctx.options.vvv(key.id) { "skip fetch(revision is not matched)" }
@@ -80,11 +74,11 @@ sealed class InfiniteQueryCommands<T, S> : QueryCommand<QueryChunks<T, S>> {
      * @param key Instance of a class implementing [InfiniteQueryKey].
      * @param param The parameter required for fetching data for [InfiniteQueryKey].
      */
-    data class LoadMore<T, S>(
+    class LoadMore<T, S>(
         val key: InfiniteQueryKey<T, S>,
         val param: S,
         val callback: QueryCallback<QueryChunks<T, S>>? = null
-    ) : InfiniteQueryCommands<T, S>() {
+    ) : InfiniteQueryCommand<T, S> {
         override suspend fun handle(ctx: QueryCommand.Context<QueryChunks<T, S>>) {
             val chunks = ctx.state.reply.getOrElse { emptyList() }
             if (param != key.loadMoreParam(chunks)) {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryRef.kt
@@ -24,7 +24,7 @@ interface InfiniteQueryRef<T, S> : Actor {
     /**
      * Sends a [QueryCommand] to the Actor.
      */
-    suspend fun send(command: QueryCommand<QueryChunks<T, S>>)
+    suspend fun send(command: InfiniteQueryCommand<T, S>)
 }
 
 /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationCommands.kt
@@ -6,12 +6,7 @@ package soil.query
 import soil.query.core.vvv
 import kotlin.coroutines.cancellation.CancellationException
 
-/**
- * Mutation commands are used to update the [mutation state][MutationState].
- *
- * @param T Type of the return value from the mutation.
- */
-sealed class MutationCommands<T> : MutationCommand<T> {
+object MutationCommands {
 
     /**
      * Executes the [mutate][MutationKey.mutate] function of the specified [MutationKey].
@@ -22,12 +17,12 @@ sealed class MutationCommands<T> : MutationCommand<T> {
      * @param variable The variable to be mutated.
      * @param revision The revision of the mutation state.
      */
-    data class Mutate<T, S>(
+    class Mutate<T, S>(
         val key: MutationKey<T, S>,
         val variable: S,
         val revision: String,
         val callback: MutationCallback<T>? = null
-    ) : MutationCommands<T>() {
+    ) : MutationCommand<T> {
 
         override suspend fun handle(ctx: MutationCommand.Context<T>) {
             if (!ctx.shouldMutate(revision)) {
@@ -43,7 +38,7 @@ sealed class MutationCommands<T> : MutationCommand<T> {
     /**
      * Resets the mutation state.
      */
-    class Reset<T> : MutationCommands<T>() {
+    class Reset<T> : MutationCommand<T> {
 
         override suspend fun handle(ctx: MutationCommand.Context<T>) {
             ctx.dispatch(MutationAction.Reset)

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommands.kt
@@ -6,12 +6,7 @@ package soil.query
 import soil.query.core.vvv
 import kotlin.coroutines.cancellation.CancellationException
 
-/**
- * Query command for [QueryKey].
- *
- * @param T Type of data to retrieve.
- */
-sealed class QueryCommands<T> : QueryCommand<T> {
+object QueryCommands {
 
     /**
      * Performs data fetching and validation based on the current data state.
@@ -21,11 +16,11 @@ sealed class QueryCommands<T> : QueryCommand<T> {
      * @param key Instance of a class implementing [QueryKey].
      * @param revision The revision of the data to be fetched.
      */
-    data class Connect<T>(
+    class Connect<T>(
         val key: QueryKey<T>,
         val revision: String? = null,
         val callback: QueryCallback<T>? = null
-    ) : QueryCommands<T>() {
+    ) : QueryCommand<T> {
 
         override suspend fun handle(ctx: QueryCommand.Context<T>) {
             if (!ctx.shouldFetch(revision)) {
@@ -46,11 +41,11 @@ sealed class QueryCommands<T> : QueryCommand<T> {
      * @param key Instance of a class implementing [QueryKey].
      * @param revision The revision of the data to be invalidated.
      */
-    data class Invalidate<T>(
+    class Invalidate<T>(
         val key: QueryKey<T>,
         val revision: String,
         val callback: QueryCallback<T>? = null
-    ) : QueryCommands<T>() {
+    ) : QueryCommand<T> {
 
         override suspend fun handle(ctx: QueryCommand.Context<T>) {
             if (ctx.state.revision != revision) {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrInfiniteQuery.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrInfiniteQuery.kt
@@ -24,7 +24,7 @@ internal class SwrInfiniteQuery<T, S>(
         }
     }
 
-    override suspend fun send(command: QueryCommand<QueryChunks<T, S>>) {
+    override suspend fun send(command: InfiniteQueryCommand<T, S>) {
         query.command.send(command)
     }
 


### PR DESCRIPTION
The following changes were made:

- The Commands type is now an object that aggregates Command types.
- Defined the interface for each Command type. (InfiniteQueryCommand)
- Changed from data class to class definition.