### PR TITLE
Create an instance of BatchScheduler via a factory function

### DIFF
--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCache.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCache.kt
@@ -75,17 +75,15 @@ class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutableClie
     private val queryReceiver = policy.queryReceiver
     private val queryStore: MutableMap<UniqueId, ManagedQuery<*>> = mutableMapOf()
     private val queryCache: QueryCache = policy.queryCache
-    private val batchScheduler: BatchScheduler = policy.batchScheduler
     private val coroutineScope: CoroutineScope = CoroutineScope(
         context = newCoroutineContext(policy.coroutineScope)
     )
+    private val batchScheduler: BatchScheduler by lazy {
+        policy.batchSchedulerFactory.create(coroutineScope)
+    }
 
     private var mountedIds: Set<String> = emptySet()
     private var mountedScope: CoroutineScope? = null
-
-    init {
-        batchScheduler.start(coroutineScope)
-    }
 
     /**
      * Releases data in memory based on the specified [level].

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePolicy.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePolicy.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import soil.query.core.BatchScheduler
+import soil.query.core.BatchSchedulerFactory
 import soil.query.core.ErrorRelay
 import soil.query.core.MemoryPressure
 import soil.query.core.NetworkConnectivity
@@ -69,7 +70,7 @@ class SwrCachePolicy(
      * This is used for internal processes such as moving inactive query caches.
      * Please avoid changing this unless you need to substitute it for testing purposes.
      */
-    val batchScheduler: BatchScheduler = BatchScheduler.default(mainDispatcher),
+    val batchSchedulerFactory: BatchSchedulerFactory = BatchSchedulerFactory.default(mainDispatcher),
 
     /**
      * Specify the mechanism of [ErrorRelay] when using [SwrClient.errorRelay].

--- a/soil-query-core/src/commonTest/kotlin/soil/query/core/BatchSchedulerTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/core/BatchSchedulerTest.kt
@@ -20,13 +20,13 @@ class BatchSchedulerTest : UnitTest() {
 
     @Test
     fun testDefault_chunkSizeTrigger() = runTest {
-        val scheduler = BatchScheduler.default(
+        val factory = BatchSchedulerFactory.default(
             dispatcher = StandardTestDispatcher(testScheduler),
             interval = 3.seconds,
             chunkSize = 3
         )
         val scope = CoroutineScope(backgroundScope.coroutineContext + UnconfinedTestDispatcher(testScheduler))
-        scheduler.start(scope)
+        val scheduler = factory.create(scope)
         val task = TestBatchTask()
 
         scheduler.post(task)
@@ -43,13 +43,13 @@ class BatchSchedulerTest : UnitTest() {
 
     @Test
     fun testDefault_intervalTrigger() = runTest {
-        val scheduler = BatchScheduler.default(
+        val factory = BatchSchedulerFactory.default(
             dispatcher = StandardTestDispatcher(testScheduler),
             interval = 3.seconds,
             chunkSize = 3
         )
         val scope = CoroutineScope(backgroundScope.coroutineContext + UnconfinedTestDispatcher(testScheduler))
-        scheduler.start(scope)
+        val scheduler = factory.create(scope)
         val task = TestBatchTask()
 
         scheduler.post(task)


### PR DESCRIPTION
By making it a factory function, it is possible to defer creation until it is needed.

refs: #66