### PR TITLE
Tests in `query.compose.runtime` package 🧪

### DIFF
--- a/soil-query-compose-runtime/build.gradle.kts
+++ b/soil-query-compose-runtime/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
@@ -26,7 +27,13 @@ kotlin {
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        browser()
+        browser {
+            // TODO: We will consider using wasm tests when we update to 'org.jetbrains.compose.ui:ui:1.7.0' or later.
+            //  - https://slack-chats.kotlinlang.org/t/22883390/wasmjs-unit-testing-what-is-the-status-of-unit-testing-on-wa
+            testTask {
+                enabled = false
+            }
+        }
     }
 
     sourceSets {
@@ -36,6 +43,28 @@ kotlin {
             implementation(compose.runtime)
             implementation(compose.foundation)
             implementation(compose.ui)
+        }
+
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            @OptIn(ExperimentalComposeLibrary::class)
+            implementation(compose.uiTest)
+            implementation(compose.runtime)
+            implementation(compose.ui)
+            implementation(compose.material)
+            implementation(projects.internal.testing)
+            api(projects.soilQueryTest)
+        }
+
+        val androidUnitTest by getting {
+            dependencies {
+                implementation(libs.compose.ui.test.junit4.android)
+                implementation(libs.compose.ui.test.manifest)
+            }
+        }
+
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
         }
     }
 }
