### PR TITLE
Use a companion object to `QueryId` and `InfiniteQueryId`

### DIFF
--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/albums/GetAlbumPhotosKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/albums/GetAlbumPhotosKey.kt
@@ -10,7 +10,7 @@ import soil.query.InfiniteQueryKey
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
 class GetAlbumPhotosKey(albumId: Int) : InfiniteQueryKey<Photos, PageParam> by buildKtorInfiniteQueryKey(
-    id = Id(albumId),
+    id = InfiniteQueryId.forGetAlbumPhotos(albumId),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/albums/$albumId/photos") {
             parameter("_start", param.offset)
@@ -23,8 +23,8 @@ class GetAlbumPhotosKey(albumId: Int) : InfiniteQueryKey<Photos, PageParam> by b
             ?.takeIf { it.data.isNotEmpty() }
             ?.run { param.copy(offset = param.offset + param.limit) }
     }
-) {
-    class Id(albumId: Int) : InfiniteQueryId<Photos, PageParam>(
-        namespace = "albums/$albumId/photos/*"
-    )
-}
+)
+
+fun InfiniteQueryId.Companion.forGetAlbumPhotos(albumId: Int) = InfiniteQueryId<Photos, PageParam>(
+    namespace = "albums/$albumId/photos/*"
+)

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/albums/GetAlbumsKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/albums/GetAlbumsKey.kt
@@ -10,7 +10,7 @@ import soil.query.InfiniteQueryKey
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
 class GetAlbumsKey : InfiniteQueryKey<Albums, PageParam> by buildKtorInfiniteQueryKey(
-    id = Id(),
+    id = InfiniteQueryId.forGetAlbums(),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/albums") {
             parameter("_start", param.offset)
@@ -23,8 +23,8 @@ class GetAlbumsKey : InfiniteQueryKey<Albums, PageParam> by buildKtorInfiniteQue
             ?.takeIf { it.data.isNotEmpty() }
             ?.run { param.copy(offset = param.offset + param.limit) }
     }
-) {
-    class Id : InfiniteQueryId<Albums, PageParam>(
-        namespace = "albums/*"
-    )
-}
+)
+
+fun InfiniteQueryId.Companion.forGetAlbums() = InfiniteQueryId<Albums, PageParam>(
+    namespace = "albums/*"
+)

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/CreatePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/CreatePostKey.kt
@@ -4,6 +4,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import soil.playground.query.data.Post
+import soil.query.InfiniteQueryId
 import soil.query.MutationKey
 import soil.query.QueryEffect
 import soil.query.receivers.ktor.buildKtorMutationKey
@@ -17,7 +18,7 @@ class CreatePostKey : MutationKey<Post, PostForm> by buildKtorMutationKey(
     }
 ) {
     override fun onQueryUpdate(variable: PostForm, data: Post): QueryEffect = {
-        invalidateQueriesBy(GetPostsKey.Id())
+        invalidateQueriesBy(InfiniteQueryId.forGetPosts())
     }
 }
 

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/DeletePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/DeletePostKey.kt
@@ -1,8 +1,10 @@
 package soil.playground.query.key.posts
 
 import io.ktor.client.request.delete
+import soil.query.InfiniteQueryId
 import soil.query.MutationKey
 import soil.query.QueryEffect
+import soil.query.QueryId
 import soil.query.receivers.ktor.buildKtorMutationKey
 
 class DeletePostKey : MutationKey<Unit, Int> by buildKtorMutationKey(
@@ -12,7 +14,7 @@ class DeletePostKey : MutationKey<Unit, Int> by buildKtorMutationKey(
     }
 ) {
     override fun onQueryUpdate(variable: Int, data: Unit): QueryEffect = {
-        removeQueriesBy(GetPostKey.Id(variable))
-        invalidateQueriesBy(GetPostsKey.Id())
+        removeQueriesBy(QueryId.forGetPost(variable))
+        invalidateQueriesBy(InfiniteQueryId.forGetPosts())
     }
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostCommentsKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostCommentsKey.kt
@@ -10,7 +10,7 @@ import soil.query.InfiniteQueryKey
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
 class GetPostCommentsKey(private val postId: Int) : InfiniteQueryKey<Comments, PageParam> by buildKtorInfiniteQueryKey(
-    id = Id(postId),
+    id = InfiniteQueryId.forGetPostComments(postId),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/posts/$postId/comments") {
             parameter("_start", param.offset)
@@ -23,8 +23,8 @@ class GetPostCommentsKey(private val postId: Int) : InfiniteQueryKey<Comments, P
             ?.takeIf { it.data.isNotEmpty() }
             ?.run { param.copy(offset = param.offset + param.limit) }
     }
-) {
-    class Id(postId: Int) : InfiniteQueryId<Comments, PageParam>(
-        namespace = "posts/$postId/comments/*"
-    )
-}
+)
+
+fun InfiniteQueryId.Companion.forGetPostComments(postId: Int) = InfiniteQueryId<Comments, PageParam>(
+    namespace = "posts/$postId/comments/*"
+)

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostKey.kt
@@ -3,6 +3,7 @@ package soil.playground.query.key.posts
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import soil.playground.query.data.Post
+import soil.query.InfiniteQueryId
 import soil.query.QueryId
 import soil.query.QueryInitialData
 import soil.query.QueryKey
