### PR TITLE
Revert `XxxRef` from Extension Function to Interface Function

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
@@ -15,8 +15,6 @@ import soil.query.QueryStatus
 import soil.query.core.getOrThrow
 import soil.query.core.isNone
 import soil.query.core.map
-import soil.query.invalidate
-import soil.query.loadMore
 
 /**
  * Remember a [InfiniteQueryObject] and subscribes to the query state of [key].

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
@@ -13,9 +13,6 @@ import soil.query.MutationKey
 import soil.query.MutationRef
 import soil.query.MutationState
 import soil.query.MutationStatus
-import soil.query.mutate
-import soil.query.mutateAsync
-import soil.query.reset
 
 /**
  * Remember a [MutationObject] and subscribes to the mutation state of [key].

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryCachingStrategy.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryCachingStrategy.kt
@@ -20,7 +20,6 @@ import soil.query.QueryState
 import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.core.UniqueId
 import soil.query.core.isNone
-import soil.query.resume
 
 /**
  * A mechanism to finely adjust the behavior of the query results on a component basis in Composable functions.

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
@@ -13,7 +13,6 @@ import soil.query.QueryState
 import soil.query.QueryStatus
 import soil.query.core.isNone
 import soil.query.core.map
-import soil.query.invalidate
 
 /**
  * Remember a [QueryObject] and subscribes to the query state of [key].

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
@@ -62,6 +62,8 @@ class QueryPreviewClient(
     ) : QueryRef<T> {
         override fun launchIn(scope: CoroutineScope): Job = Job()
         override suspend fun send(command: QueryCommand<T>) = Unit
+        override suspend fun resume() = Unit
+        override suspend fun invalidate() = Unit
     }
 
     private class SnapshotInfiniteQuery<T, S>(
@@ -71,5 +73,8 @@ class QueryPreviewClient(
     ) : InfiniteQueryRef<T, S> {
         override fun launchIn(scope: CoroutineScope): Job = Job()
         override suspend fun send(command: InfiniteQueryCommand<T, S>) = Unit
+        override suspend fun resume() = Unit
+        override suspend fun loadMore(param: S) = Unit
+        override suspend fun invalidate() = Unit
     }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryRef.kt
@@ -25,34 +25,34 @@ interface InfiniteQueryRef<T, S> : Actor {
      * Sends a [QueryCommand] to the Actor.
      */
     suspend fun send(command: InfiniteQueryCommand<T, S>)
-}
 
-/**
- * Invalidates the Query.
- *
- * Calling this function will invalidate the retrieved data of the Query,
- * setting [QueryModel.isInvalidated] to `true` until revalidation is completed.
- */
-suspend fun <T, S> InfiniteQueryRef<T, S>.invalidate() {
-    val deferred = CompletableDeferred<QueryChunks<T, S>>()
-    send(InfiniteQueryCommands.Invalidate(key, state.value.revision, deferred::completeWith))
-    deferred.awaitOrNull()
-}
+    /**
+     * Resumes the Query.
+     */
+    suspend fun resume() {
+        val deferred = CompletableDeferred<QueryChunks<T, S>>()
+        send(InfiniteQueryCommands.Connect(key, state.value.revision, deferred::completeWith))
+        deferred.awaitOrNull()
+    }
 
-/**
- * Resumes the Query.
- */
-suspend fun <T, S> InfiniteQueryRef<T, S>.resume() {
-    val deferred = CompletableDeferred<QueryChunks<T, S>>()
-    send(InfiniteQueryCommands.Connect(key, state.value.revision, deferred::completeWith))
-    deferred.awaitOrNull()
-}
+    /**
+     * Fetches data for the [InfiniteQueryKey] using the value of [param].
+     */
+    suspend fun loadMore(param: S) {
+        val deferred = CompletableDeferred<QueryChunks<T, S>>()
+        send(InfiniteQueryCommands.LoadMore(key, param, deferred::completeWith))
+        deferred.awaitOrNull()
+    }
 