@@ -50,6 +79,7 @@ android {
 
     defaultConfig {
         minSdk = buildTarget.androidMinSdk.get()
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     packaging {
         resources {
@@ -64,6 +94,10 @@ android {
     compileOptions {
         sourceCompatibility = buildTarget.javaVersion.get()
         targetCompatibility = buildTarget.javaVersion.get()
+    }
+    @Suppress("UnstableApiUsage")
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
     }
     dependencies {
         debugImplementation(libs.compose.ui.tooling)

--- a/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/AwaitTest.kt
+++ b/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/AwaitTest.kt
@@ -1,0 +1,245 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.runtime
+
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.waitUntilDoesNotExist
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import soil.query.InfiniteQueryId
+import soil.query.InfiniteQueryKey
+import soil.query.QueryId
+import soil.query.QueryKey
+import soil.query.SwrCache
+import soil.query.SwrCacheScope
+import soil.query.buildInfiniteQueryKey
+import soil.query.buildQueryKey
+import soil.query.compose.SwrClientProvider
+import soil.query.compose.rememberInfiniteQuery
+import soil.query.compose.rememberQuery
+import soil.query.test.test
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.time.Duration
+
+@OptIn(ExperimentalTestApi::class)
+class AwaitTest : UnitTest() {
+
+    @Test
+    fun testAwait() = runComposeUiTest {
+        val deferred = CompletableDeferred<String>()
+        val key = TestQueryKey("foo")
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test {
+            mock(key.id) { deferred.await() }
+        }
+        setContent {
+            SwrClientProvider(client) {
+                val query = rememberQuery(key)
+                Await(query) { data ->
+                    Text(data, modifier = Modifier.testTag("await"))
+                }
+            }
+        }
+        waitForIdle()
+        onNodeWithTag("await").assertDoesNotExist()
+
+        deferred.complete("Hello, Soil!")
+        waitUntilExactlyOneExists(hasTestTag("await"))
+        onNodeWithTag("await").assertTextEquals("Hello, Soil!")
+    }
+
+    @Test
+    fun testAwait_pair() = runComposeUiTest {
+        val deferred1 = CompletableDeferred<String>()
+        val deferred2 = CompletableDeferred<String>()
+        val key1 = TestQueryKey("foo")
+        val key2 = TestQueryKey("bar")
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test {
+            mock(key1.id) { deferred1.await() }
+            mock(key2.id) { deferred2.await() }
+        }
+        setContent {
+            SwrClientProvider(client) {
+                val query1 = rememberQuery(key1)
+                val query2 = rememberQuery(key2)
+                Await(query1, query2) { data1, data2 ->
+                    Text(data1 + data2, modifier = Modifier.testTag("await"))
+                }
+            }
+        }
+        waitForIdle()
+        onNodeWithTag("await").assertDoesNotExist()
+
+        deferred1.complete("Hello, Soil!")
+        waitForIdle()
+        onNodeWithTag("await").assertDoesNotExist()
+
+        deferred2.complete("Hello, Compose!")
+        waitUntilExactlyOneExists(hasTestTag("await"))
+        onNodeWithTag("await").assertTextEquals("Hello, Soil!Hello, Compose!")
+    }
+
+    @Test
+    fun testAwait_triple() = runComposeUiTest {
+        val deferred1 = CompletableDeferred<String>()
+        val deferred2 = CompletableDeferred<String>()
+        val deferred3 = CompletableDeferred<Int>()
+        val key1 = TestQueryKey("foo")
+        val key2 = TestQueryKey("bar")
+        val key3 = TestInfiniteQueryKey()
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test {
+            mock(key1.id) { deferred1.await() }
+            mock(key2.id) { deferred2.await() }
+            mock(key3.id) { deferred3.await() }
+        }
+        setContent {
+            SwrClientProvider(client) {
+                val query1 = rememberQuery(key1)
+                val query2 = rememberQuery(key2)
+                val query3 = rememberInfiniteQuery(key3, select = { it.first().data })
+                Await(query1, query2, query3) { data1, data2, data3 ->
+                    Text(data1 + data2 + data3, modifier = Modifier.testTag("await"))
+                }
+            }
+        }
+        waitForIdle()
+        onNodeWithTag("await").assertDoesNotExist()
+
+        deferred1.complete("Hello, Soil!")
+        waitForIdle()
+        onNodeWithTag("await").assertDoesNotExist()
+
+        deferred2.complete("Hello, Compose!")
+        waitForIdle()
+        onNodeWithTag("await").assertDoesNotExist()
+
+        deferred3.complete(3)
+        waitUntilExactlyOneExists(hasTestTag("await"))
+        onNodeWithTag("await").assertTextEquals("Hello, Soil!Hello, Compose!3")
+    }
+
+    @Test
+    fun testAwait_withSuspense() = runComposeUiTest {
+        val deferred1 = CompletableDeferred<String>()
+        val deferred2 = CompletableDeferred<String>()
+        val key1 = TestQueryKey("foo")
+        val key2 = TestQueryKey("bar")
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test {
+            mock(key1.id) { deferred1.await() }
+            mock(key2.id) { deferred2.await() }
+        }
+        setContent {
+            SwrClientProvider(client) {
+                val query1 = rememberQuery(key1)
+                val query2 = rememberQuery(key2)
+                Suspense(
+                    fallback = { Text("Loading...", modifier = Modifier.testTag("fallback")) }
+                ) {
+                    Await(query1, query2) { data1, data2 ->
+                        Text(data1 + data2, modifier = Modifier.testTag("await"))
+                    }
+                }
+            }
+        }
+        waitForIdle()
+        waitUntilExactlyOneExists(hasTestTag("fallback"))
+        onNodeWithTag("fallback").assertTextEquals("Loading...")
+        onNodeWithTag("await").assertDoesNotExist()
+
+        deferred1.complete("Hello, Soil!")
+        waitForIdle()
+        onNodeWithTag("fallback").assertTextEquals("Loading...")
+        onNodeWithTag("await").assertDoesNotExist()
+
+        deferred2.complete("Hello, Compose!")
+        waitUntilExactlyOneExists(hasTestTag("await"))
+        onNodeWithTag("await").assertTextEquals("Hello, Soil!Hello, Compose!")
+        onNodeWithTag("fallback").assertDoesNotExist()
+    }
+
+    @Test
+    fun testAwait_withSuspense_refresh() = runComposeUiTest {
+        val deferred1 = CompletableDeferred<String>()
+        val deferred2 = CompletableDeferred<String>()
+        var isFirst = true
+        val key = TestQueryKey("foo")
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test {
+            mock(key.id) {
+                if (isFirst) {
+                    isFirst = false
+                    deferred1.await()
+                } else {
+                    deferred2.await()
+                }
+            }
+        }
+        setContent {
+            SwrClientProvider(client) {
+                val query = rememberQuery(key)
+                Suspense(
+                    fallback = { Text("Loading...", modifier = Modifier.testTag("fallback")) },
+                    contentThreshold = Duration.ZERO
+                ) {
+                    Await(query) { data ->
+                        Text(data, modifier = Modifier.testTag("await"))
+                    }
+                }
+                val scope = rememberCoroutineScope()
+                Button(
+                    onClick = { scope.launch { query.refresh() } },
+                    modifier = Modifier.testTag("refresh")
+                ) {
+                    Text("Refresh")
+                }
+            }
+        }
+        waitForIdle()
+        waitUntilExactlyOneExists(hasTestTag("fallback"))
+        onNodeWithTag("fallback").assertTextEquals("Loading...")
+        onNodeWithTag("await").assertDoesNotExist()
+
+        deferred1.complete("Hello, Soil!")
+        waitForIdle()
+        waitUntilExactlyOneExists(hasTestTag("await"))
+        onNodeWithTag("await").assertTextEquals("Hello, Soil!")
+        onNodeWithTag("fallback").assertDoesNotExist()
+
+        onNodeWithTag("refresh").performClick()
+        waitForIdle()
+        waitUntilExactlyOneExists(hasTestTag("fallback"))
+        onNodeWithTag("fallback").assertTextEquals("Loading...")
+        onNodeWithTag("await").assertTextEquals("Hello, Soil!")
+
+        deferred2.complete("Hello, Compose!")
+        waitUntilDoesNotExist(hasTestTag("fallback"))
+        onNodeWithTag("await").assertTextEquals("Hello, Compose!")
+    }
+
+    private class TestQueryKey(val variant: String) : QueryKey<String> by buildQueryKey(
+        id = Id(variant),
+        fetch = { "Hello, Soil!" }
+    ) {
+        class Id(variant: String) : QueryId<String>("test/query", "variant" to variant)
+    }
+
+    private class TestInfiniteQueryKey : InfiniteQueryKey<Int, Int> by buildInfiniteQueryKey(
+        id = Id,
+        fetch = { it },
+        initialParam = { 0 },
+        loadMoreParam = { it.last().param + 1 }
+    ) {
+        object Id : InfiniteQueryId<Int, Int>("test/infinite-query")
+    }
+}

--- a/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/CatchTest.kt
+++ b/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/CatchTest.kt
@@ -1,0 +1,130 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.runtime
+
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import soil.query.QueryId
+import soil.query.QueryKey
+import soil.query.SwrCache
+import soil.query.SwrCacheScope
+import soil.query.buildQueryKey
+import soil.query.compose.SwrClientProvider
+import soil.query.compose.rememberQuery
+import soil.query.test.test
+import soil.testing.UnitTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class CatchTest : UnitTest() {
+
+    @Test
+    fun testCatch() = runComposeUiTest {
+        val deferred1 = CompletableDeferred<String>()
+        val deferred2 = CompletableDeferred<String>()
+        var isFirst = true
+        val key = TestQueryKey("foo")
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test {
+            mock(key.id) {
+                if (isFirst) {
+                    isFirst = false
+                    deferred1.await()
+                } else {
+                    deferred2.await()
+                }
+            }
+        }
+        setContent {
+            SwrClientProvider(client) {
+                val query = rememberQuery(key)
+                Catch(query) {
+                    Text("Error", modifier = Modifier.testTag("catch"))
+                }
+                val scope = rememberCoroutineScope()
+                Button(
+                    onClick = { scope.launch { query.refresh() } },
+                    modifier = Modifier.testTag("refresh")
+                ) {
+                    Text("Refresh")
+                }
+            }
+        }
+        waitForIdle()
+        onNodeWithTag("catch").assertDoesNotExist()
+
+        deferred1.completeExceptionally(RuntimeException("Error"))
+        waitUntilExactlyOneExists(hasTestTag("catch"))
+        onNodeWithTag("catch").assertTextEquals("Error")
+
+        onNodeWithTag("refresh").performClick()
+        deferred2.complete("Hello, Soil!")
+        waitForIdle()
+        onNodeWithTag("catch").assertDoesNotExist()
+    }
+
+    @Test
+    fun testCatch_withErrorBoundary() = runComposeUiTest {
+        val deferred1 = CompletableDeferred<String>()
+        val deferred2 = CompletableDeferred<String>()
+        var isFirst = true
+        val key = TestQueryKey("foo")
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test {
+            mock(key.id) {
+                if (isFirst) {
+                    isFirst = false
+                    deferred1.await()
+                } else {
+                    deferred2.await()
+                }
+            }
+        }
+        setContent {
+            SwrClientProvider(client) {
+                val query = rememberQuery(key)
+                ErrorBoundary(
+                    fallback = { Text("Error", modifier = Modifier.testTag("fallback")) }
+                ) {
+                    Catch(query)
+                }
+                val scope = rememberCoroutineScope()
+                Button(
+                    onClick = { scope.launch { query.refresh() } },
+                    modifier = Modifier.testTag("refresh")
+                ) {
+                    Text("Refresh")
+                }
+            }
+        }
+        waitForIdle()
+        onNodeWithTag("fallback").assertDoesNotExist()
+
+        deferred1.completeExceptionally(RuntimeException("Error"))
+        waitUntilExactlyOneExists(hasTestTag("fallback"))
+        onNodeWithTag("fallback").assertTextEquals("Error")
+
+        onNodeWithTag("refresh").performClick()
+        deferred2.complete("Hello, Soil!")
+        waitForIdle()
+        onNodeWithTag("fallback").assertDoesNotExist()
+    }
+
+    private class TestQueryKey(val variant: String) : QueryKey<String> by buildQueryKey(
+        id = Id(variant),
+        fetch = { "Hello, Soil!" }
+    ) {
+        class Id(variant: String) : QueryId<String>("test/query", "variant" to variant)
+    }
+}

--- a/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/SuspenseTest.kt
+++ b/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/SuspenseTest.kt
@@ -1,0 +1,56 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.runtime
+
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import soil.testing.UnitTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class SuspenseTest : UnitTest() {
+
+    @Test
+    fun testSuspense() = runComposeUiTest {
+        setContent {
+            var state by remember { mutableStateOf<Loadable<String>>(Loadable.Pending) }
+            Suspense(
+                fallback = { Text("Loading...", modifier = Modifier.testTag("fallback")) }
+            ) {
+                Await(state) {
+                    Text(it, modifier = Modifier.testTag("content"))
+                }
+            }
+            Button(
+                onClick = {
+                    state = Loadable.Fulfilled("Hello, Soil!")
+                },
+                modifier = Modifier.testTag("load")
+            ) {
+                Text("Load")
+            }
+        }
+
+        waitUntilExactlyOneExists(hasTestTag("fallback"))
+        onNodeWithTag("fallback").assertTextEquals("Loading...")
+
+        onNodeWithTag("load").performClick()
+        waitUntilExactlyOneExists(hasTestTag("content"))
+        onNodeWithTag("content").assertTextEquals("Hello, Soil!")
+        onNodeWithTag("fallback").assertDoesNotExist()
+    }
+}

--- a/soil-query-compose/build.gradle.kts
+++ b/soil-query-compose/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
             implementation(compose.ui)
             implementation(compose.material)
             implementation(projects.internal.testing)
+            api(projects.soilQueryTest)
         }
 
         val androidUnitTest by getting {


### PR DESCRIPTION
We have added some test code related to the `query.compose.runtime` package.