### PR TITLE
Rename `mock(xx)` to `on(xx)`

### DIFF
--- a/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/AwaitTest.kt
+++ b/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/AwaitTest.kt
@@ -42,7 +42,7 @@ class AwaitTest : UnitTest() {
         val deferred = CompletableDeferred<String>()
         val key = TestQueryKey("foo")
         val client = SwrCache(coroutineScope = SwrCacheScope()).test {
-            mock(key.id) { deferred.await() }
+            on(key.id) { deferred.await() }
         }
         setContent {
             SwrClientProvider(client) {
@@ -67,8 +67,8 @@ class AwaitTest : UnitTest() {
         val key1 = TestQueryKey("foo")
         val key2 = TestQueryKey("bar")
         val client = SwrCache(coroutineScope = SwrCacheScope()).test {
-            mock(key1.id) { deferred1.await() }
-            mock(key2.id) { deferred2.await() }
+            on(key1.id) { deferred1.await() }
+            on(key2.id) { deferred2.await() }
         }
         setContent {
             SwrClientProvider(client) {
@@ -100,9 +100,9 @@ class AwaitTest : UnitTest() {
         val key2 = TestQueryKey("bar")
         val key3 = TestInfiniteQueryKey()
         val client = SwrCache(coroutineScope = SwrCacheScope()).test {
-            mock(key1.id) { deferred1.await() }
-            mock(key2.id) { deferred2.await() }
-            mock(key3.id) { deferred3.await() }
+            on(key1.id) { deferred1.await() }
+            on(key2.id) { deferred2.await() }
+            on(key3.id) { deferred3.await() }
         }
         setContent {
             SwrClientProvider(client) {
@@ -137,8 +137,8 @@ class AwaitTest : UnitTest() {
         val key1 = TestQueryKey("foo")
         val key2 = TestQueryKey("bar")
         val client = SwrCache(coroutineScope = SwrCacheScope()).test {
-            mock(key1.id) { deferred1.await() }
-            mock(key2.id) { deferred2.await() }
+            on(key1.id) { deferred1.await() }
+            on(key2.id) { deferred2.await() }
         }
         setContent {
             SwrClientProvider(client) {
@@ -176,7 +176,7 @@ class AwaitTest : UnitTest() {
         var isFirst = true
         val key = TestQueryKey("foo")
         val client = SwrCache(coroutineScope = SwrCacheScope()).test {
-            mock(key.id) {
+            on(key.id) {
                 if (isFirst) {
                     isFirst = false
                     deferred1.await()

--- a/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/CatchTest.kt
+++ b/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/CatchTest.kt
@@ -38,7 +38,7 @@ class CatchTest : UnitTest() {
         var isFirst = true
         val key = TestQueryKey("foo")
         val client = SwrCache(coroutineScope = SwrCacheScope()).test {
-            mock(key.id) {
+            on(key.id) {
                 if (isFirst) {
                     isFirst = false
                     deferred1.await()
@@ -82,7 +82,7 @@ class CatchTest : UnitTest() {
         var isFirst = true
         val key = TestQueryKey("foo")
         val client = SwrCache(coroutineScope = SwrCacheScope()).test {
-            mock(key.id) {
+            on(key.id) {
                 if (isFirst) {
                     isFirst = false
                     deferred1.await()

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationComposableTest.kt
@@ -72,7 +72,7 @@ class MutationComposableTest : UnitTest() {
     fun testRememberMutation_throwError() = runComposeUiTest {
         val key = TestMutationKey()
         val client = SwrCache(coroutineScope = SwrCacheScope()).test {
-            mock(key.id) { throw RuntimeException("Failed to do something :(") }
+            on(key.id) { throw RuntimeException("Failed to do something :(") }
         }
         setContent {
             SwrClientProvider(client) {
@@ -111,7 +111,7 @@ class MutationComposableTest : UnitTest() {
     fun testRememberMutation_throwErrorAsync() = runComposeUiTest {
         val key = TestMutationKey()
         val client = SwrCache(coroutineScope = SwrCacheScope()).test {
-            mock(key.id) { throw RuntimeException("Failed to do something :(") }
+            on(key.id) { throw RuntimeException("Failed to do something :(") }
         }
         setContent {
             SwrClientProvider(client) {

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryComposableTest.kt
@@ -54,7 +54,7 @@ class QueryComposableTest : UnitTest() {
     fun testRememberQuery_select() = runComposeUiTest {
         val key = TestQueryKey()
         val client = SwrCache(coroutineScope = SwrCacheScope()).test {
-            mock(key.id) { "Hello, Soil!" }
+            on(key.id) { "Hello, Soil!" }
         }
         setContent {
             SwrClientProvider(client) {
@@ -74,7 +74,7 @@ class QueryComposableTest : UnitTest() {
     fun testRememberQuery_throwError() = runComposeUiTest {
         val key = TestQueryKey()
         val client = SwrCache(coroutineScope = SwrCacheScope()).test {
-            mock(key.id) { throw RuntimeException("Failed to do something :(") }
+            on(key.id) { throw RuntimeException("Failed to do something :(") }
         }
         setContent {
             SwrClientProvider(client) {

--- a/soil-query-test/src/commonMain/kotlin/soil/query/test/TestSwrClient.kt
+++ b/soil-query-test/src/commonMain/kotlin/soil/query/test/TestSwrClient.kt
@@ -22,8 +22,9 @@ import soil.query.core.Marker
  *
  * ```kotlin
  * val client = SwrCache(..)
- * val testClient = client.test()
- * testClient.mock(MyQueryId) { "returned fake data" }
+ * val testClient = client.test {
+ *      on(MyQueryId) { "returned fake data" }
+ * }
  *
  * testClient.doSomething()
  * ```
@@ -33,17 +34,17 @@ interface TestSwrClient : SwrClient {
     /**
      * Mocks the mutation process corresponding to [MutationId].
      */
-    fun <T, S> mock(id: MutationId<T, S>, mutate: FakeMutationMutate<T, S>)
+    fun <T, S> on(id: MutationId<T, S>, mutate: FakeMutationMutate<T, S>)
 
     /**
      * Mocks the query process corresponding to [QueryId].
      */
-    fun <T> mock(id: QueryId<T>, fetch: FakeQueryFetch<T>)
+    fun <T> on(id: QueryId<T>, fetch: FakeQueryFetch<T>)
 
     /**
      * Mocks the query process corresponding to [InfiniteQueryId].
      */
-    fun <T, S> mock(id: InfiniteQueryId<T, S>, fetch: FakeInfiniteQueryFetch<T, S>)
+    fun <T, S> on(id: InfiniteQueryId<T, S>, fetch: FakeInfiniteQueryFetch<T, S>)
 }
 
 /**
@@ -61,15 +62,15 @@ internal class TestSwrClientImpl(
     private val mockQueries = mutableMapOf<QueryId<*>, FakeQueryFetch<*>>()
     private val mockInfiniteQueries = mutableMapOf<InfiniteQueryId<*, *>, FakeInfiniteQueryFetch<*, *>>()
 
-    override fun <T, S> mock(id: MutationId<T, S>, mutate: FakeMutationMutate<T, S>) {
+    override fun <T, S> on(id: MutationId<T, S>, mutate: FakeMutationMutate<T, S>) {
         mockMutations[id] = mutate
     }
 
-    override fun <T> mock(id: QueryId<T>, fetch: FakeQueryFetch<T>) {
+    override fun <T> on(id: QueryId<T>, fetch: FakeQueryFetch<T>) {
         mockQueries[id] = fetch
     }
 
-    override fun <T, S> mock(id: InfiniteQueryId<T, S>, fetch: FakeInfiniteQueryFetch<T, S>) {
+    override fun <T, S> on(id: InfiniteQueryId<T, S>, fetch: FakeInfiniteQueryFetch<T, S>) {
         mockInfiniteQueries[id] = fetch
     }
 

--- a/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientTest.kt
+++ b/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientTest.kt
@@ -26,7 +26,6 @@ import soil.query.buildMutationKey
 import soil.query.buildQueryKey
 import soil.query.core.Marker
 import soil.query.core.getOrThrow
-import soil.query.mutate
 import soil.testing.UnitTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -42,10 +41,8 @@ class TestSwrClientTest : UnitTest() {
                 mainDispatcher = UnconfinedTestDispatcher(testScheduler)
             )
         )
-        val testClient = client.test().apply {
-            mock(ExampleMutationKey.Id) {
-                "Hello, World!"
-            }
+        val testClient = client.test {
+            on(ExampleMutationKey.Id) { "Hello, World!" }
         }
         val key = ExampleMutationKey()
         val mutation = testClient.getMutation(key).also { it.launchIn(backgroundScope) }
@@ -61,10 +58,8 @@ class TestSwrClientTest : UnitTest() {
                 mainDispatcher = UnconfinedTestDispatcher(testScheduler)
             )
         )
-        val testClient = client.test().apply {
-            mock(ExampleQueryKey.Id) {
-                "Hello, World!"
-            }
+        val testClient = client.test {
+            on(ExampleQueryKey.Id) { "Hello, World!" }
         }
         val key = ExampleQueryKey()
         val query = testClient.getQuery(key).also { it.launchIn(backgroundScope) }
@@ -80,10 +75,8 @@ class TestSwrClientTest : UnitTest() {
                 mainDispatcher = UnconfinedTestDispatcher(testScheduler)
             )
         )
-        val testClient = client.test().apply {
-            mock(ExampleInfiniteQueryKey.Id) {
-                "Hello, World!"
-            }
+        val testClient = client.test {
+            on(ExampleInfiniteQueryKey.Id) { "Hello, World!" }
         }
         val key = ExampleInfiniteQueryKey()
         val query = testClient.getInfiniteQuery(key).also { it.launchIn(backgroundScope) }


### PR DESCRIPTION
Aligning PreviewClient implementation and naming reduces cognitive load.

refs: #63, #70