@@ -10,19 +11,18 @@ import soil.query.chunkedData
 import soil.query.receivers.ktor.buildKtorQueryKey
 
 class GetPostKey(private val postId: Int) : QueryKey<Post> by buildKtorQueryKey(
-    id = Id(postId),
+    id = QueryId.forGetPost(postId),
     fetch = {
         get("https://jsonplaceholder.typicode.com/posts/$postId").body()
     }
 ) {
-
     override fun onInitialData(): QueryInitialData<Post> = {
-        getInfiniteQueryData(GetPostsKey.Id())?.let {
+        getInfiniteQueryData(InfiniteQueryId.forGetPosts())?.let {
             it.chunkedData.firstOrNull { post -> post.id == postId }
         }
     }
-
-    class Id(postId: Int) : QueryId<Post>(
-        namespace = "posts/$postId"
-    )
 }
+
+fun QueryId.Companion.forGetPost(postId: Int) = QueryId<Post>(
+    namespace = "posts/$postId"
+)

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostsKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostsKey.kt
@@ -12,8 +12,8 @@ import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 // NOTE: userId
 // Filtering resources
 // ref. https://jsonplaceholder.typicode.com/guide/
-class GetPostsKey(userId: Int? = null) : InfiniteQueryKey<Posts, PageParam> by buildKtorInfiniteQueryKey(
-    id = Id(userId),
+class GetPostsKey(val userId: Int? = null) : InfiniteQueryKey<Posts, PageParam> by buildKtorInfiniteQueryKey(
+    id = InfiniteQueryId.forGetPosts(userId),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/posts") {
             parameter("_start", param.offset)
@@ -29,9 +29,9 @@ class GetPostsKey(userId: Int? = null) : InfiniteQueryKey<Posts, PageParam> by b
             ?.takeIf { it.data.isNotEmpty() }
             ?.run { param.copy(offset = param.offset + param.limit) }
     }
-) {
-    class Id(userId: Int? = null) : InfiniteQueryId<Posts, PageParam>(
-        namespace = "posts/*",
-        "userId" to userId
-    )
-}
+)
+
+fun InfiniteQueryId.Companion.forGetPosts(userId: Int? = null) = InfiniteQueryId<Posts, PageParam>(
+    namespace = "posts/*",
+    "userId" to userId
+)

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/UpdatePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/UpdatePostKey.kt
@@ -4,8 +4,10 @@ import io.ktor.client.call.body
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import soil.playground.query.data.Post
+import soil.query.InfiniteQueryId
 import soil.query.MutationKey
 import soil.query.QueryEffect
+import soil.query.QueryId
 import soil.query.modifyData
 import soil.query.receivers.ktor.buildKtorMutationKey
 
@@ -18,7 +20,7 @@ class UpdatePostKey : MutationKey<Post, Post> by buildKtorMutationKey(
     }
 ) {
     override fun onQueryUpdate(variable: Post, data: Post): QueryEffect = {
-        updateQueryData(GetPostKey.Id(data.id)) { data }
-        updateInfiniteQueryData(GetPostsKey.Id()) { modifyData({ it.id == data.id }) { data } }
+        updateQueryData(QueryId.forGetPost(data.id)) { data }
+        updateInfiniteQueryData(InfiniteQueryId.forGetPosts()) { modifyData({ it.id == data.id }) { data } }
     }
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserAlbumsKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserAlbumsKey.kt
@@ -10,7 +10,7 @@ import soil.query.InfiniteQueryKey
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
 class GetUserAlbumsKey(userId: Int) : InfiniteQueryKey<Albums, PageParam> by buildKtorInfiniteQueryKey(
-    id = Id(userId),
+    id = InfiniteQueryId.forGetUserAlbums(userId),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/users/$userId/albums") {
             parameter("_start", param.offset)
@@ -23,8 +23,8 @@ class GetUserAlbumsKey(userId: Int) : InfiniteQueryKey<Albums, PageParam> by bui
             ?.takeIf { it.data.isNotEmpty() }
             ?.run { param.copy(offset = param.offset + param.limit) }
     }
-) {
-    class Id(userId: Int) : InfiniteQueryId<Albums, PageParam>(
-        namespace = "users/$userId/albums/*"
-    )
-}
+)
+
+fun InfiniteQueryId.Companion.forGetUserAlbums(userId: Int) = InfiniteQueryId<Albums, PageParam>(
+    namespace = "users/$userId/albums/*"
+)

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserKey.kt
@@ -3,6 +3,7 @@ package soil.playground.query.key.users
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import soil.playground.query.data.User
+import soil.query.InfiniteQueryId
 import soil.query.QueryId
 import soil.query.QueryInitialData
 import soil.query.QueryKey
