### PR TITLE
Implements a ObjectMapper class for Compose

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryConfig.kt
@@ -15,15 +15,18 @@ import soil.query.core.Marker
 @Immutable
 data class InfiniteQueryConfig internal constructor(
     val strategy: InfiniteQueryStrategy,
+    val mapper: InfiniteQueryObjectMapper,
     val marker: Marker
 ) {
 
     class Builder {
         var strategy: InfiniteQueryStrategy = Default.strategy
+        var mapper: InfiniteQueryObjectMapper = Default.mapper
         var marker: Marker = Default.marker
 
         fun build() = InfiniteQueryConfig(
             strategy = strategy,
+            mapper = mapper,
             marker = marker
         )
     }
@@ -31,6 +34,7 @@ data class InfiniteQueryConfig internal constructor(
     companion object {
         val Default = InfiniteQueryConfig(
             strategy = InfiniteQueryStrategy.Default,
+            mapper = InfiniteQueryObjectMapper.Default,
             marker = Marker.None
         )
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryObject.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryObject.kt
@@ -50,7 +50,7 @@ sealed interface InfiniteQueryObject<out T, S> : QueryModel<T> {
  * @constructor Creates a [InfiniteQueryLoadingObject].
  */
 @Immutable
-data class InfiniteQueryLoadingObject<T, S> internal constructor(
+data class InfiniteQueryLoadingObject<T, S>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable?,
@@ -74,7 +74,7 @@ data class InfiniteQueryLoadingObject<T, S> internal constructor(
  * @constructor Creates a [InfiniteQueryLoadingErrorObject].
  */
 @Immutable
-data class InfiniteQueryLoadingErrorObject<T, S> internal constructor(
+data class InfiniteQueryLoadingErrorObject<T, S>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable,
@@ -98,7 +98,7 @@ data class InfiniteQueryLoadingErrorObject<T, S> internal constructor(
  * @constructor Creates a [InfiniteQuerySuccessObject].
  */
 @Immutable
-data class InfiniteQuerySuccessObject<T, S> internal constructor(
+data class InfiniteQuerySuccessObject<T, S>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable?,
@@ -124,7 +124,7 @@ data class InfiniteQuerySuccessObject<T, S> internal constructor(
  * @constructor Creates a [InfiniteQueryRefreshErrorObject].
  */
 @Immutable
-data class InfiniteQueryRefreshErrorObject<T, S> internal constructor(
+data class InfiniteQueryRefreshErrorObject<T, S>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable,

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryObjectMapper.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryObjectMapper.kt
@@ -1,0 +1,99 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import soil.query.InfiniteQueryRef
+import soil.query.QueryChunks
+import soil.query.QueryState
+import soil.query.QueryStatus
+import soil.query.core.getOrThrow
+import soil.query.core.isNone
+import soil.query.core.map
+
+/**
+ * A mapper that converts [QueryState] to [InfiniteQueryObject].
+ */
+interface InfiniteQueryObjectMapper {
+
+    /**
+     * Converts the given [QueryState] to [InfiniteQueryObject].
+     *
+     * @param query The query reference.
+     * @param select A function that selects the object from the chunks.
+     * @return The converted object.
+     */
+    fun <T, S, U> QueryState<QueryChunks<T, S>>.toObject(
+        query: InfiniteQueryRef<T, S>,
+        select: (chunks: QueryChunks<T, S>) -> U
+    ): InfiniteQueryObject<U, S>
+
+    companion object
+}
+
+/**
+ * The default [InfiniteQueryObjectMapper].
+ */
+val InfiniteQueryObjectMapper.Companion.Default: InfiniteQueryObjectMapper
+    get() = DefaultInfiniteQueryObjectMapper
+
+private object DefaultInfiniteQueryObjectMapper : InfiniteQueryObjectMapper {
+    override fun <T, S, U> QueryState<QueryChunks<T, S>>.toObject(
+        query: InfiniteQueryRef<T, S>,
+        select: (chunks: QueryChunks<T, S>) -> U
+    ): InfiniteQueryObject<U, S> = when (status) {
+        QueryStatus.Pending -> InfiniteQueryLoadingObject(
+            reply = reply.map(select),
+            replyUpdatedAt = replyUpdatedAt,
+            error = error,
+            errorUpdatedAt = errorUpdatedAt,
+            staleAt = staleAt,
+            fetchStatus = fetchStatus,
+            isInvalidated = isInvalidated,
+            refresh = query::invalidate,
+            loadMore = query::loadMore,
+            loadMoreParam = null
+        )
+
+        QueryStatus.Success -> InfiniteQuerySuccessObject(
+            reply = reply.map(select),
+            replyUpdatedAt = replyUpdatedAt,
+            error = error,
+            errorUpdatedAt = errorUpdatedAt,
+            staleAt = staleAt,
+            fetchStatus = fetchStatus,
+            isInvalidated = isInvalidated,
+            refresh = query::invalidate,
+            loadMore = query::loadMore,
+            loadMoreParam = query.key.loadMoreParam(reply.getOrThrow())
+        )
+
+        QueryStatus.Failure -> if (reply.isNone) {
+            InfiniteQueryLoadingErrorObject(
+                reply = reply.map(select),
+                replyUpdatedAt = replyUpdatedAt,
+                error = checkNotNull(error),
+                errorUpdatedAt = errorUpdatedAt,
+                staleAt = staleAt,
+                fetchStatus = fetchStatus,
+                isInvalidated = isInvalidated,
+                refresh = query::invalidate,
+                loadMore = query::loadMore,
+                loadMoreParam = null
+            )
+        } else {
+            InfiniteQueryRefreshErrorObject(
+                reply = reply.map(select),
+                replyUpdatedAt = replyUpdatedAt,
+                error = checkNotNull(error),
+                errorUpdatedAt = errorUpdatedAt,
+                staleAt = staleAt,
+                fetchStatus = fetchStatus,
+                isInvalidated = isInvalidated,
+                refresh = query::invalidate,
+                loadMore = query::loadMore,
+                loadMoreParam = query.key.loadMoreParam(reply.getOrThrow())
+            )
+        }
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryStrategy.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryStrategy.kt
@@ -33,9 +33,9 @@ interface InfiniteQueryStrategy {
  * The default built-in strategy for Infinite Query built into the library.
  */
 val InfiniteQueryStrategy.Companion.Default: InfiniteQueryStrategy
-    get() = InfiniteQueryStrategyDefault
+    get() = DefaultInfiniteQueryStrategy
 
-private object InfiniteQueryStrategyDefault : InfiniteQueryStrategy {
+private object DefaultInfiniteQueryStrategy : InfiniteQueryStrategy {
     @Composable
     override fun <T, S> collectAsState(query: InfiniteQueryRef<T, S>): QueryState<QueryChunks<T, S>> {
         val state by query.state.collectAsState()

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
@@ -8,9 +8,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import soil.query.MutationClient
 import soil.query.MutationKey
-import soil.query.MutationRef
-import soil.query.MutationState
-import soil.query.MutationStatus
 
 /**
  * Remember a [MutationObject] and subscribes to the mutation state of [key].
@@ -30,55 +27,7 @@ fun <T, S> rememberMutation(
 ): MutationObject<T, S> {
     val scope = rememberCoroutineScope()
     val mutation = remember(key) { client.getMutation(key, config.marker).also { it.launchIn(scope) } }
-    return config.strategy.collectAsState(mutation).toObject(mutation = mutation)
-}
-
-private fun <T, S> MutationState<T>.toObject(
-    mutation: MutationRef<T, S>,
-): MutationObject<T, S> {
-    return when (status) {
-        MutationStatus.Idle -> MutationIdleObject(
-            reply = reply,
-            replyUpdatedAt = replyUpdatedAt,
-            error = error,
-            errorUpdatedAt = errorUpdatedAt,
-            mutatedCount = mutatedCount,
-            mutate = mutation::mutate,
-            mutateAsync = mutation::mutateAsync,
-            reset = mutation::reset
-        )
-
-        MutationStatus.Pending -> MutationLoadingObject(
-            reply = reply,
-            replyUpdatedAt = replyUpdatedAt,
-            error = error,
-            errorUpdatedAt = errorUpdatedAt,
-            mutatedCount = mutatedCount,
-            mutate = mutation::mutate,
-            mutateAsync = mutation::mutateAsync,
-            reset = mutation::reset
-        )
-
-        MutationStatus.Success -> MutationSuccessObject(
-            reply = reply,
-            replyUpdatedAt = replyUpdatedAt,
-            error = error,
-            errorUpdatedAt = errorUpdatedAt,
-            mutatedCount = mutatedCount,
-            mutate = mutation::mutate,
-            mutateAsync = mutation::mutateAsync,
-            reset = mutation::reset
-        )
-
-        MutationStatus.Failure -> MutationErrorObject(
-            reply = reply,
-            replyUpdatedAt = replyUpdatedAt,
-            error = checkNotNull(error),
-            errorUpdatedAt = errorUpdatedAt,
-            mutatedCount = mutatedCount,
-            mutate = mutation::mutate,
-            mutateAsync = mutation::mutateAsync,
-            reset = mutation::reset
-        )
+    return with(config.mapper) {
+        config.strategy.collectAsState(mutation).toObject(mutation = mutation)
     }
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationConfig.kt
@@ -14,15 +14,18 @@ import soil.query.core.Marker
 @Immutable
 data class MutationConfig internal constructor(
     val strategy: MutationStrategy,
+    val mapper: MutationObjectMapper,
     val marker: Marker
 ) {
 
     class Builder {
         var strategy: MutationStrategy = Default.strategy
+        var mapper: MutationObjectMapper = Default.mapper
         var marker: Marker = Default.marker
 
         fun build() = MutationConfig(
             strategy = strategy,
+            mapper = mapper,
             marker = marker
         )
     }
@@ -30,6 +33,7 @@ data class MutationConfig internal constructor(
     companion object {
         val Default = MutationConfig(
             strategy = MutationStrategy.Default,
+            mapper = MutationObjectMapper.Default,
             marker = Marker.None
         )
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationObject.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationObject.kt
@@ -48,7 +48,7 @@ sealed interface MutationObject<out T, S> : MutationModel<T> {
  * @param S Type of the variable to be mutated.
  */
 @Immutable
-data class MutationIdleObject<T, S> internal constructor(
+data class MutationIdleObject<T, S>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable?,
@@ -69,7 +69,7 @@ data class MutationIdleObject<T, S> internal constructor(
  * @param S Type of the variable to be mutated.
  */
 @Immutable
-data class MutationLoadingObject<T, S> internal constructor(
+data class MutationLoadingObject<T, S>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable?,
@@ -90,7 +90,7 @@ data class MutationLoadingObject<T, S> internal constructor(
  * @param S Type of the variable to be mutated.
  */
 @Immutable
-data class MutationErrorObject<T, S> internal constructor(
+data class MutationErrorObject<T, S>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable,
@@ -111,7 +111,7 @@ data class MutationErrorObject<T, S> internal constructor(
  * @param S Type of the variable to be mutated.
  */
 @Immutable
-data class MutationSuccessObject<T, S> internal constructor(
+data class MutationSuccessObject<T, S>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable?,

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationObjectMapper.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationObjectMapper.kt
@@ -1,0 +1,82 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import soil.query.MutationRef
+import soil.query.MutationState
+import soil.query.MutationStatus
+
+/**
+ * A mapper that converts [MutationState] to [MutationObject].
+ */
+interface MutationObjectMapper {
+
+    /**
+     * Converts the given [MutationState] to [MutationObject].
+     *
+     * @param mutation The mutation reference.
+     * @return The converted object.
+     */
+    fun <T, S> MutationState<T>.toObject(
+        mutation: MutationRef<T, S>,
+    ): MutationObject<T, S>
+
+    companion object
+}
+
+/**
+ * The default [MutationObjectMapper].
+ */
+val MutationObjectMapper.Companion.Default: MutationObjectMapper
+    get() = DefaultMutationObjectMapper
+
+private object DefaultMutationObjectMapper : MutationObjectMapper {
+    override fun <T, S> MutationState<T>.toObject(
+        mutation: MutationRef<T, S>
+    ): MutationObject<T, S> = when (status) {
+        MutationStatus.Idle -> MutationIdleObject(
+            reply = reply,
+            replyUpdatedAt = replyUpdatedAt,
+            error = error,
+            errorUpdatedAt = errorUpdatedAt,
+            mutatedCount = mutatedCount,
+            mutate = mutation::mutate,
+            mutateAsync = mutation::mutateAsync,
+            reset = mutation::reset
+        )
+
+        MutationStatus.Pending -> MutationLoadingObject(
+            reply = reply,
+            replyUpdatedAt = replyUpdatedAt,
+            error = error,
+            errorUpdatedAt = errorUpdatedAt,
+            mutatedCount = mutatedCount,
+            mutate = mutation::mutate,
+            mutateAsync = mutation::mutateAsync,
+            reset = mutation::reset
+        )
+
+        MutationStatus.Success -> MutationSuccessObject(
+            reply = reply,
+            replyUpdatedAt = replyUpdatedAt,
+            error = error,
+            errorUpdatedAt = errorUpdatedAt,
+            mutatedCount = mutatedCount,
+            mutate = mutation::mutate,
+            mutateAsync = mutation::mutateAsync,
+            reset = mutation::reset
+        )
+
+        MutationStatus.Failure -> MutationErrorObject(
+            reply = reply,
+            replyUpdatedAt = replyUpdatedAt,
+            error = checkNotNull(error),
+            errorUpdatedAt = errorUpdatedAt,
+            mutatedCount = mutatedCount,
+            mutate = mutation::mutate,
+            mutateAsync = mutation::mutateAsync,
+            reset = mutation::reset
+        )
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationStrategy.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationStrategy.kt
@@ -28,9 +28,9 @@ interface MutationStrategy {
  * The default built-in strategy for Mutation built into the library.
  */
 val MutationStrategy.Companion.Default: MutationStrategy
-    get() = MutationStrategyDefault
+    get() = DefaultMutationStrategy
 
-private object MutationStrategyDefault : MutationStrategy {
+private object DefaultMutationStrategy : MutationStrategy {
     @Composable
     override fun <T, S> collectAsState(mutation: MutationRef<T, S>): MutationState<T> {
         return mutation.state.collectAsState().value

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryConfig.kt
@@ -15,15 +15,18 @@ import soil.query.core.Marker
 @Immutable
 data class QueryConfig internal constructor(
     val strategy: QueryStrategy,
+    val mapper: QueryObjectMapper,
     val marker: Marker
 ) {
 
     class Builder {
         var strategy: QueryStrategy = Default.strategy
+        var mapper: QueryObjectMapper = Default.mapper
         var marker: Marker = Default.marker
 
         fun build() = QueryConfig(
             strategy = strategy,
+            mapper = mapper,
             marker = marker
         )
     }
@@ -31,6 +34,7 @@ data class QueryConfig internal constructor(
     companion object {
         val Default = QueryConfig(
             strategy = QueryStrategy.Default,
+            mapper = QueryObjectMapper.Default,
             marker = Marker.None
         )
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryObject.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryObject.kt
@@ -38,7 +38,7 @@ sealed interface QueryObject<out T> : QueryModel<T> {
  * @param T Type of data to retrieve.
  */
 @Immutable
-data class QueryLoadingObject<T> internal constructor(
+data class QueryLoadingObject<T>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable?,
@@ -58,7 +58,7 @@ data class QueryLoadingObject<T> internal constructor(
  * @param T Type of data to retrieve.
  */
 @Immutable
-data class QueryLoadingErrorObject<T> internal constructor(
+data class QueryLoadingErrorObject<T>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable,
@@ -78,7 +78,7 @@ data class QueryLoadingErrorObject<T> internal constructor(
  * @param T Type of data to retrieve.
  */
 @Immutable
-data class QuerySuccessObject<T> internal constructor(
+data class QuerySuccessObject<T>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable?,
@@ -101,7 +101,7 @@ data class QuerySuccessObject<T> internal constructor(
  * @constructor Creates a [QueryRefreshErrorObject].
  */
 @Immutable
-data class QueryRefreshErrorObject<T> internal constructor(
+data class QueryRefreshErrorObject<T>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable,

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryObjectMapper.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryObjectMapper.kt
@@ -1,0 +1,89 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import soil.query.QueryRef
+import soil.query.QueryState
+import soil.query.QueryStatus
+import soil.query.core.isNone
+import soil.query.core.map
+
+/**
+ * A mapper that converts [QueryState] to [QueryObject].
+ */
+interface QueryObjectMapper {
+
+    /**
+     * Converts the given [QueryState] to [QueryObject].
+     *
+     * @param query The query reference.
+     * @param select A function that selects the object from the reply.
+     * @return The converted object.
+     */
+    fun <T, U> QueryState<T>.toObject(
+        query: QueryRef<T>,
+        select: (T) -> U
+    ): QueryObject<U>
+
+    companion object
+}
+
+/**
+ * The default [QueryObjectMapper].
+ */
+val QueryObjectMapper.Companion.Default: QueryObjectMapper
+    get() = DefaultQueryObjectMapper
+
+private object DefaultQueryObjectMapper : QueryObjectMapper {
+    override fun <T, U> QueryState<T>.toObject(
+        query: QueryRef<T>,
+        select: (T) -> U
+    ): QueryObject<U> = when (status) {
+        QueryStatus.Pending -> QueryLoadingObject(
+            reply = reply.map(select),
+            replyUpdatedAt = replyUpdatedAt,
+            error = error,
+            errorUpdatedAt = errorUpdatedAt,
+            staleAt = staleAt,
+            fetchStatus = fetchStatus,
+            isInvalidated = isInvalidated,
+            refresh = query::invalidate
+        )
+
+        QueryStatus.Success -> QuerySuccessObject(
+            reply = reply.map(select),
+            replyUpdatedAt = replyUpdatedAt,
+            error = error,
+            errorUpdatedAt = errorUpdatedAt,
+            staleAt = staleAt,
+            fetchStatus = fetchStatus,
+            isInvalidated = isInvalidated,
+            refresh = query::invalidate
+        )
+
+        QueryStatus.Failure -> if (reply.isNone) {
+            QueryLoadingErrorObject(
+                reply = reply.map(select),
+                replyUpdatedAt = replyUpdatedAt,
+                error = checkNotNull(error),
+                errorUpdatedAt = errorUpdatedAt,
+                staleAt = staleAt,
+                fetchStatus = fetchStatus,
+                isInvalidated = isInvalidated,
+                refresh = query::invalidate
+            )
+        } else {
+            QueryRefreshErrorObject(
+                reply = reply.map(select),
+                replyUpdatedAt = replyUpdatedAt,
+                error = checkNotNull(error),
+                staleAt = staleAt,
+                errorUpdatedAt = errorUpdatedAt,
+                fetchStatus = fetchStatus,
+                isInvalidated = isInvalidated,
+                refresh = query::invalidate
+            )
+        }
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryStrategy.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryStrategy.kt
@@ -32,9 +32,9 @@ interface QueryStrategy {
  * The default built-in strategy for Query built into the library.
  */
 val QueryStrategy.Companion.Default: QueryStrategy
-    get() = QueryStrategyDefault
+    get() = DefaultQueryStrategy
 
-private object QueryStrategyDefault : QueryStrategy {
+private object DefaultQueryStrategy : QueryStrategy {
     @Composable
     override fun <T> collectAsState(query: QueryRef<T>): QueryState<T> {
         val state by query.state.collectAsState()

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionConfig.kt
@@ -15,15 +15,18 @@ import soil.query.core.Marker
 @Immutable
 data class SubscriptionConfig internal constructor(
     val strategy: SubscriptionStrategy,
+    val mapper: SubscriptionObjectMapper,
     val marker: Marker
 ) {
 
     class Builder {
         var strategy: SubscriptionStrategy = SubscriptionStrategy.Default
+        var mapper: SubscriptionObjectMapper = SubscriptionObjectMapper.Default
         var marker: Marker = Default.marker
 
         fun build() = SubscriptionConfig(
             strategy = strategy,
+            mapper = mapper,
             marker = marker
         )
     }
@@ -31,6 +34,7 @@ data class SubscriptionConfig internal constructor(
     companion object {
         val Default = SubscriptionConfig(
             strategy = SubscriptionStrategy.Default,
+            mapper = SubscriptionObjectMapper.Default,
             marker = Marker.None
         )
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionObject.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionObject.kt
@@ -50,7 +50,7 @@ sealed interface SubscriptionObject<out T> : SubscriptionModel<T> {
  * @param T Type of data to receive.
  */
 @Immutable
-data class SubscriptionIdleObject<T> internal constructor(
+data class SubscriptionIdleObject<T>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable?,
@@ -72,7 +72,7 @@ data class SubscriptionIdleObject<T> internal constructor(
  * @param T Type of data to receive.
  */
 @Immutable
-data class SubscriptionLoadingObject<T> internal constructor(
+data class SubscriptionLoadingObject<T>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable?,
@@ -95,7 +95,7 @@ data class SubscriptionLoadingObject<T> internal constructor(
  * @param T Type of data to receive.
  */
 @Immutable
-data class SubscriptionErrorObject<T> internal constructor(
+data class SubscriptionErrorObject<T>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable,
@@ -115,7 +115,7 @@ data class SubscriptionErrorObject<T> internal constructor(
  * @param T Type of data to receive.
  */
 @Immutable
-data class SubscriptionSuccessObject<T> internal constructor(
+data class SubscriptionSuccessObject<T>(
     override val reply: Reply<T>,
     override val replyUpdatedAt: Long,
     override val error: Throwable?,

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionObjectMapper.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionObjectMapper.kt
@@ -1,0 +1,87 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import soil.query.SubscriberStatus
+import soil.query.SubscriptionRef
+import soil.query.SubscriptionState
+import soil.query.SubscriptionStatus
+import soil.query.core.map
+
+/**
+ * A mapper that converts [SubscriptionState] to [SubscriptionObject].
+ */
+interface SubscriptionObjectMapper {
+
+    /**
+     * Converts the given [SubscriptionState] to [SubscriptionObject].
+     *
+     * @param subscription The subscription reference.
+     * @param select A function that selects the object from the reply.
+     * @return The converted object.
+     */
+    fun <T, U> SubscriptionState<T>.toObject(
+        subscription: SubscriptionRef<T>,
+        select: (T) -> U
+    ): SubscriptionObject<U>
+
+    companion object
+}
+
+/**
+ * The default [SubscriptionObjectMapper].
+ */
+val SubscriptionObjectMapper.Companion.Default: SubscriptionObjectMapper
+    get() = DefaultSubscriptionObjectMapper
+
+private object DefaultSubscriptionObjectMapper : SubscriptionObjectMapper {
+    override fun <T, U> SubscriptionState<T>.toObject(
+        subscription: SubscriptionRef<T>,
+        select: (T) -> U
+    ): SubscriptionObject<U> = when (status) {
+        SubscriptionStatus.Pending -> if (subscriberStatus == SubscriberStatus.NoSubscribers) {
+            SubscriptionIdleObject(
+                reply = reply.map(select),
+                replyUpdatedAt = replyUpdatedAt,
+                error = error,
+                errorUpdatedAt = errorUpdatedAt,
+                subscribe = subscription::resume,
+                unsubscribe = subscription::cancel,
+                reset = subscription::reset
+            )
+        } else {
+            SubscriptionLoadingObject(
+                reply = reply.map(select),
+                replyUpdatedAt = replyUpdatedAt,
+                error = error,
+                errorUpdatedAt = errorUpdatedAt,
+                subscribe = subscription::resume,
+                unsubscribe = subscription::cancel,
+                reset = subscription::reset
+            )
+        }
+
+        SubscriptionStatus.Success -> SubscriptionSuccessObject(
+            reply = reply.map(select),
+            replyUpdatedAt = replyUpdatedAt,
+            error = error,
+            errorUpdatedAt = errorUpdatedAt,
+            subscriberStatus = subscriberStatus,
+            subscribe = subscription::resume,
+            unsubscribe = subscription::cancel,
+            reset = subscription::reset
+        )
+
+        SubscriptionStatus.Failure -> SubscriptionErrorObject(
+            reply = reply.map(select),
+            replyUpdatedAt = replyUpdatedAt,
+            error = checkNotNull(error),
+            errorUpdatedAt = errorUpdatedAt,
+            subscriberStatus = subscriberStatus,
+            subscribe = subscription::resume,
+            unsubscribe = subscription::cancel,
+            reset = subscription::reset
+        )
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionStrategy.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionStrategy.kt
@@ -30,9 +30,9 @@ interface SubscriptionStrategy {
  * The default built-in strategy for Subscription built into the library.
  */
 val SubscriptionStrategy.Companion.Default: SubscriptionStrategy
-    get() = SubscriptionStrategyDefault
+    get() = DefaultSubscriptionStrategy
 
-private object SubscriptionStrategyDefault : SubscriptionStrategy {
+private object DefaultSubscriptionStrategy : SubscriptionStrategy {
     @Composable
     override fun <T> collectAsState(subscription: SubscriptionRef<T>): SubscriptionState<T> {
         val state by subscription.state.collectAsState()
@@ -49,9 +49,9 @@ private object SubscriptionStrategyDefault : SubscriptionStrategy {
 //  Android, it works only with Compose UI 1.7.0-alpha05 or above.
 //  Therefore, we will postpone adding this code until a future release.
 //val SubscriptionStrategy.Companion.Lifecycle: SubscriptionStrategy
-//    get() = SubscriptionStrategyLifecycle
+//    get() = LifecycleSubscriptionStrategy
 //
-//private object SubscriptionStrategyLifecycle : SubscriptionStrategy {
+//private object LifecycleSubscriptionStrategy : SubscriptionStrategy {
 //    @Composable
 //    override fun <T> collectAsState(subscription: SubscriptionRef<T>): SubscriptionState<T> {
 //        val state by subscription.state.collectAsStateWithLifecycle()

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryComposableTest.kt
@@ -45,6 +45,7 @@ class InfiniteQueryComposableTest : UnitTest() {
             SwrClientProvider(client) {
                 val query = rememberInfiniteQuery(key, config = InfiniteQueryConfig {
                     strategy = InfiniteQueryStrategy.Default
+                    mapper = InfiniteQueryObjectMapper.Default
                     marker = Marker.None
                 })
                 when (val reply = query.reply) {

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryObjectMapperTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryObjectMapperTest.kt
@@ -1,0 +1,180 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import soil.query.InfiniteQueryId
+import soil.query.InfiniteQueryKey
+import soil.query.QueryChunk
+import soil.query.QueryFetchStatus
+import soil.query.QueryState
+import soil.query.QueryStatus
+import soil.query.buildInfiniteQueryKey
+import soil.query.chunkedData
+import soil.query.compose.tooling.QueryPreviewClient
+import soil.query.compose.tooling.SwrPreviewClient
+import soil.query.core.getOrThrow
+import soil.query.core.isNone
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class InfiniteQueryObjectMapperTest : UnitTest() {
+
+    @Test
+    fun testToObject_loading() {
+        val key = TestInfiniteQueryKey()
+        val client = SwrPreviewClient(
+            query = QueryPreviewClient {
+                on(key.id) { QueryState.initial() }
+            }
+        )
+        val query = client.getInfiniteQuery(key)
+        val actual = with(InfiniteQueryObjectMapper.Default) {
+            query.state.value.toObject(query = query, select = { it.chunkedData })
+        }
+        assertTrue(actual is InfiniteQueryLoadingObject)
+        assertTrue(actual.reply.isNone)
+        assertEquals(0, actual.replyUpdatedAt)
+        assertNull(actual.error)
+        assertEquals(0, actual.errorUpdatedAt)
+        assertEquals(0, actual.staleAt)
+        assertEquals(QueryFetchStatus.Idle, actual.fetchStatus)
+        assertFalse(actual.isInvalidated)
+        assertEquals(query::invalidate, actual.refresh)
+        assertEquals(query::loadMore, actual.loadMore)
+        assertNull(actual.loadMoreParam)
+        assertEquals(QueryStatus.Pending, actual.status)
+        assertNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_success() {
+        val key = TestInfiniteQueryKey()
+        val client = SwrPreviewClient(
+            query = QueryPreviewClient {
+                on(key.id) {
+                    QueryState.success(buildList {
+                        add(QueryChunk((0 until 10).map { "Item $it" }, PageParam(0, 10)))
+                        add(QueryChunk((10 until 20).map { "Item $it" }, PageParam(1, 10)))
+                        add(QueryChunk((20 until 30).map { "Item $it" }, PageParam(2, 10)))
+                    }, dataUpdatedAt = 300, dataStaleAt = 400)
+                }
+            }
+        )
+        val query = client.getInfiniteQuery(key)
+        val actual = with(InfiniteQueryObjectMapper.Default) {
+            query.state.value.toObject(query = query, select = { it.chunkedData })
+        }
+        assertTrue(actual is InfiniteQuerySuccessObject)
+        assertEquals(30, actual.reply.getOrThrow().size)
+        assertEquals(300, actual.replyUpdatedAt)
+        assertNull(actual.error)
+        assertEquals(0, actual.errorUpdatedAt)
+        assertEquals(400, actual.staleAt)
+        assertEquals(QueryFetchStatus.Idle, actual.fetchStatus)
+        assertFalse(actual.isInvalidated)
+        assertEquals(query::invalidate, actual.refresh)
+        assertEquals(query::loadMore, actual.loadMore)
+        assertEquals(PageParam(3, 10), actual.loadMoreParam)
+        assertEquals(QueryStatus.Success, actual.status)
+        assertNotNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_loadingError() {
+        val key = TestInfiniteQueryKey()
+        val client = SwrPreviewClient(
+            query = QueryPreviewClient {
+                on(key.id) {
+                    QueryState.failure(
+                        error = RuntimeException("Error"),
+                        errorUpdatedAt = 200
+                    )
+                }
+            }
+        )
+        val query = client.getInfiniteQuery(key)
+        val actual = with(InfiniteQueryObjectMapper.Default) {
+            query.state.value.toObject(query = query, select = { it.chunkedData })
+        }
+        assertTrue(actual is InfiniteQueryLoadingErrorObject)
+        assertTrue(actual.reply.isNone)
+        assertEquals(0, actual.replyUpdatedAt)
+        assertNotNull(actual.error)
+        assertEquals(200, actual.errorUpdatedAt)
+        assertEquals(0, actual.staleAt)
+        assertEquals(QueryFetchStatus.Idle, actual.fetchStatus)
+        assertFalse(actual.isInvalidated)
+        assertEquals(query::invalidate, actual.refresh)
+        assertEquals(query::loadMore, actual.loadMore)
+        assertNull(actual.loadMoreParam)
+        assertEquals(QueryStatus.Failure, actual.status)
+        assertNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_refreshError() {
+        val key = TestInfiniteQueryKey()
+        val client = SwrPreviewClient(
+            query = QueryPreviewClient {
+                on(key.id) {
+                    QueryState.failure(
+                        error = RuntimeException("Error"),
+                        errorUpdatedAt = 600,
+                        data = buildList {
+                            add(QueryChunk((0 until 10).map { "Item $it" }, PageParam(0, 10)))
+                            add(QueryChunk((10 until 20).map { "Item $it" }, PageParam(1, 10)))
+                            add(QueryChunk((20 until 30).map { "Item $it" }, PageParam(2, 10)))
+                        },
+                        dataUpdatedAt = 300,
+                        dataStaleAt = 400
+                    )
+                }
+            }
+        )
+        val query = client.getInfiniteQuery(key)
+        val actual = with(InfiniteQueryObjectMapper.Default) {
+            query.state.value.toObject(query = query, select = { it.chunkedData })
+        }
+        assertTrue(actual is InfiniteQueryRefreshErrorObject)
+        assertEquals(30, actual.reply.getOrThrow().size)
+        assertEquals(300, actual.replyUpdatedAt)
+        assertNotNull(actual.error)
+        assertEquals(600, actual.errorUpdatedAt)
+        assertEquals(400, actual.staleAt)
+        assertEquals(QueryFetchStatus.Idle, actual.fetchStatus)
+        assertFalse(actual.isInvalidated)
+        assertEquals(query::invalidate, actual.refresh)
+        assertEquals(query::loadMore, actual.loadMore)
+        assertEquals(PageParam(3, 10), actual.loadMoreParam)
+        assertEquals(QueryStatus.Failure, actual.status)
+        assertNotNull(actual.data)
+    }
+
+    private class TestInfiniteQueryKey : InfiniteQueryKey<List<String>, PageParam> by buildInfiniteQueryKey(
+        id = Id,
+        fetch = { param ->
+            val startPosition = param.page * param.size
+            (startPosition..<startPosition + param.size).map {
+                "Item $it"
+            }
+        },
+        initialParam = { PageParam(0, 10) },
+        loadMoreParam = {
+            val chunk = it.last()
+            PageParam(chunk.param.page + 1, 10)
+        }
+    ) {
+        object Id : InfiniteQueryId<List<String>, PageParam>("test/infinite-query")
+    }
+
+    private data class PageParam(
+        val page: Int,
+        val size: Int
+    )
+}

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationComposableTest.kt
@@ -40,6 +40,7 @@ class MutationComposableTest : UnitTest() {
             SwrClientProvider(client) {
                 val mutation = rememberMutation(key, config = MutationConfig {
                     strategy = MutationStrategy.Default
+                    mapper = MutationObjectMapper.Default
                     marker = Marker.None
                 })
                 when (val reply = mutation.reply) {

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationObjectMapperTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationObjectMapperTest.kt
@@ -1,0 +1,177 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import soil.query.MutationKey
+import soil.query.MutationState
+import soil.query.MutationStatus
+import soil.query.buildMutationKey
+import soil.query.compose.tooling.MutationPreviewClient
+import soil.query.compose.tooling.SwrPreviewClient
+import soil.query.core.getOrThrow
+import soil.query.core.isNone
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class MutationObjectMapperTest : UnitTest() {
+
+    @Test
+    fun testToObject_idle() {
+        val key = TestMutationKey()
+        val client = SwrPreviewClient(
+            mutation = MutationPreviewClient {
+                on(key.id) { MutationState.initial() }
+            }
+        )
+        val mutation = client.getMutation(key)
+        val actual = with(MutationObjectMapper.Default) {
+            mutation.state.value.toObject(mutation = mutation)
+        }
+        assertTrue(actual is MutationIdleObject)
+        assertTrue(actual.reply.isNone)
+        assertEquals(0, actual.replyUpdatedAt)
+        assertNull(actual.error)
+        assertEquals(0, actual.errorUpdatedAt)
+        assertEquals(0, actual.mutatedCount)
+        assertEquals(mutation::mutate, actual.mutate)
+        assertEquals(mutation::mutateAsync, actual.mutateAsync)
+        assertEquals(mutation::reset, actual.reset)
+        assertEquals(MutationStatus.Idle, actual.status)
+        assertNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_pending() {
+        val key = TestMutationKey()
+        val client = SwrPreviewClient(
+            mutation = MutationPreviewClient {
+                on(key.id) { MutationState.pending() }
+            }
+        )
+        val mutation = client.getMutation(key)
+        val actual = with(MutationObjectMapper.Default) {
+            mutation.state.value.toObject(mutation = mutation)
+        }
+        assertTrue(actual is MutationLoadingObject)
+        assertTrue(actual.reply.isNone)
+        assertEquals(0, actual.replyUpdatedAt)
+        assertNull(actual.error)
+        assertEquals(0, actual.errorUpdatedAt)
+        assertEquals(0, actual.mutatedCount)
+        assertEquals(mutation::mutate, actual.mutate)
+        assertEquals(mutation::mutateAsync, actual.mutateAsync)
+        assertEquals(mutation::reset, actual.reset)
+        assertEquals(MutationStatus.Pending, actual.status)
+        assertNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_success() {
+        val key = TestMutationKey()
+        val client = SwrPreviewClient(
+            mutation = MutationPreviewClient {
+                on(key.id) {
+                    MutationState.success(
+                        data = "Hello, Mutation!",
+                        dataUpdatedAt = 100,
+                        mutatedCount = 1
+                    )
+                }
+            }
+        )
+        val mutation = client.getMutation(key)
+        val actual = with(MutationObjectMapper.Default) {
+            mutation.state.value.toObject(mutation = mutation)
+        }
+        assertTrue(actual is MutationSuccessObject)
+        assertEquals("Hello, Mutation!", actual.reply.getOrThrow())
+        assertEquals(100, actual.replyUpdatedAt)
+        assertNull(actual.error)
+        assertEquals(0, actual.errorUpdatedAt)
+        assertEquals(1, actual.mutatedCount)
+        assertEquals(mutation::mutate, actual.mutate)
+        assertEquals(mutation::mutateAsync, actual.mutateAsync)
+        assertEquals(mutation::reset, actual.reset)
+        assertEquals(MutationStatus.Success, actual.status)
+        assertNotNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_error() {
+        val key = TestMutationKey()
+        val client = SwrPreviewClient(
+            mutation = MutationPreviewClient {
+                on(key.id) {
+                    MutationState.failure(
+                        error = RuntimeException("Error"),
+                        errorUpdatedAt = 200
+                    )
+                }
+            }
+        )
+        val mutation = client.getMutation(key)
+        val actual = with(MutationObjectMapper.Default) {
+            mutation.state.value.toObject(mutation = mutation)
+        }
+        assertTrue(actual is MutationErrorObject)
+        assertTrue(actual.reply.isNone)
+        assertEquals(0, actual.replyUpdatedAt)
+        assertNotNull(actual.error)
+        assertEquals(200, actual.errorUpdatedAt)
+        assertEquals(0, actual.mutatedCount)
+        assertEquals(mutation::mutate, actual.mutate)
+        assertEquals(mutation::mutateAsync, actual.mutateAsync)
+        assertEquals(mutation::reset, actual.reset)
+        assertEquals(MutationStatus.Failure, actual.status)
+        assertNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_errorWithData() {
+        val key = TestMutationKey()
+        val client = SwrPreviewClient(
+            mutation = MutationPreviewClient {
+                on(key.id) {
+                    MutationState.failure(
+                        error = RuntimeException("Error"),
+                        errorUpdatedAt = 200,
+                        data = "Hello, Mutation!",
+                        dataUpdatedAt = 100,
+                        mutatedCount = 1
+                    )
+                }
+            }
+        )
+        val mutation = client.getMutation(key)
+        val actual = with(MutationObjectMapper.Default) {
+            mutation.state.value.toObject(mutation = mutation)
+        }
+        assertTrue(actual is MutationErrorObject)
+        assertEquals("Hello, Mutation!", actual.reply.getOrThrow())
+        assertEquals(100, actual.replyUpdatedAt)
+        assertNotNull(actual.error)
+        assertEquals(200, actual.errorUpdatedAt)
+        assertEquals(1, actual.mutatedCount)
+        assertEquals(mutation::mutate, actual.mutate)
+        assertEquals(mutation::mutateAsync, actual.mutateAsync)
+        assertEquals(mutation::reset, actual.reset)
+        assertEquals(MutationStatus.Failure, actual.status)
+        assertNotNull(actual.data)
+    }
+
+    private class TestMutationKey : MutationKey<String, TestForm> by buildMutationKey(
+        mutate = { form ->
+            "${form.name} - ${form.age}"
+        }
+    )
+
+    private data class TestForm(
+        val name: String,
+        val age: Int
+    )
+}

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryComposableTest.kt
@@ -37,6 +37,7 @@ class QueryComposableTest : UnitTest() {
             SwrClientProvider(client) {
                 val query = rememberQuery(key, config = QueryConfig {
                     strategy = QueryStrategy.Default
+                    mapper = QueryObjectMapper.Default
                     marker = Marker.None
                 })
                 when (val reply = query.reply) {

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryObjectMapperTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryObjectMapperTest.kt
@@ -1,0 +1,151 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import soil.query.QueryFetchStatus
+import soil.query.QueryId
+import soil.query.QueryKey
+import soil.query.QueryState
+import soil.query.QueryStatus
+import soil.query.buildQueryKey
+import soil.query.compose.tooling.QueryPreviewClient
+import soil.query.compose.tooling.SwrPreviewClient
+import soil.query.core.getOrThrow
+import soil.query.core.isNone
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class QueryObjectMapperTest : UnitTest() {
+
+    @Test
+    fun testToObject_loading() {
+        val key = TestQueryKey()
+        val client = SwrPreviewClient(
+            query = QueryPreviewClient {
+                on(key.id) { QueryState.initial() }
+            }
+        )
+        val query = client.getQuery(key)
+        val actual = with(QueryObjectMapper.Default) {
+            query.state.value.toObject(query = query, select = { it })
+        }
+        assertTrue(actual is QueryLoadingObject)
+        assertTrue(actual.reply.isNone)
+        assertEquals(0, actual.replyUpdatedAt)
+        assertNull(actual.error)
+        assertEquals(0, actual.errorUpdatedAt)
+        assertEquals(0, actual.staleAt)
+        assertEquals(QueryFetchStatus.Idle, actual.fetchStatus)
+        assertFalse(actual.isInvalidated)
+        assertEquals(query::invalidate, actual.refresh)
+        assertEquals(QueryStatus.Pending, actual.status)
+        assertNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_success() {
+        val key = TestQueryKey()
+        val client = SwrPreviewClient(
+            query = QueryPreviewClient {
+                on(key.id) {
+                    QueryState.success(
+                        data = "Hello, Soil!",
+                        dataUpdatedAt = 400,
+                        dataStaleAt = 500
+                    )
+                }
+            }
+        )
+        val query = client.getQuery(key)
+        val actual = with(QueryObjectMapper.Default) {
+            query.state.value.toObject(query = query, select = { it })
+        }
+        assertTrue(actual is QuerySuccessObject)
+        assertEquals("Hello, Soil!", actual.reply.getOrThrow())
+        assertEquals(400, actual.replyUpdatedAt)
+        assertNull(actual.error)
+        assertEquals(0, actual.errorUpdatedAt)
+        assertEquals(500, actual.staleAt)
+        assertEquals(QueryFetchStatus.Idle, actual.fetchStatus)
+        assertFalse(actual.isInvalidated)
+        assertEquals(query::invalidate, actual.refresh)
+        assertEquals(QueryStatus.Success, actual.status)
+        assertNotNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_loadingError() {
+        val key = TestQueryKey()
+        val client = SwrPreviewClient(
+            query = QueryPreviewClient {
+                on(key.id) {
+                    QueryState.failure(
+                        error = IllegalStateException("Test"),
+                        errorUpdatedAt = 300
+                    )
+                }
+            }
+        )
+        val query = client.getQuery(key)
+        val actual = with(QueryObjectMapper.Default) {
+            query.state.value.toObject(query = query, select = { it })
+        }
+        assertTrue(actual is QueryLoadingErrorObject)
+        assertTrue(actual.reply.isNone)
+        assertEquals(0, actual.replyUpdatedAt)
+        assertNotNull(actual.error)
+        assertEquals(300, actual.errorUpdatedAt)
+        assertEquals(0, actual.staleAt)
+        assertEquals(QueryFetchStatus.Idle, actual.fetchStatus)
+        assertFalse(actual.isInvalidated)
+        assertEquals(query::invalidate, actual.refresh)
+        assertEquals(QueryStatus.Failure, actual.status)
+        assertNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_refreshError() {
+        val key = TestQueryKey()
+        val client = SwrPreviewClient(
+            query = QueryPreviewClient {
+                on(key.id) {
+                    QueryState.failure(
+                        error = IllegalStateException("Test"),
+                        errorUpdatedAt = 600,
+                        data = "Hello, Soil!",
+                        dataUpdatedAt = 400,
+                        dataStaleAt = 500
+                    )
+                }
+            }
+        )
+        val query = client.getQuery(key)
+        val actual = with(QueryObjectMapper.Default) {
+            query.state.value.toObject(query = query, select = { it })
+        }
+        assertTrue(actual is QueryRefreshErrorObject)
+        assertEquals("Hello, Soil!", actual.reply.getOrThrow())
+        assertEquals(400, actual.replyUpdatedAt)
+        assertNotNull(actual.error)
+        assertEquals(600, actual.errorUpdatedAt)
+        assertEquals(500, actual.staleAt)
+        assertEquals(QueryFetchStatus.Idle, actual.fetchStatus)
+        assertFalse(actual.isInvalidated)
+        assertEquals(query::invalidate, actual.refresh)
+        assertEquals(QueryStatus.Failure, actual.status)
+        assertNotNull(actual.data)
+    }
+
+    private class TestQueryKey : QueryKey<String> by buildQueryKey(
+        id = Id,
+        fetch = { "Hello, Soil!" }
+    ) {
+        object Id : QueryId<String>("test/query")
+    }
+}

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionComposableTest.kt
@@ -41,6 +41,7 @@ class SubscriptionComposableTest : UnitTest() {
             SwrClientProvider(client) {
                 val subscription = rememberSubscription(key, config = SubscriptionConfig {
                     strategy = SubscriptionStrategy.Default
+                    mapper = SubscriptionObjectMapper.Default
                     marker = Marker.None
                 })
                 when (val reply = subscription.reply) {

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionObjectMapperTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionObjectMapperTest.kt
@@ -1,0 +1,179 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import soil.query.SubscriberStatus
+import soil.query.SubscriptionId
+import soil.query.SubscriptionKey
+import soil.query.SubscriptionState
+import soil.query.SubscriptionStatus
+import soil.query.annotation.ExperimentalSoilQueryApi
+import soil.query.buildSubscriptionKey
+import soil.query.compose.tooling.SubscriptionPreviewClient
+import soil.query.compose.tooling.SwrPreviewClient
+import soil.query.core.getOrThrow
+import soil.query.core.isNone
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalSoilQueryApi::class)
+class SubscriptionObjectMapperTest : UnitTest() {
+
+    @Test
+    fun testToObject_idle() {
+        val key = TestSubscriptionKey()
+        val client = SwrPreviewClient(
+            subscription = SubscriptionPreviewClient {
+                on(key.id) { SubscriptionState.initial() }
+            }
+        )
+        val subscription = client.getSubscription(key)
+        val actual = with(SubscriptionObjectMapper.Default) {
+            subscription.state.value.toObject(subscription = subscription, select = { it })
+        }
+        assertTrue(actual is SubscriptionIdleObject)
+        assertTrue(actual.reply.isNone)
+        assertEquals(0, actual.replyUpdatedAt)
+        assertNull(actual.error)
+        assertEquals(0, actual.errorUpdatedAt)
+        assertEquals(subscription::resume, actual.subscribe)
+        assertEquals(subscription::cancel, actual.unsubscribe)
+        assertEquals(subscription::reset, actual.reset)
+        assertEquals(SubscriptionStatus.Pending, actual.status)
+        assertEquals(SubscriberStatus.NoSubscribers, actual.subscriberStatus)
+        assertNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_loading() {
+        val key = TestSubscriptionKey()
+        val client = SwrPreviewClient(
+            subscription = SubscriptionPreviewClient {
+                on(key.id) { SubscriptionState.initial(subscriberStatus = SubscriberStatus.Active) }
+            }
+        )
+        val subscription = client.getSubscription(key)
+        val actual = with(SubscriptionObjectMapper.Default) {
+            subscription.state.value.toObject(subscription = subscription, select = { it })
+        }
+        assertTrue(actual is SubscriptionLoadingObject)
+        assertTrue(actual.reply.isNone)
+        assertEquals(0, actual.replyUpdatedAt)
+        assertNull(actual.error)
+        assertEquals(0, actual.errorUpdatedAt)
+        assertEquals(subscription::resume, actual.subscribe)
+        assertEquals(subscription::cancel, actual.unsubscribe)
+        assertEquals(subscription::reset, actual.reset)
+        assertEquals(SubscriptionStatus.Pending, actual.status)
+        assertEquals(SubscriberStatus.Active, actual.subscriberStatus)
+        assertNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_success() {
+        val key = TestSubscriptionKey()
+        val client = SwrPreviewClient(
+            subscription = SubscriptionPreviewClient {
+                on(key.id) {
+                    SubscriptionState.success(
+                        data = "Hello, Subscription!",
+                        dataUpdatedAt = 400,
+                        subscriberStatus = SubscriberStatus.Active
+                    )
+                }
+            }
+        )
+        val subscription = client.getSubscription(key)
+        val actual = with(SubscriptionObjectMapper.Default) {
+            subscription.state.value.toObject(subscription = subscription, select = { it })
+        }
+        assertTrue(actual is SubscriptionSuccessObject)
+        assertEquals("Hello, Subscription!", actual.reply.getOrThrow())
+        assertEquals(400, actual.replyUpdatedAt)
+        assertNull(actual.error)
+        assertEquals(0, actual.errorUpdatedAt)
+        assertEquals(subscription::resume, actual.subscribe)
+        assertEquals(subscription::cancel, actual.unsubscribe)
+        assertEquals(subscription::reset, actual.reset)
+        assertEquals(SubscriptionStatus.Success, actual.status)
+        assertEquals(SubscriberStatus.Active, actual.subscriberStatus)
+        assertNotNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_error() {
+        val key = TestSubscriptionKey()
+        val client = SwrPreviewClient(
+            subscription = SubscriptionPreviewClient {
+                on(key.id) {
+                    SubscriptionState.failure(
+                        error = RuntimeException("Error"),
+                        errorUpdatedAt = 500,
+                        subscriberStatus = SubscriberStatus.Active
+                    )
+                }
+            }
+        )
+        val subscription = client.getSubscription(key)
+        val actual = with(SubscriptionObjectMapper.Default) {
+            subscription.state.value.toObject(subscription = subscription, select = { it })
+        }
+        assertTrue(actual is SubscriptionErrorObject)
+        assertTrue(actual.reply.isNone)
+        assertEquals(0, actual.replyUpdatedAt)
+        assertNotNull(actual.error)
+        assertEquals(500, actual.errorUpdatedAt)
+        assertEquals(subscription::resume, actual.subscribe)
+        assertEquals(subscription::cancel, actual.unsubscribe)
+        assertEquals(subscription::reset, actual.reset)
+        assertEquals(SubscriptionStatus.Failure, actual.status)
+        assertEquals(SubscriberStatus.Active, actual.subscriberStatus)
+        assertNull(actual.data)
+    }
+
+    @Test
+    fun testToObject_errorWithData() {
+        val key = TestSubscriptionKey()
+        val client = SwrPreviewClient(
+            subscription = SubscriptionPreviewClient {
+                on(key.id) {
+                    SubscriptionState.failure(
+                        error = RuntimeException("Error"),
+                        errorUpdatedAt = 500,
+                        data = "Hello, Subscription!",
+                        dataUpdatedAt = 400,
+                        subscriberStatus = SubscriberStatus.Active
+                    )
+                }
+            }
+        )
+        val subscription = client.getSubscription(key)
+        val actual = with(SubscriptionObjectMapper.Default) {
+            subscription.state.value.toObject(subscription = subscription, select = { it })
+        }
+        assertTrue(actual is SubscriptionErrorObject)
+        assertEquals("Hello, Subscription!", actual.reply.getOrThrow())
+        assertEquals(400, actual.replyUpdatedAt)
+        assertNotNull(actual.error)
+        assertEquals(500, actual.errorUpdatedAt)
+        assertEquals(subscription::resume, actual.subscribe)
+        assertEquals(subscription::cancel, actual.unsubscribe)
+        assertEquals(subscription::reset, actual.reset)
+        assertEquals(SubscriptionStatus.Failure, actual.status)
+        assertEquals(SubscriberStatus.Active, actual.subscriberStatus)
+        assertNotNull(actual.data)
+    }
+
+    private class TestSubscriptionKey : SubscriptionKey<String> by buildSubscriptionKey(
+        id = Id,
+        subscribe = { MutableStateFlow("Hello, Soil!") }
+    ) {
+        object Id : SubscriptionId<String>("test/subscription")
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationState.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationState.kt
@@ -71,5 +71,31 @@ data class MutationState<T> internal constructor(
                 status = MutationStatus.Failure
             )
         }
+
+        /**
+         * Creates a new [MutationState] with the [MutationStatus.Failure] status.
+         *
+         * @param error The error that occurred.
+         * @param errorUpdatedAt The timestamp when the error occurred. Default is the current epoch.
+         * @param data The data to be stored in the state.
+         * @param dataUpdatedAt The timestamp when the data was updated. Default is the current epoch.
+         * @param mutatedCount The number of times the data was mutated.
+         */
+        fun <T> failure(
+            error: Throwable,
+            errorUpdatedAt: Long = epoch(),
+            data: T,
+            dataUpdatedAt: Long = epoch(),
+            mutatedCount: Int = 1
+        ): MutationState<T> {
+            return MutationState(
+                reply = Reply(data),
+                replyUpdatedAt = dataUpdatedAt,
+                error = error,
+                errorUpdatedAt = errorUpdatedAt,
+                status = MutationStatus.Failure,
+                mutatedCount = mutatedCount
+            )
+        }
     }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionState.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionState.kt
@@ -72,5 +72,31 @@ data class SubscriptionState<T> internal constructor(
                 subscriberStatus = subscriberStatus
             )
         }
+
+        /**
+         * Creates a new [SubscriptionState] with the [SubscriptionStatus.Failure] status.
+         *
+         * @param error The error to be stored in the state.
+         * @param errorUpdatedAt The timestamp when the error was updated. Default is the current epoch.
+         * @param data The data to be stored in the state.
+         * @param dataUpdatedAt The timestamp when the data was updated. Default is the current epoch.
+         * @param subscriberStatus The status of the subscriber.
+         */
+        fun <T> failure(
+            error: Throwable,
+            errorUpdatedAt: Long = epoch(),
+            data: T,
+            dataUpdatedAt: Long = epoch(),
+            subscriberStatus: SubscriberStatus = SubscriberStatus.NoSubscribers
+        ): SubscriptionState<T> {
+            return SubscriptionState(
+                reply = Reply(data),
+                replyUpdatedAt = dataUpdatedAt,
+                error = error,
+                errorUpdatedAt = errorUpdatedAt,
+                status = SubscriptionStatus.Failure,
+                subscriberStatus = subscriberStatus
+            )
+        }
     }
 }


### PR DESCRIPTION
In #80, we implemented the Configuration class. We introduced a separate mapper class for Composable functions so that you can customize the object conversion process.