### PR TITLE
Using XxxOptions via the XxxRef interface

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
@@ -39,11 +39,13 @@ class MutationPreviewClient(
         marker: Marker
     ): MutationRef<T, S> {
         val state = previewData[key.id] as? MutationState<T> ?: MutationState.initial()
-        return SnapshotMutation(key, marker, MutableStateFlow(state))
+        val options = key.onConfigureOptions()?.invoke(defaultMutationOptions) ?: defaultMutationOptions
+        return SnapshotMutation(key, options, marker, MutableStateFlow(state))
     }
 
     private class SnapshotMutation<T, S>(
         override val key: MutationKey<T, S>,
+        override val options: MutationOptions,
         override val marker: Marker,
         override val state: StateFlow<MutationState<T>>
     ) : MutationRef<T, S> {

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
@@ -44,7 +44,8 @@ class QueryPreviewClient(
         marker: Marker
     ): QueryRef<T> {
         val state = previewData[key.id] as? QueryState<T> ?: QueryState.initial()
-        return SnapshotQuery(key, marker, MutableStateFlow(state))
+        val options = key.onConfigureOptions()?.invoke(defaultQueryOptions) ?: defaultQueryOptions
+        return SnapshotQuery(key, options, marker, MutableStateFlow(state))
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -53,7 +54,8 @@ class QueryPreviewClient(
         marker: Marker
     ): InfiniteQueryRef<T, S> {
         val state = previewData[key.id] as? QueryState<QueryChunks<T, S>> ?: QueryState.initial()
-        return SnapshotInfiniteQuery(key, marker, MutableStateFlow(state))
+        val options = key.onConfigureOptions()?.invoke(defaultQueryOptions) ?: defaultQueryOptions
+        return SnapshotInfiniteQuery(key, options, marker, MutableStateFlow(state))
     }
 
     override fun <T> prefetchQuery(
@@ -68,6 +70,7 @@ class QueryPreviewClient(
 
     private class SnapshotQuery<T>(
         override val key: QueryKey<T>,
+        override val options: QueryOptions,
         override val marker: Marker,
         override val state: StateFlow<QueryState<T>>
     ) : QueryRef<T> {
@@ -79,6 +82,7 @@ class QueryPreviewClient(
 
     private class SnapshotInfiniteQuery<T, S>(
         override val key: InfiniteQueryKey<T, S>,
+        override val options: QueryOptions,
         override val marker: Marker,
         override val state: StateFlow<QueryState<QueryChunks<T, S>>>
     ) : InfiniteQueryRef<T, S> {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryRef.kt
@@ -18,8 +18,24 @@ import soil.query.core.awaitOrNull
  */
 interface InfiniteQueryRef<T, S> : Actor {
 
+    /**
+     * The [InfiniteQueryKey] for the Query.
+     */
     val key: InfiniteQueryKey<T, S>
+
+    /**
+     * The QueryOptions configured for the query.
+     */
+    val options: QueryOptions
+
+    /**
+     * The Marker specified in [QueryClient.getInfiniteQuery].
+     */
     val marker: Marker
+
+    /**
+     * [State Flow][StateFlow] to receive the current state of the query.
+     */
     val state: StateFlow<QueryState<QueryChunks<T, S>>>
 
     /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/Mutation.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/Mutation.kt
@@ -15,6 +15,11 @@ import soil.query.core.Actor
 internal interface Mutation<T> : Actor {
 
     /**
+     * The MutationOptions configured for the mutation.
+     */
+    val options: MutationOptions
+
+    /**
      * [State Flow][StateFlow] to receive the current state of the mutation.
      */
     val state: StateFlow<MutationState<T>>

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationRef.kt
@@ -17,8 +17,24 @@ import soil.query.core.Marker
  */
 interface MutationRef<T, S> : Actor {
 
+    /**
+     * The [MutationKey] for the Mutation.
+     */
     val key: MutationKey<T, S>
+
+    /**
+     * The MutationOptions configured for the mutation.
+     */
+    val options: MutationOptions
+
+    /**
+     * The Marker specified in [MutationClient.getMutation].
+     */
     val marker: Marker
+
+    /**
+     * [State Flow][StateFlow] to receive the current state of the mutation.
+     */
     val state: StateFlow<MutationState<T>>
 
     /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/Query.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/Query.kt
@@ -13,7 +13,12 @@ import soil.query.core.Actor
  *
  * @param T Type of the return value from the query.
  */
-internal interface Query<T>: Actor {
+internal interface Query<T> : Actor {
+
+    /**
+     * The QueryOptions configured for the query.
+     */
+    val options: QueryOptions
 
     /**
      * [Shared Flow][SharedFlow] to receive query [events][QueryEvent].

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryRef.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryRef.kt
@@ -17,8 +17,24 @@ import soil.query.core.awaitOrNull
  */
 interface QueryRef<T> : Actor {
 
+    /**
+     * The [QueryKey] for the Query.
+     */
     val key: QueryKey<T>
+
+    /**
+     * The QueryOptions configured for the query.
+     */
+    val options: QueryOptions
+
+    /**
+     * The Marker specified in [QueryClient.getQuery].
+     */
     val marker: Marker
+
+    /**
+     * [State Flow][StateFlow] to receive the current state of the query.
+     */
     val state: StateFlow<QueryState<T>>
 
     /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrInfiniteQuery.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrInfiniteQuery.kt
@@ -15,6 +15,9 @@ internal class SwrInfiniteQuery<T, S>(
     private val query: Query<QueryChunks<T, S>>
 ) : InfiniteQueryRef<T, S> {
 
+    override val options: QueryOptions
+        get() = query.options
+
     override val state: StateFlow<QueryState<QueryChunks<T, S>>>
         get() = query.state
 

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrMutation.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrMutation.kt
@@ -14,6 +14,9 @@ internal class SwrMutation<T, S>(
     private val mutation: Mutation<T>
 ) : MutationRef<T, S> {
 
+    override val options: MutationOptions
+        get() = mutation.options
+
     override val state: StateFlow<MutationState<T>>
         get() = mutation.state
 

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrQuery.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrQuery.kt
@@ -15,6 +15,9 @@ internal class SwrQuery<T>(
     private val query: Query<T>
 ) : QueryRef<T> {
 
+    override val options: QueryOptions
+        get() = query.options
+
     override val state: StateFlow<QueryState<T>>
         get() = query.state
 


### PR DESCRIPTION
With the implementation of the Strategy Interface (#84), we believe there will be cases in the future where players will want to refer to the options, so we have made the change so that they can be referenced.

refs: #84