@@ -10,19 +11,18 @@ import soil.query.chunkedData
 import soil.query.receivers.ktor.buildKtorQueryKey
 
 class GetUserKey(private val userId: Int) : QueryKey<User> by buildKtorQueryKey(
-    id = Id(userId),
+    id = QueryId.forGetUser(userId),
     fetch = {
         get("https://jsonplaceholder.typicode.com/users/$userId").body()
     }
 ) {
-
     override fun onInitialData(): QueryInitialData<User> = {
-        getInfiniteQueryData(GetUsersKey.Id())?.let {
+        getInfiniteQueryData(InfiniteQueryId.forGetUsers())?.let {
             it.chunkedData.firstOrNull { user -> user.id == userId }
         }
     }
-
-    class Id(userId: Int) : QueryId<User>(
-        namespace = "users/$userId"
-    )
 }
+
+fun QueryId.Companion.forGetUser(userId: Int) = QueryId<User>(
+    namespace = "users/$userId"
+)

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserPostsKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserPostsKey.kt
@@ -10,7 +10,7 @@ import soil.query.InfiniteQueryKey
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
 class GetUserPostsKey(userId: Int) : InfiniteQueryKey<Posts, PageParam> by buildKtorInfiniteQueryKey(
-    id = Id(userId),
+    id = InfiniteQueryId.forGetUserPosts(userId),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/users/$userId/posts") {
             parameter("_start", param.offset)
@@ -23,8 +23,8 @@ class GetUserPostsKey(userId: Int) : InfiniteQueryKey<Posts, PageParam> by build
             ?.takeIf { it.data.isNotEmpty() }
             ?.run { param.copy(offset = param.offset + param.limit) }
     }
-) {
-    class Id(userId: Int) : InfiniteQueryId<Posts, PageParam>(
-        namespace = "users/$userId/posts/*"
-    )
-}
+)
+
+fun InfiniteQueryId.Companion.forGetUserPosts(userId: Int) = InfiniteQueryId<Posts, PageParam>(
+    namespace = "users/$userId/posts/*"
+)

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserTodosKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserTodosKey.kt
@@ -10,7 +10,7 @@ import soil.query.InfiniteQueryKey
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
 class GetUserTodosKey(userId: Int) : InfiniteQueryKey<Todos, PageParam> by buildKtorInfiniteQueryKey(
-    id = Id(userId),
+    id = InfiniteQueryId.forGetUserTodos(userId),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/users/$userId/todos") {
             parameter("_start", param.offset)
@@ -23,8 +23,8 @@ class GetUserTodosKey(userId: Int) : InfiniteQueryKey<Todos, PageParam> by build
             ?.takeIf { it.data.isNotEmpty() }
             ?.run { param.copy(offset = param.offset + param.limit) }
     }
-) {
-    class Id(userId: Int) : InfiniteQueryId<Todos, PageParam>(
-        namespace = "users/$userId/todos/*"
-    )
-}
+)
+
+fun InfiniteQueryId.Companion.forGetUserTodos(userId: Int) = InfiniteQueryId<Todos, PageParam>(
+    namespace = "users/$userId/todos/*"
+)

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUsersKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUsersKey.kt
@@ -10,7 +10,7 @@ import soil.query.InfiniteQueryKey
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
 class GetUsersKey : InfiniteQueryKey<Users, PageParam> by buildKtorInfiniteQueryKey(
-    id = Id(),
+    id = InfiniteQueryId.forGetUsers(),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/users") {
             parameter("_start", param.offset)
@@ -23,8 +23,8 @@ class GetUsersKey : InfiniteQueryKey<Users, PageParam> by buildKtorInfiniteQuery
             ?.takeIf { it.data.isNotEmpty() }
             ?.run { param.copy(offset = param.offset + param.limit) }
     }
-) {
-    class Id : InfiniteQueryId<Users, PageParam>(
-        namespace = "users/*"
-    )
-}
+)
+
+fun InfiniteQueryId.Companion.forGetUsers() = InfiniteQueryId<Users, PageParam>(
+    namespace = "users/*"
+)

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryKey.kt
@@ -82,6 +82,8 @@ open class InfiniteQueryId<T, S>(
     override fun toString(): String {
         return "InfiniteQueryId(namespace='$namespace', tags=${tags.contentToString()})"
     }
+
+    companion object
 }
 
 internal fun <T, S> InfiniteQueryKey<T, S>.hasMore(chunks: QueryChunks<T, S>): Boolean {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
@@ -100,6 +100,8 @@ open class QueryId<T>(
     override fun toString(): String {
         return "QueryId(namespace='$namespace', tags=${tags.contentToString()})"
     }
+
+    companion object
 }
 
 /**


### PR DESCRIPTION
With the enhancement of preview and test implementations, more APIs now accept `UniqueId` types as arguments. Associating the ID definitions with a companion object helps leverage these features more effectively.

refs: #63, #70