-/**
- * Fetches data for the [InfiniteQueryKey] using the value of [param].
- */
-suspend fun <T, S> InfiniteQueryRef<T, S>.loadMore(param: S) {
-    val deferred = CompletableDeferred<QueryChunks<T, S>>()
-    send(InfiniteQueryCommands.LoadMore(key, param, deferred::completeWith))
-    deferred.awaitOrNull()
+    /**
+     * Invalidates the Query.
+     *
+     * Calling this function will invalidate the retrieved data of the Query,
+     * setting [QueryModel.isInvalidated] to `true` until revalidation is completed.
+     */
+    suspend fun invalidate() {
+        val deferred = CompletableDeferred<QueryChunks<T, S>>()
+        send(InfiniteQueryCommands.Invalidate(key, state.value.revision, deferred::completeWith))
+        deferred.awaitOrNull()
+    }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationRef.kt
@@ -24,32 +24,32 @@ interface MutationRef<T, S> : Actor {
      * Sends a [MutationCommand] to the Actor.
      */
     suspend fun send(command: MutationCommand<T>)
-}
 
-/**
- * Mutates the variable.
- *
- * @param variable The variable to be mutated.
- * @return The result of the mutation.
- */
-suspend fun <T, S> MutationRef<T, S>.mutate(variable: S): T {
-    val deferred = CompletableDeferred<T>()
-    send(MutationCommands.Mutate(key, variable, state.value.revision, deferred::completeWith))
-    return deferred.await()
-}
+    /**
+     * Mutates the variable.
+     *
+     * @param variable The variable to be mutated.
+     * @return The result of the mutation.
+     */
+    suspend fun mutate(variable: S): T {
+        val deferred = CompletableDeferred<T>()
+        send(MutationCommands.Mutate(key, variable, state.value.revision, deferred::completeWith))
+        return deferred.await()
+    }
 
-/**
- * Mutates the variable asynchronously.
- *
- * @param variable The variable to be mutated.
- */
-suspend fun <T, S> MutationRef<T, S>.mutateAsync(variable: S) {
-    send(MutationCommands.Mutate(key, variable, state.value.revision))
-}
+    /**
+     * Mutates the variable asynchronously.
+     *
+     * @param variable The variable to be mutated.
+     */
+    suspend fun mutateAsync(variable: S) {
+        send(MutationCommands.Mutate(key, variable, state.value.revision))
+    }
 
-/**
- * Resets the mutation state.
- */
-suspend fun <T, S> MutationRef<T, S>.reset() {
-    send(MutationCommands.Reset())
+    /**
+     * Resets the mutation state.
+     */
+    suspend fun reset() {
+        send(MutationCommands.Reset())
+    }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryRef.kt
@@ -24,25 +24,25 @@ interface QueryRef<T> : Actor {
      * Sends a [QueryCommand] to the Actor.
      */
     suspend fun send(command: QueryCommand<T>)
-}
 
-/**
- * Invalidates the Query.
- *
- * Calling this function will invalidate the retrieved data of the Query,
- * setting [QueryModel.isInvalidated] to `true` until revalidation is completed.
- */
-suspend fun <T> QueryRef<T>.invalidate() {
-    val deferred = CompletableDeferred<T>()
-    send(QueryCommands.Invalidate(key, state.value.revision, deferred::completeWith))
-    deferred.awaitOrNull()
-}
+    /**
+     * Resumes the Query.
+     */
+    suspend fun resume() {
+        val deferred = CompletableDeferred<T>()
+        send(QueryCommands.Connect(key, state.value.revision, deferred::completeWith))
+        deferred.awaitOrNull()
+    }
 
-/**
- * Resumes the Query.
- */
-suspend fun <T> QueryRef<T>.resume() {
-    val deferred = CompletableDeferred<T>()
-    send(QueryCommands.Connect(key, state.value.revision, deferred::completeWith))
-    deferred.awaitOrNull()
+    /**
+     * Invalidates the Query.
+     *
+     * Calling this function will invalidate the retrieved data of the Query,
+     * setting [QueryModel.isInvalidated] to `true` until revalidation is completed.
+     */
+    suspend fun invalidate() {
+        val deferred = CompletableDeferred<T>()
+        send(QueryCommands.Invalidate(key, state.value.revision, deferred::completeWith))
+        deferred.awaitOrNull()
+    }
 }


### PR DESCRIPTION
We reverted the `XxxRef` implementation from an extension function back to an interface-based function due to unexpected behavior when combining `PreviewClient` for Compose with `QueryCachingStrategy.NetworkFirst`. By reverting to an interface-based function, PreviewClient can handle the `resume` function properly, ensuring expected behavior across all combinations.

https://github.com/soil-kt/soil/blob/14f9c21eacefa703ace64b16b205aeca9aa5c342/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryCachingStrategy.kt#L148

refs: #70
