### PR TITLE
Implement a Configuration Class for Compose

### DIFF
--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetPostQuery.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetPostQuery.kt
@@ -4,13 +4,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import soil.playground.query.data.Post
 import soil.playground.query.key.posts.GetPostKey
+import soil.query.compose.QueryConfig
 import soil.query.compose.QueryObject
 import soil.query.compose.rememberQuery
 
 typealias GetPostQueryObject = QueryObject<Post>
 
 @Composable
-fun rememberGetPostQuery(postId: Int): GetPostQueryObject {
+fun rememberGetPostQuery(
+    postId: Int,
+    builderBlock: QueryConfig.Builder.() -> Unit = {}
+): GetPostQueryObject {
     val key = remember(postId) { GetPostKey(postId) }
-    return rememberQuery(key)
+    return rememberQuery(key, QueryConfig(builderBlock))
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetPostsQuery.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetPostsQuery.kt
@@ -6,13 +6,17 @@ import soil.playground.query.data.PageParam
 import soil.playground.query.data.Posts
 import soil.playground.query.key.posts.GetPostsKey
 import soil.query.chunkedData
+import soil.query.compose.InfiniteQueryConfig
 import soil.query.compose.InfiniteQueryObject
 import soil.query.compose.rememberInfiniteQuery
 
 typealias GetPostsQueryObject = InfiniteQueryObject<Posts, PageParam>
 
 @Composable
-fun rememberGetPostsQuery(userId: Int? = null): GetPostsQueryObject {
+fun rememberGetPostsQuery(
+    userId: Int? = null,
+    builderBlock: InfiniteQueryConfig.Builder.() -> Unit = {}
+): GetPostsQueryObject {
     val key = remember(userId) { GetPostsKey(userId) }
-    return rememberInfiniteQuery(key, select = { it.chunkedData })
+    return rememberInfiniteQuery(key, select = { it.chunkedData }, config = InfiniteQueryConfig(builderBlock))
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetUserPostsQuery.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetUserPostsQuery.kt
@@ -6,13 +6,17 @@ import soil.playground.query.data.PageParam
 import soil.playground.query.data.Posts
 import soil.playground.query.key.users.GetUserPostsKey
 import soil.query.chunkedData
+import soil.query.compose.InfiniteQueryConfig
 import soil.query.compose.InfiniteQueryObject
 import soil.query.compose.rememberInfiniteQuery
 
 typealias GetUserPostsQueryObject = InfiniteQueryObject<Posts, PageParam>
 
 @Composable
-fun rememberGetUserPostsQuery(userId: Int): GetUserPostsQueryObject {
+fun rememberGetUserPostsQuery(
+    userId: Int,
+    builderBlock: InfiniteQueryConfig.Builder.() -> Unit = {}
+): GetUserPostsQueryObject {
     val key = remember(userId) { GetUserPostsKey(userId) }
-    return rememberInfiniteQuery(key = key, select = { it.chunkedData })
+    return rememberInfiniteQuery(key = key, select = { it.chunkedData }, config = InfiniteQueryConfig(builderBlock))
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetUserQuery.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetUserQuery.kt
@@ -4,13 +4,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import soil.playground.query.data.User
 import soil.playground.query.key.users.GetUserKey
+import soil.query.compose.QueryConfig
 import soil.query.compose.QueryObject
 import soil.query.compose.rememberQuery
 
 typealias GetUserQueryObject = QueryObject<User>
 
 @Composable
-fun rememberGetUserQuery(userId: Int): GetUserQueryObject {
+fun rememberGetUserQuery(
+    userId: Int,
+    builderBlock: QueryConfig.Builder.() -> Unit = {}
+): GetUserQueryObject {
     val key = remember(userId) { GetUserKey(userId) }
-    return rememberQuery(key)
+    return rememberQuery(key, config = QueryConfig(builderBlock))
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
@@ -22,18 +22,19 @@ import soil.query.core.map
  * @param T Type of data to retrieve.
  * @param S Type of parameter.
  * @param key The [InfiniteQueryKey] for managing [query][soil.query.Query] associated with [id][soil.query.InfiniteQueryId].
+ * @param config The configuration for the query. By default, it uses the [InfiniteQueryConfig.Default].
  * @param client The [QueryClient] to resolve [key]. By default, it uses the [LocalQueryClient].
  * @return A [InfiniteQueryObject] each the query state changed.
  */
 @Composable
 fun <T, S> rememberInfiniteQuery(
     key: InfiniteQueryKey<T, S>,
-    strategy: QueryCachingStrategy = QueryCachingStrategy,
+    config: InfiniteQueryConfig = InfiniteQueryConfig.Default,
     client: QueryClient = LocalQueryClient.current
 ): InfiniteQueryObject<QueryChunks<T, S>, S> {
     val scope = rememberCoroutineScope()
-    val query = remember(key) { client.getInfiniteQuery(key).also { it.launchIn(scope) } }
-    return strategy.collectAsState(query).toInfiniteObject(query = query, select = { it })
+    val query = remember(key) { client.getInfiniteQuery(key, config.marker).also { it.launchIn(scope) } }
+    return config.strategy.collectAsState(query).toInfiniteObject(query = query, select = { it })
 }
 
 /**
@@ -43,6 +44,7 @@ fun <T, S> rememberInfiniteQuery(
  * @param S Type of parameter.
  * @param key The [InfiniteQueryKey] for managing [query][soil.query.Query] associated with [id][soil.query.InfiniteQueryId].
  * @param select A function to select data from [QueryChunks].
+ * @param config The configuration for the query. By default, it uses the [InfiniteQueryConfig.Default].
  * @param client The [QueryClient] to resolve [key]. By default, it uses the [LocalQueryClient].
  * @return A [InfiniteQueryObject] with selected data each the query state changed.
  */
@@ -50,12 +52,12 @@ fun <T, S> rememberInfiniteQuery(
 fun <T, S, U> rememberInfiniteQuery(
     key: InfiniteQueryKey<T, S>,
     select: (chunks: QueryChunks<T, S>) -> U,
-    strategy: QueryCachingStrategy = QueryCachingStrategy,
+    config: InfiniteQueryConfig = InfiniteQueryConfig.Default,
     client: QueryClient = LocalQueryClient.current
 ): InfiniteQueryObject<U, S> {
     val scope = rememberCoroutineScope()
-    val query = remember(key) { client.getInfiniteQuery(key).also { it.launchIn(scope) } }
-    return strategy.collectAsState(query).toInfiniteObject(query = query, select = select)
+    val query = remember(key) { client.getInfiniteQuery(key, config.marker).also { it.launchIn(scope) } }
+    return config.strategy.collectAsState(query).toInfiniteObject(query = query, select = select)
 }
 
 private fun <T, S, U> QueryState<QueryChunks<T, S>>.toInfiniteObject(

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryConfig.kt
@@ -1,0 +1,45 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import androidx.compose.runtime.Immutable
+import soil.query.core.Marker
+
+/**
+ * Configuration for the infinite query.
+ *
+ * @property strategy The strategy for caching query data.
+ * @property marker The marker with additional information based on the caller of a query.
+ */
+@Immutable
+data class InfiniteQueryConfig internal constructor(
+    val strategy: QueryCachingStrategy,
+    val marker: Marker
+) {
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    class Builder {
+        var strategy: QueryCachingStrategy = Default.strategy
+        val marker: Marker = Default.marker
+
+        fun build() = InfiniteQueryConfig(
+            strategy = strategy,
+            marker = marker
+        )
+    }
+
+    companion object {
+        val Default = InfiniteQueryConfig(
+            strategy = QueryCachingStrategy.Default,
+            marker = Marker.None
+        )
+    }
+}
+
+/**
+ * Creates a [InfiniteQueryConfig] with the provided [initializer].
+ */
+fun InfiniteQueryConfig(initializer: InfiniteQueryConfig.Builder.() -> Unit): InfiniteQueryConfig {
+    return InfiniteQueryConfig.Builder().apply(initializer).build()
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
@@ -20,16 +20,18 @@ import soil.query.MutationStatus
  * @param T Type of the return value from the mutation.
  * @param S Type of the variable to be mutated.
  * @param key The [MutationKey] for managing [mutation][soil.query.Mutation] associated with [id][soil.query.MutationId].
+ * @param config The configuration for the mutation. By default, it uses the [MutationConfig.Default].
  * @param client The [MutationClient] to resolve [key]. By default, it uses the [LocalMutationClient].
  * @return A [MutationObject] each the mutation state changed.
  */
 @Composable
 fun <T, S> rememberMutation(
     key: MutationKey<T, S>,
+    config: MutationConfig = MutationConfig.Default,
     client: MutationClient = LocalMutationClient.current
 ): MutationObject<T, S> {
     val scope = rememberCoroutineScope()
-    val mutation = remember(key) { client.getMutation(key).also { it.launchIn(scope) } }
+    val mutation = remember(key) { client.getMutation(key, config.marker).also { it.launchIn(scope) } }
     val state by mutation.state.collectAsState()
     return state.toObject(mutation = mutation)
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationConfig.kt
@@ -1,0 +1,40 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import androidx.compose.runtime.Immutable
+import soil.query.core.Marker
+
+/**
+ * Configuration for the mutation.
+ *
+ * @property marker The marker with additional information based on the caller of a mutation.
+ */
+@Immutable
+data class MutationConfig internal constructor(
+    val marker: Marker
+) {
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    class Builder {
+        val marker: Marker = Default.marker
+
+        fun build() = MutationConfig(
+            marker = marker
+        )
+    }
+
+    companion object {
+        val Default = MutationConfig(
+            marker = Marker.None
+        )
+    }
+}
+
+/**
+ * Creates a [MutationConfig] with the provided [initializer].
+ */
+fun MutationConfig(initializer: MutationConfig.Builder.() -> Unit): MutationConfig {
+    return MutationConfig.Builder().apply(initializer).build()
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
@@ -19,18 +19,19 @@ import soil.query.core.map
  *
  * @param T Type of data to retrieve.
  * @param key The [QueryKey] for managing [query][soil.query.Query].
+ * @param config The configuration for the query. By default, it uses the [QueryConfig.Default].
  * @param client The [QueryClient] to resolve [key]. By default, it uses the [LocalQueryClient].
  * @return A [QueryObject] each the query state changed.
  */
 @Composable
 fun <T> rememberQuery(
     key: QueryKey<T>,
-    strategy: QueryCachingStrategy = QueryCachingStrategy,
+    config: QueryConfig = QueryConfig.Default,
     client: QueryClient = LocalQueryClient.current
 ): QueryObject<T> {
     val scope = rememberCoroutineScope()
-    val query = remember(key) { client.getQuery(key).also { it.launchIn(scope) } }
-    return strategy.collectAsState(query).toObject(query = query, select = { it })
+    val query = remember(key) { client.getQuery(key, config.marker).also { it.launchIn(scope) } }
+    return config.strategy.collectAsState(query).toObject(query = query, select = { it })
 }
 
 /**
@@ -40,6 +41,7 @@ fun <T> rememberQuery(
  * @param U Type of selected data.
  * @param key The [QueryKey] for managing [query][soil.query.Query].
  * @param select A function to select data from [T].
+ * @param config The configuration for the query. By default, it uses the [QueryConfig.Default].
  * @param client The [QueryClient] to resolve [key]. By default, it uses the [LocalQueryClient].
  * @return A [QueryObject] with selected data each the query state changed.
  */
@@ -47,12 +49,12 @@ fun <T> rememberQuery(
 fun <T, U> rememberQuery(
     key: QueryKey<T>,
     select: (T) -> U,
-    strategy: QueryCachingStrategy = QueryCachingStrategy,
+    config: QueryConfig = QueryConfig.Default,
     client: QueryClient = LocalQueryClient.current
 ): QueryObject<U> {
     val scope = rememberCoroutineScope()
-    val query = remember(key) { client.getQuery(key).also { it.launchIn(scope) } }
-    return strategy.collectAsState(query).toObject(query = query, select = select)
+    val query = remember(key) { client.getQuery(key, config.marker).also { it.launchIn(scope) } }
+    return config.strategy.collectAsState(query).toObject(query = query, select = select)
 }
 
 private fun <T, U> QueryState<T>.toObject(

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryConfig.kt
@@ -1,0 +1,45 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import androidx.compose.runtime.Immutable
+import soil.query.core.Marker
+
+/**
+ * Configuration for the query.
+ *
+ * @property strategy The strategy for caching query data.
+ * @property marker The marker with additional information based on the caller of a query.
+ */
+@Immutable
+data class QueryConfig internal constructor(
+    val strategy: QueryCachingStrategy,
+    val marker: Marker
+) {
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    class Builder {
+        var strategy: QueryCachingStrategy = Default.strategy
+        var marker: Marker = Default.marker
+
+        fun build() = QueryConfig(
+            strategy = strategy,
+            marker = marker
+        )
+    }
+
+    companion object {
+        val Default = QueryConfig(
+            strategy = QueryCachingStrategy.Default,
+            marker = Marker.None
+        )
+    }
+}
+
+/**
+ * Creates a [QueryConfig] with the provided [initializer].
+ */
+fun QueryConfig(initializer: QueryConfig.Builder.() -> Unit): QueryConfig {
+    return QueryConfig.Builder().apply(initializer).build()
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
@@ -14,6 +14,7 @@ import soil.query.MutationKey
 import soil.query.MutationOptions
 import soil.query.MutationRef
 import soil.query.MutationState
+import soil.query.core.Marker
 import soil.query.core.UniqueId
 
 /**
@@ -34,15 +35,17 @@ class MutationPreviewClient(
 ) : MutationClient {
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T, S> getMutation(key: MutationKey<T, S>): MutationRef<T, S> {
+    override fun <T, S> getMutation(
+        key: MutationKey<T, S>,
+        marker: Marker
+    ): MutationRef<T, S> {
         val state = previewData[key.id] as? MutationState<T> ?: MutationState.initial()
-        val options = key.onConfigureOptions()?.invoke(defaultMutationOptions) ?: defaultMutationOptions
-        return SnapshotMutation(key, options, MutableStateFlow(state))
+        return SnapshotMutation(key, marker, MutableStateFlow(state))
     }
 
     private class SnapshotMutation<T, S>(
         override val key: MutationKey<T, S>,
-        override val options: MutationOptions,
+        override val marker: Marker,
         override val state: StateFlow<MutationState<T>>
     ) : MutationRef<T, S> {
         override fun launchIn(scope: CoroutineScope): Job = Job()

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
@@ -18,6 +18,7 @@ import soil.query.QueryKey
 import soil.query.QueryOptions
 import soil.query.QueryRef
 import soil.query.QueryState
+import soil.query.core.Marker
 import soil.query.core.UniqueId
 
 /**
@@ -38,26 +39,36 @@ class QueryPreviewClient(
 ) : QueryClient {
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T> getQuery(key: QueryKey<T>): QueryRef<T> {
+    override fun <T> getQuery(
+        key: QueryKey<T>,
+        marker: Marker
+    ): QueryRef<T> {
         val state = previewData[key.id] as? QueryState<T> ?: QueryState.initial()
-        val options = key.onConfigureOptions()?.invoke(defaultQueryOptions) ?: defaultQueryOptions
-        return SnapshotQuery(key, options, MutableStateFlow(state))
+        return SnapshotQuery(key, marker, MutableStateFlow(state))
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T, S> getInfiniteQuery(key: InfiniteQueryKey<T, S>): InfiniteQueryRef<T, S> {
+    override fun <T, S> getInfiniteQuery(
+        key: InfiniteQueryKey<T, S>,
+        marker: Marker
+    ): InfiniteQueryRef<T, S> {
         val state = previewData[key.id] as? QueryState<QueryChunks<T, S>> ?: QueryState.initial()
-        val options = key.onConfigureOptions()?.invoke(defaultQueryOptions) ?: defaultQueryOptions
-        return SnapshotInfiniteQuery(key, options, MutableStateFlow(state))
+        return SnapshotInfiniteQuery(key, marker, MutableStateFlow(state))
     }
 
-    override fun <T> prefetchQuery(key: QueryKey<T>): Job = Job()
+    override fun <T> prefetchQuery(
+        key: QueryKey<T>,
+        marker: Marker
+    ): Job = Job()
 
-    override fun <T, S> prefetchInfiniteQuery(key: InfiniteQueryKey<T, S>): Job = Job()
+    override fun <T, S> prefetchInfiniteQuery(
+        key: InfiniteQueryKey<T, S>,
+        marker: Marker
+    ): Job = Job()
 
     private class SnapshotQuery<T>(
         override val key: QueryKey<T>,
-        override val options: QueryOptions,
+        override val marker: Marker,
         override val state: StateFlow<QueryState<T>>
     ) : QueryRef<T> {
         override fun launchIn(scope: CoroutineScope): Job = Job()
@@ -68,7 +79,7 @@ class QueryPreviewClient(
 
     private class SnapshotInfiniteQuery<T, S>(
         override val key: InfiniteQueryKey<T, S>,
-        override val options: QueryOptions,
+        override val marker: Marker,
         override val state: StateFlow<QueryState<QueryChunks<T, S>>>
     ) : InfiniteQueryRef<T, S> {
         override fun launchIn(scope: CoroutineScope): Job = Job()

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommands.kt
@@ -3,6 +3,7 @@
 
 package soil.query
 
+import soil.query.core.Marker
 import soil.query.core.getOrElse
 import soil.query.core.getOrNull
 import soil.query.core.vvv
@@ -17,10 +18,13 @@ object InfiniteQueryCommands {
      *
      * @param key Instance of a class implementing [InfiniteQueryKey].
      * @param revision The revision of the data to be fetched.
+     * @param marker The marker with additional information based on the caller of a query.
+     * @param callback The callback to receive the result of the query.
      */
     class Connect<T, S>(
         val key: InfiniteQueryKey<T, S>,
         val revision: String? = null,
+        val marker: Marker = Marker.None,
         val callback: QueryCallback<QueryChunks<T, S>>? = null
     ) : InfiniteQueryCommand<T, S> {
         override suspend fun handle(ctx: QueryCommand.Context<QueryChunks<T, S>>) {
@@ -32,9 +36,9 @@ object InfiniteQueryCommands {
             ctx.dispatch(QueryAction.Fetching())
             val chunks = ctx.state.reply.getOrNull()
             if (chunks.isNullOrEmpty()) {
-                ctx.dispatchFetchChunksResult(key, key.initialParam(), callback)
+                ctx.dispatchFetchChunksResult(key, key.initialParam(), marker, callback)
             } else {
-                ctx.dispatchRevalidateChunksResult(key, chunks, callback)
+                ctx.dispatchRevalidateChunksResult(key, chunks, marker, callback)
             }
         }
     }
@@ -46,10 +50,13 @@ object InfiniteQueryCommands {
      *
      * @param key Instance of a class implementing [InfiniteQueryKey].
      * @param revision The revision of the data to be invalidated.
+     * @param marker The marker with additional information based on the caller of a query.
+     * @param callback The callback to receive the result of the query.
      */
     class Invalidate<T, S>(
         val key: InfiniteQueryKey<T, S>,
         val revision: String,
+        val marker: Marker = Marker.None,
         val callback: QueryCallback<QueryChunks<T, S>>? = null
     ) : InfiniteQueryCommand<T, S> {
         override suspend fun handle(ctx: QueryCommand.Context<QueryChunks<T, S>>) {
@@ -61,9 +68,9 @@ object InfiniteQueryCommands {
             ctx.dispatch(QueryAction.Fetching(isInvalidated = true))
             val chunks = ctx.state.reply.getOrNull()
             if (chunks.isNullOrEmpty()) {
-                ctx.dispatchFetchChunksResult(key, key.initialParam(), callback)
+                ctx.dispatchFetchChunksResult(key, key.initialParam(), marker, callback)
             } else {
-                ctx.dispatchRevalidateChunksResult(key, chunks, callback)
+                ctx.dispatchRevalidateChunksResult(key, chunks, marker, callback)
             }
         }
     }
@@ -73,10 +80,13 @@ object InfiniteQueryCommands {
      *
      * @param key Instance of a class implementing [InfiniteQueryKey].
      * @param param The parameter required for fetching data for [InfiniteQueryKey].
+     * @param marker The marker with additional information based on the caller of a query.
+     * @param callback The callback to receive the result of the query.
      */
     class LoadMore<T, S>(
         val key: InfiniteQueryKey<T, S>,
         val param: S,
+        val marker: Marker = Marker.None,
         val callback: QueryCallback<QueryChunks<T, S>>? = null
     ) : InfiniteQueryCommand<T, S> {
         override suspend fun handle(ctx: QueryCommand.Context<QueryChunks<T, S>>) {
@@ -88,7 +98,7 @@ object InfiniteQueryCommands {
             }
 
             ctx.dispatch(QueryAction.Fetching())
-            ctx.dispatchFetchChunksResult(key, param, callback)
+            ctx.dispatchFetchChunksResult(key, param, marker, callback)
         }
     }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryRef.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.completeWith
 import kotlinx.coroutines.flow.StateFlow
 import soil.query.core.Actor
+import soil.query.core.Marker
 import soil.query.core.awaitOrNull
 
 /**
@@ -18,7 +19,7 @@ import soil.query.core.awaitOrNull
 interface InfiniteQueryRef<T, S> : Actor {
 
     val key: InfiniteQueryKey<T, S>
-    val options: QueryOptions
+    val marker: Marker
     val state: StateFlow<QueryState<QueryChunks<T, S>>>
 
     /**
@@ -31,7 +32,7 @@ interface InfiniteQueryRef<T, S> : Actor {
      */
     suspend fun resume() {
         val deferred = CompletableDeferred<QueryChunks<T, S>>()
-        send(InfiniteQueryCommands.Connect(key, state.value.revision, deferred::completeWith))
+        send(InfiniteQueryCommands.Connect(key, state.value.revision, marker, deferred::completeWith))
         deferred.awaitOrNull()
     }
 
@@ -40,7 +41,7 @@ interface InfiniteQueryRef<T, S> : Actor {
      */
     suspend fun loadMore(param: S) {
         val deferred = CompletableDeferred<QueryChunks<T, S>>()
-        send(InfiniteQueryCommands.LoadMore(key, param, deferred::completeWith))
+        send(InfiniteQueryCommands.LoadMore(key, param, marker, deferred::completeWith))
         deferred.awaitOrNull()
     }
 
@@ -52,7 +53,7 @@ interface InfiniteQueryRef<T, S> : Actor {
      */
     suspend fun invalidate() {
         val deferred = CompletableDeferred<QueryChunks<T, S>>()
-        send(InfiniteQueryCommands.Invalidate(key, state.value.revision, deferred::completeWith))
+        send(InfiniteQueryCommands.Invalidate(key, state.value.revision, marker, deferred::completeWith))
         deferred.awaitOrNull()
     }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationClient.kt
@@ -3,6 +3,8 @@
 
 package soil.query
 
+import soil.query.core.Marker
+
 /**
  * A Mutation client, which allows you to make mutations actor and handle [MutationKey].
  */
@@ -17,7 +19,8 @@ interface MutationClient {
      * Gets the [MutationRef] by the specified [MutationKey].
      */
     fun <T, S> getMutation(
-        key: MutationKey<T, S>
+        key: MutationKey<T, S>,
+        marker: Marker = Marker.None
     ): MutationRef<T, S>
 }
 

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationCommands.kt
@@ -3,6 +3,7 @@
 
 package soil.query
 
+import soil.query.core.Marker
 import soil.query.core.vvv
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -16,11 +17,14 @@ object MutationCommands {
      * @param key Instance of a class implementing [MutationKey].
      * @param variable The variable to be mutated.
      * @param revision The revision of the mutation state.
+     * @param marker The marker with additional information based on the caller of a mutation.
+     * @param callback The callback to receive the result of the mutation.
      */
     class Mutate<T, S>(
         val key: MutationKey<T, S>,
         val variable: S,
         val revision: String,
+        val marker: Marker = Marker.None,
         val callback: MutationCallback<T>? = null
     ) : MutationCommand<T> {
 
@@ -31,7 +35,7 @@ object MutationCommands {
                 return
             }
             ctx.dispatch(MutationAction.Mutating)
-            ctx.dispatchMutateResult(key, variable, callback)
+            ctx.dispatchMutateResult(key, variable, marker, callback)
         }
     }
 

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationRef.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.completeWith
 import kotlinx.coroutines.flow.StateFlow
 import soil.query.core.Actor
+import soil.query.core.Marker
 
 /**
  * A reference to a Mutation for [MutationKey].
@@ -17,7 +18,7 @@ import soil.query.core.Actor
 interface MutationRef<T, S> : Actor {
 
     val key: MutationKey<T, S>
-    val options: MutationOptions
+    val marker: Marker
     val state: StateFlow<MutationState<T>>
 
     /**
@@ -33,7 +34,7 @@ interface MutationRef<T, S> : Actor {
      */
     suspend fun mutate(variable: S): T {
         val deferred = CompletableDeferred<T>()
-        send(MutationCommands.Mutate(key, variable, state.value.revision, deferred::completeWith))
+        send(MutationCommands.Mutate(key, variable, state.value.revision, marker, deferred::completeWith))
         return deferred.await()
     }
 
@@ -43,7 +44,7 @@ interface MutationRef<T, S> : Actor {
      * @param variable The variable to be mutated.
      */
     suspend fun mutateAsync(variable: S) {
-        send(MutationCommands.Mutate(key, variable, state.value.revision))
+        send(MutationCommands.Mutate(key, variable, state.value.revision, marker))
     }
 
     /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
@@ -4,6 +4,7 @@
 package soil.query
 
 import kotlinx.coroutines.Job
+import soil.query.core.Marker
 import soil.query.core.UniqueId
 
 /**
@@ -19,12 +20,18 @@ interface QueryClient {
     /**
      * Gets the [QueryRef] by the specified [QueryKey].
      */
-    fun <T> getQuery(key: QueryKey<T>): QueryRef<T>
+    fun <T> getQuery(
+        key: QueryKey<T>,
+        marker: Marker = Marker.None
+    ): QueryRef<T>
 
     /**
      * Gets the [InfiniteQueryRef] by the specified [InfiniteQueryKey].
      */
-    fun <T, S> getInfiniteQuery(key: InfiniteQueryKey<T, S>): InfiniteQueryRef<T, S>
+    fun <T, S> getInfiniteQuery(
+        key: InfiniteQueryKey<T, S>,
+        marker: Marker = Marker.None
+    ): InfiniteQueryRef<T, S>
 
     /**
      * Prefetches the query by the specified [QueryKey].
@@ -33,7 +40,10 @@ interface QueryClient {
      * Prefetch is executed within a [kotlinx.coroutines.CoroutineScope] associated with the instance of [QueryClient].
      * After data retrieval, subscription is automatically unsubscribed, hence the caching period depends on [QueryOptions].
      */
-    fun <T> prefetchQuery(key: QueryKey<T>): Job
+    fun <T> prefetchQuery(
+        key: QueryKey<T>,
+        marker: Marker = Marker.None
+    ): Job
 
     /**
      * Prefetches the infinite query by the specified [InfiniteQueryKey].
@@ -42,7 +52,10 @@ interface QueryClient {
      * Prefetch is executed within a [kotlinx.coroutines.CoroutineScope] associated with the instance of [QueryClient].
      * After data retrieval, subscription is automatically unsubscribed, hence the caching period depends on [QueryOptions].
      */
-    fun <T, S> prefetchInfiniteQuery(key: InfiniteQueryKey<T, S>): Job
+    fun <T, S> prefetchInfiniteQuery(
+        key: InfiniteQueryKey<T, S>,
+        marker: Marker = Marker.None
+    ): Job
 }
 
 /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommands.kt
@@ -3,6 +3,7 @@
 
 package soil.query
 
+import soil.query.core.Marker
 import soil.query.core.vvv
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -15,10 +16,13 @@ object QueryCommands {
      *
      * @param key Instance of a class implementing [QueryKey].
      * @param revision The revision of the data to be fetched.
+     * @param marker The marker with additional information based on the caller of a query.
+     * @param callback The callback to receive the result of the query.
      */
     class Connect<T>(
         val key: QueryKey<T>,
         val revision: String? = null,
+        val marker: Marker = Marker.None,
         val callback: QueryCallback<T>? = null
     ) : QueryCommand<T> {
 
@@ -29,7 +33,7 @@ object QueryCommands {
                 return
             }
             ctx.dispatch(QueryAction.Fetching())
-            ctx.dispatchFetchResult(key, callback)
+            ctx.dispatchFetchResult(key, marker, callback)
         }
     }
 
@@ -40,10 +44,13 @@ object QueryCommands {
      *
      * @param key Instance of a class implementing [QueryKey].
      * @param revision The revision of the data to be invalidated.
+     * @param marker The marker with additional information based on the caller of a query.
+     * @param callback The callback to receive the result of the query.
      */
     class Invalidate<T>(
         val key: QueryKey<T>,
         val revision: String,
+        val marker: Marker = Marker.None,
         val callback: QueryCallback<T>? = null
     ) : QueryCommand<T> {
 
@@ -54,7 +61,7 @@ object QueryCommands {
                 return
             }
             ctx.dispatch(QueryAction.Fetching(isInvalidated = true))
-            ctx.dispatchFetchResult(key, callback)
+            ctx.dispatchFetchResult(key, marker, callback)
         }
     }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryRef.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.completeWith
 import kotlinx.coroutines.flow.StateFlow
 import soil.query.core.Actor
+import soil.query.core.Marker
 import soil.query.core.awaitOrNull
 
 /**
@@ -17,7 +18,7 @@ import soil.query.core.awaitOrNull
 interface QueryRef<T> : Actor {
 
     val key: QueryKey<T>
-    val options: QueryOptions
+    val marker: Marker
     val state: StateFlow<QueryState<T>>
 
     /**
@@ -30,7 +31,7 @@ interface QueryRef<T> : Actor {
      */
     suspend fun resume() {
         val deferred = CompletableDeferred<T>()
-        send(QueryCommands.Connect(key, state.value.revision, deferred::completeWith))
+        send(QueryCommands.Connect(key, state.value.revision, marker, deferred::completeWith))
         deferred.awaitOrNull()
     }
 
@@ -42,7 +43,7 @@ interface QueryRef<T> : Actor {
      */
     suspend fun invalidate() {
         val deferred = CompletableDeferred<T>()
-        send(QueryCommands.Invalidate(key, state.value.revision, deferred::completeWith))
+        send(QueryCommands.Invalidate(key, state.value.revision, marker, deferred::completeWith))
         deferred.awaitOrNull()
     }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrInfiniteQuery.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrInfiniteQuery.kt
@@ -7,10 +7,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import soil.query.core.Marker
 
 internal class SwrInfiniteQuery<T, S>(
     override val key: InfiniteQueryKey<T, S>,
-    override val options: QueryOptions,
+    override val marker: Marker,
     private val query: Query<QueryChunks<T, S>>
 ) : InfiniteQueryRef<T, S> {
 

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrMutation.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrMutation.kt
@@ -6,10 +6,11 @@ package soil.query
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
+import soil.query.core.Marker
 
 internal class SwrMutation<T, S>(
     override val key: MutationKey<T, S>,
-    override val options: MutationOptions,
+    override val marker: Marker,
     private val mutation: Mutation<T>
 ) : MutationRef<T, S> {
 

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrQuery.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrQuery.kt
@@ -7,10 +7,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import soil.query.core.Marker
 
 internal class SwrQuery<T>(
     override val key: QueryKey<T>,
-    override val options: QueryOptions,
+    override val marker: Marker,
     private val query: Query<T>
 ) : QueryRef<T> {
 

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/ErrorRecord.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/ErrorRecord.kt
@@ -15,9 +15,12 @@ data class ErrorRecord internal constructor(
     val exception: Throwable,
 
     /**
-     * Key information that caused the error.
-     *
-     * NOTE: Defining an ID with a custom interface, such as metadata, can be helpful when receiving error information.
+     * The unique identifier of the key that caused the error.
      */
-    val key: UniqueId
+    val keyId: UniqueId,
+
+    /**
+     * The marker that was set when the error occurred.
+     */
+    val marker: Marker
 )

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/Marker.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/Marker.kt
@@ -1,0 +1,16 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+/**
+ * An interface for providing additional information based on the caller of a query or mutation.
+ *
+ * **Note:**
+ * You can include different information in the [ErrorRecord] depending on where the key is used.
+ * This is useful when you want to differentiate error messages based on the specific use case,
+ * even if the same query or mutation is used in multiple places.
+ */
+interface Marker {
+    companion object None : Marker
+}

--- a/soil-query-test/src/commonMain/kotlin/soil/query/test/TestSwrClient.kt
+++ b/soil-query-test/src/commonMain/kotlin/soil/query/test/TestSwrClient.kt
@@ -13,6 +13,7 @@ import soil.query.QueryId
 import soil.query.QueryKey
 import soil.query.QueryRef
 import soil.query.SwrClient
+import soil.query.core.Marker
 
 /**
  * This extended interface of the [SwrClient] provides the capability to mock specific queries and mutations for the purpose of testing.
@@ -71,32 +72,41 @@ internal class TestSwrClientImpl(
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T, S> getMutation(key: MutationKey<T, S>): MutationRef<T, S> {
+    override fun <T, S> getMutation(
+        key: MutationKey<T, S>,
+        marker: Marker
+    ): MutationRef<T, S> {
         val mock = mockMutations[key.id] as? FakeMutationMutate<T, S>
         return if (mock != null) {
-            target.getMutation(FakeMutationKey(key, mock))
+            target.getMutation(FakeMutationKey(key, mock), marker)
         } else {
-            target.getMutation(key)
+            target.getMutation(key, marker)
         }
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T> getQuery(key: QueryKey<T>): QueryRef<T> {
+    override fun <T> getQuery(
+        key: QueryKey<T>,
+        marker: Marker
+    ): QueryRef<T> {
         val mock = mockQueries[key.id] as? FakeQueryFetch<T>
         return if (mock != null) {
-            target.getQuery(FakeQueryKey(key, mock))
+            target.getQuery(FakeQueryKey(key, mock), marker)
         } else {
-            target.getQuery(key)
+            target.getQuery(key, marker)
         }
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T, S> getInfiniteQuery(key: InfiniteQueryKey<T, S>): InfiniteQueryRef<T, S> {
+    override fun <T, S> getInfiniteQuery(
+        key: InfiniteQueryKey<T, S>,
+        marker: Marker
+    ): InfiniteQueryRef<T, S> {
         val mock = mockInfiniteQueries[key.id] as? FakeInfiniteQueryFetch<T, S>
         return if (mock != null) {
-            target.getInfiniteQuery(FakeInfiniteQueryKey(key, mock))
+            target.getInfiniteQuery(FakeInfiniteQueryKey(key, mock), marker)
         } else {
-            target.getInfiniteQuery(key)
+            target.getInfiniteQuery(key, marker)
         }
     }
 }

--- a/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientTest.kt
+++ b/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientTest.kt
@@ -24,6 +24,7 @@ import soil.query.SwrCachePolicy
 import soil.query.buildInfiniteQueryKey
 import soil.query.buildMutationKey
 import soil.query.buildQueryKey
+import soil.query.core.Marker
 import soil.query.core.getOrThrow
 import soil.query.mutate
 import soil.testing.UnitTest
@@ -128,12 +129,12 @@ private class ExampleInfiniteQueryKey : InfiniteQueryKey<String, Int> by buildIn
 
 private suspend fun <T> QueryRef<T>.test(): T {
     val deferred = CompletableDeferred<T>()
-    send(QueryCommands.Connect(key, callback = deferred::completeWith))
+    send(QueryCommands.Connect(key, marker = Marker.None, callback = deferred::completeWith))
     return deferred.await()
 }
 
 private suspend fun <T, S> InfiniteQueryRef<T, S>.test(): QueryChunks<T, S> {
     val deferred = CompletableDeferred<QueryChunks<T, S>>()
-    send(InfiniteQueryCommands.Connect(key, callback = deferred::completeWith))
+    send(InfiniteQueryCommands.Connect(key, marker = Marker.None, callback = deferred::completeWith))
     return deferred.await()
 }


### PR DESCRIPTION
In #69, we implemented `QueryCachingStrategy`. To avoid the undesired practice of continually adding more arguments with future feature additions, we have introduced a separate configuration class specifically for Composable functions.