### PR TITLE
Introducing Combined Query

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/CachingStrategy.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/CachingStrategy.kt
@@ -51,12 +51,12 @@ sealed interface CachingStrategy {
     data object CacheFirst : CachingStrategy, QueryStrategy, InfiniteQueryStrategy {
         @Composable
         override fun <T> collectAsState(query: QueryRef<T>): QueryState<T> {
-            return collectAsState(query.key.id, query.state, query::resume)
+            return collectAsState(query.id, query.state, query::resume)
         }
 
         @Composable
         override fun <T, S> collectAsState(query: InfiniteQueryRef<T, S>): QueryState<QueryChunks<T, S>> {
-            return collectAsState(query.key.id, query.state, query::resume)
+            return collectAsState(query.id, query.state, query::resume)
         }
 
         @Composable
@@ -81,12 +81,12 @@ sealed interface CachingStrategy {
     data object NetworkFirst : CachingStrategy, QueryStrategy, InfiniteQueryStrategy {
         @Composable
         override fun <T> collectAsState(query: QueryRef<T>): QueryState<T> {
-            return collectAsState(query.key.id, query.state, query::resume)
+            return collectAsState(query.id, query.state, query::resume)
         }
 
         @Composable
         override fun <T, S> collectAsState(query: InfiniteQueryRef<T, S>): QueryState<QueryChunks<T, S>> {
-            return collectAsState(query.key.id, query.state, query::resume)
+            return collectAsState(query.id, query.state, query::resume)
         }
 
         @Composable

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
@@ -27,7 +27,7 @@ fun <T, S> rememberInfiniteQuery(
     client: QueryClient = LocalQueryClient.current
 ): InfiniteQueryObject<QueryChunks<T, S>, S> {
     val scope = rememberCoroutineScope()
-    val query = remember(key) { client.getInfiniteQuery(key, config.marker).also { it.launchIn(scope) } }
+    val query = remember(key.id) { client.getInfiniteQuery(key, config.marker).also { it.launchIn(scope) } }
     return with(config.mapper) {
         config.strategy.collectAsState(query).toObject(query = query, select = { it })
     }
@@ -52,7 +52,7 @@ fun <T, S, U> rememberInfiniteQuery(
     client: QueryClient = LocalQueryClient.current
 ): InfiniteQueryObject<U, S> {
     val scope = rememberCoroutineScope()
-    val query = remember(key) { client.getInfiniteQuery(key, config.marker).also { it.launchIn(scope) } }
+    val query = remember(key.id) { client.getInfiniteQuery(key, config.marker).also { it.launchIn(scope) } }
     return with(config.mapper) {
         config.strategy.collectAsState(query).toObject(query = query, select = select)
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryObjectMapper.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryObjectMapper.kt
@@ -7,9 +7,10 @@ import soil.query.InfiniteQueryRef
 import soil.query.QueryChunks
 import soil.query.QueryState
 import soil.query.QueryStatus
-import soil.query.core.getOrThrow
+import soil.query.core.getOrElse
 import soil.query.core.isNone
 import soil.query.core.map
+import soil.query.emptyChunks
 
 /**
  * A mapper that converts [QueryState] to [InfiniteQueryObject].
@@ -65,7 +66,7 @@ private object DefaultInfiniteQueryObjectMapper : InfiniteQueryObjectMapper {
             isInvalidated = isInvalidated,
             refresh = query::invalidate,
             loadMore = query::loadMore,
-            loadMoreParam = query.key.loadMoreParam(reply.getOrThrow())
+            loadMoreParam = query.nextParam(reply.getOrElse { emptyChunks() })
         )
 
         QueryStatus.Failure -> if (reply.isNone) {
@@ -92,7 +93,7 @@ private object DefaultInfiniteQueryObjectMapper : InfiniteQueryObjectMapper {
                 isInvalidated = isInvalidated,
                 refresh = query::invalidate,
                 loadMore = query::loadMore,
-                loadMoreParam = query.key.loadMoreParam(reply.getOrThrow())
+                loadMoreParam = query.nextParam(reply.getOrElse { emptyChunks() })
             )
         }
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryStrategy.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryStrategy.kt
@@ -39,7 +39,7 @@ private object DefaultInfiniteQueryStrategy : InfiniteQueryStrategy {
     @Composable
     override fun <T, S> collectAsState(query: InfiniteQueryRef<T, S>): QueryState<QueryChunks<T, S>> {
         val state by query.state.collectAsState()
-        LaunchedEffect(query.key.id) {
+        LaunchedEffect(query.id) {
             query.resume()
         }
         return state

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
@@ -26,7 +26,7 @@ fun <T, S> rememberMutation(
     client: MutationClient = LocalMutationClient.current
 ): MutationObject<T, S> {
     val scope = rememberCoroutineScope()
-    val mutation = remember(key) { client.getMutation(key, config.marker).also { it.launchIn(scope) } }
+    val mutation = remember(key.id) { client.getMutation(key, config.marker).also { it.launchIn(scope) } }
     return with(config.mapper) {
         config.strategy.collectAsState(mutation).toObject(mutation = mutation)
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
@@ -4,10 +4,12 @@
 package soil.query.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import soil.query.QueryClient
 import soil.query.QueryKey
+import soil.query.compose.internal.combineQuery
 
 /**
  * Remember a [QueryObject] and subscribes to the query state of [key].
@@ -53,5 +55,115 @@ fun <T, U> rememberQuery(
     val query = remember(key) { client.getQuery(key, config.marker).also { it.launchIn(scope) } }
     return with(config.mapper) {
         config.strategy.collectAsState(query).toObject(query = query, select = select)
+    }
+}
+
+/**
+ * Remember a [QueryObject] and subscribes to the query state of [key1] and [key2].
+ *
+ * @param T1 Type of data to retrieve from [key1].
+ * @param T2 Type of data to retrieve from [key2].
+ * @param R Type of data to transform.
+ * @param key1 The [QueryKey] for managing [query][soil.query.Query].
+ * @param key2 The [QueryKey] for managing [query][soil.query.Query].
+ * @param transform A function to transform [T1] and [T2] into [R].
+ * @param config The configuration for the query. By default, it uses the [QueryConfig.Default].
+ * @param client The [QueryClient] to resolve [key1] and [key2]. By default, it uses the [LocalQueryClient].
+ * @return A [QueryObject] with transformed data each the query state changed.
+ */
+@Composable
+fun <T1, T2, R> rememberQuery(
+    key1: QueryKey<T1>,
+    key2: QueryKey<T2>,
+    transform: (T1, T2) -> R,
+    config: QueryConfig = QueryConfig.Default,
+    client: QueryClient = LocalQueryClient.current,
+): QueryObject<R> {
+    val scope = rememberCoroutineScope()
+    val query1 = remember(key1.id) { client.getQuery(key1, config.marker).also { it.launchIn(scope) } }
+    val query2 = remember(key2.id) { client.getQuery(key2, config.marker).also { it.launchIn(scope) } }
+    val combinedQuery = remember(query1, query2) {
+        combineQuery(query1, query2, transform)
+    }
+    DisposableEffect(combinedQuery.id) {
+        val job = combinedQuery.launchIn(scope)
+        onDispose { job.cancel() }
+    }
+    return with(config.mapper) {
+        config.strategy.collectAsState(combinedQuery).toObject(query = combinedQuery, select = { it })
+    }
+}
+
+/**
+ * Remember a [QueryObject] and subscribes to the query state of [key1], [key2], and [key3].
+ *
+ * @param T1 Type of data to retrieve from [key1].
+ * @param T2 Type of data to retrieve from [key2].
+ * @param T3 Type of data to retrieve from [key3].
+ * @param R Type of data to transform.
+ * @param key1 The [QueryKey] for managing [query][soil.query.Query].
+ * @param key2 The [QueryKey] for managing [query][soil.query.Query].
+ * @param key3 The [QueryKey] for managing [query][soil.query.Query].
+ * @param transform A function to transform [T1], [T2], and [T3] into [R].
+ * @param config The configuration for the query. By default, it uses the [QueryConfig.Default].
+ * @param client The [QueryClient] to resolve [key1], [key2], and [key3]. By default, it uses the [LocalQueryClient].
+ * @return A [QueryObject] with transformed data each the query state changed.
+ */
+@Composable
+fun <T1, T2, T3, R> rememberQuery(
+    key1: QueryKey<T1>,
+    key2: QueryKey<T2>,
+    key3: QueryKey<T3>,
+    transform: (T1, T2, T3) -> R,
+    config: QueryConfig = QueryConfig.Default,
+    client: QueryClient = LocalQueryClient.current,
+): QueryObject<R> {
+    val scope = rememberCoroutineScope()
+    val query1 = remember(key1.id) { client.getQuery(key1, config.marker).also { it.launchIn(scope) } }
+    val query2 = remember(key2.id) { client.getQuery(key2, config.marker).also { it.launchIn(scope) } }
+    val query3 = remember(key3.id) { client.getQuery(key3, config.marker).also { it.launchIn(scope) } }
+    val combinedQuery = remember(query1, query2, query3) {
+        combineQuery(query1, query2, query3, transform)
+    }
+    DisposableEffect(combinedQuery.id) {
+        val job = combinedQuery.launchIn(scope)
+        onDispose { job.cancel() }
+    }
+    return with(config.mapper) {
+        config.strategy.collectAsState(combinedQuery).toObject(query = combinedQuery, select = { it })
+    }
+}
+
+/**
+ * Remember a [QueryObject] and subscribes to the query state of [keys].
+ *
+ * @param T Type of data to retrieve.
+ * @param R Type of data to transform.
+ * @param keys The list of [QueryKey] for managing [query][soil.query.Query].
+ * @param transform A function to transform [T] into [R].
+ * @param config The configuration for the query. By default, it uses the [QueryConfig.Default].
+ * @param client The [QueryClient] to resolve [keys]. By default, it uses the [LocalQueryClient].
+ * @return A [QueryObject] with transformed data each the query state changed.
+ */
+@Composable
+fun <T, R> rememberQuery(
+    keys: List<QueryKey<T>>,
+    transform: (List<T>) -> R,
+    config: QueryConfig = QueryConfig.Default,
+    client: QueryClient = LocalQueryClient.current
+): QueryObject<R> {
+    val scope = rememberCoroutineScope()
+    val queries = remember(keys) {
+        keys.map { key -> client.getQuery(key, config.marker).also { it.launchIn(scope) } }
+    }
+    val combinedQuery = remember(queries) {
+        combineQuery(queries.toTypedArray(), transform)
+    }
+    DisposableEffect(combinedQuery.id) {
+        val job = combinedQuery.launchIn(scope)
+        onDispose { job.cancel() }
+    }
+    return with(config.mapper) {
+        config.strategy.collectAsState(combinedQuery).toObject(query = combinedQuery, select = { it })
     }
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryStrategy.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryStrategy.kt
@@ -38,7 +38,7 @@ private object DefaultQueryStrategy : QueryStrategy {
     @Composable
     override fun <T> collectAsState(query: QueryRef<T>): QueryState<T> {
         val state by query.state.collectAsState()
-        LaunchedEffect(query.key.id) {
+        LaunchedEffect(query.id) {
             query.resume()
         }
         return state

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionComposable.kt
@@ -27,7 +27,7 @@ fun <T> rememberSubscription(
     client: SubscriptionClient = LocalSubscriptionClient.current
 ): SubscriptionObject<T> {
     val scope = rememberCoroutineScope()
-    val subscription = remember(key) { client.getSubscription(key, config.marker).also { it.launchIn(scope) } }
+    val subscription = remember(key.id) { client.getSubscription(key, config.marker).also { it.launchIn(scope) } }
     return with(config.mapper) {
         config.strategy.collectAsState(subscription).toObject(subscription = subscription, select = { it })
     }
@@ -53,7 +53,7 @@ fun <T, U> rememberSubscription(
     client: SubscriptionClient = LocalSubscriptionClient.current
 ): SubscriptionObject<U> {
     val scope = rememberCoroutineScope()
-    val subscription = remember(key) { client.getSubscription(key, config.marker).also { it.launchIn(scope) } }
+    val subscription = remember(key.id) { client.getSubscription(key, config.marker).also { it.launchIn(scope) } }
     return with(config.mapper) {
         config.strategy.collectAsState(subscription).toObject(subscription = subscription, select = select)
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionStrategy.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionStrategy.kt
@@ -36,12 +36,23 @@ private object DefaultSubscriptionStrategy : SubscriptionStrategy {
     @Composable
     override fun <T> collectAsState(subscription: SubscriptionRef<T>): SubscriptionState<T> {
         val state by subscription.state.collectAsState()
-        LaunchedEffect(subscription.key.id) {
-            if (subscription.options.subscribeOnMount) {
-                subscription.resume()
-            }
+        LaunchedEffect(subscription.id) {
+            subscription.resume()
         }
         return state
+    }
+}
+
+/**
+ * Strategy for manually starting the Subscription without automatic subscription.
+ */
+val SubscriptionStrategy.Companion.Lazy: SubscriptionStrategy
+    get() = LazySubscriptionStrategy
+
+private object LazySubscriptionStrategy : SubscriptionStrategy {
+    @Composable
+    override fun <T> collectAsState(subscription: SubscriptionRef<T>): SubscriptionState<T> {
+        return subscription.state.collectAsState().value
     }
 }
 
@@ -55,10 +66,8 @@ private object DefaultSubscriptionStrategy : SubscriptionStrategy {
 //    @Composable
 //    override fun <T> collectAsState(subscription: SubscriptionRef<T>): SubscriptionState<T> {
 //        val state by subscription.state.collectAsStateWithLifecycle()
-//        LifecycleStartEffect(subscription.key.id) {
-//            if (subscription.options.subscribeOnMount) {
-//                lifecycleScope.launch { subscription.resume() }
-//            }
+//        LifecycleStartEffect(subscription.id) {
+//            lifecycleScope.launch { subscription.resume() }
 //            onStopOrDispose { subscription.cancel() }
 //        }
 //        return state

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/CombinedQuery2.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/CombinedQuery2.kt
@@ -1,0 +1,67 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.internal
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import soil.query.QueryId
+import soil.query.QueryRef
+import soil.query.QueryState
+import soil.query.core.uuid
+import soil.query.merge
+
+
+internal fun <T1, T2, R> combineQuery(
+    query1: QueryRef<T1>,
+    query2: QueryRef<T2>,
+    transform: (T1, T2) -> R
+): QueryRef<R> = CombinedQuery2(query1, query2, transform)
+
+private class CombinedQuery2<T1, T2, R>(
+    private val query1: QueryRef<T1>,
+    private val query2: QueryRef<T2>,
+    private val transform: (T1, T2) -> R
+) : QueryRef<R> {
+
+    override val id: QueryId<R> = QueryId("auto/${uuid()}")
+
+    // FIXME: Switch to K2 mode when it becomes stable.
+    private val _state: MutableStateFlow<QueryState<R>> = MutableStateFlow(
+        value = merge(query1.state.value, query2.state.value)
+    )
+    override val state: StateFlow<QueryState<R>> = _state
+
+    override suspend fun resume() {
+        coroutineScope {
+            val deferred1 = async { query1.resume() }
+            val deferred2 = async { query2.resume() }
+            awaitAll(deferred1, deferred2)
+        }
+    }
+
+    override suspend fun invalidate() {
+        coroutineScope {
+            val deferred1 = async { query1.invalidate() }
+            val deferred2 = async { query2.invalidate() }
+            awaitAll(deferred1, deferred2)
+        }
+    }
+
+    override fun launchIn(scope: CoroutineScope): Job {
+        return scope.launch {
+            combine(query1.state, query2.state, ::merge).collect { _state.value = it }
+        }
+    }
+
+    private fun merge(state1: QueryState<T1>, state2: QueryState<T2>): QueryState<R> {
+        return QueryState.merge(state1, state2, transform)
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/CombinedQuery3.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/CombinedQuery3.kt
@@ -1,0 +1,71 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.internal
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import soil.query.QueryId
+import soil.query.QueryRef
+import soil.query.QueryState
+import soil.query.core.uuid
+import soil.query.merge
+
+
+internal fun <T1, T2, T3, R> combineQuery(
+    query1: QueryRef<T1>,
+    query2: QueryRef<T2>,
+    query3: QueryRef<T3>,
+    transform: (T1, T2, T3) -> R
+): QueryRef<R> = CombinedQuery3(query1, query2, query3, transform)
+
+private class CombinedQuery3<T1, T2, T3, R>(
+    private val query1: QueryRef<T1>,
+    private val query2: QueryRef<T2>,
+    private val query3: QueryRef<T3>,
+    private val transform: (T1, T2, T3) -> R
+) : QueryRef<R> {
+
+    override val id: QueryId<R> = QueryId("auto/${uuid()}")
+
+    // FIXME: Switch to K2 mode when it becomes stable.
+    private val _state: MutableStateFlow<QueryState<R>> = MutableStateFlow(
+        value = merge(query1.state.value, query2.state.value, query3.state.value)
+    )
+    override val state: StateFlow<QueryState<R>> = _state
+
+    override suspend fun resume() {
+        coroutineScope {
+            val deferred1 = async { query1.resume() }
+            val deferred2 = async { query2.resume() }
+            val deferred3 = async { query3.resume() }
+            awaitAll(deferred1, deferred2, deferred3)
+        }
+    }
+
+    override suspend fun invalidate() {
+        coroutineScope {
+            val deferred1 = async { query1.invalidate() }
+            val deferred2 = async { query2.invalidate() }
+            val deferred3 = async { query3.invalidate() }
+            awaitAll(deferred1, deferred2, deferred3)
+        }
+    }
+
+    override fun launchIn(scope: CoroutineScope): Job {
+        return scope.launch {
+            combine(query1.state, query2.state, query3.state, ::merge).collect { _state.value = it }
+        }
+    }
+
+    private fun merge(state1: QueryState<T1>, state2: QueryState<T2>, state3: QueryState<T3>): QueryState<R> {
+        return QueryState.merge(state1, state2, state3, transform)
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/CombinedQueryN.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/CombinedQueryN.kt
@@ -1,0 +1,61 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.internal
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import soil.query.QueryId
+import soil.query.QueryRef
+import soil.query.QueryState
+import soil.query.core.uuid
+import soil.query.merge
+
+
+internal fun <T, R> combineQuery(
+    queries: Array<QueryRef<T>>,
+    transform: (List<T>) -> R
+): QueryRef<R> = CombinedQueryN(queries, transform)
+
+private class CombinedQueryN<T, R>(
+    private val queries: Array<QueryRef<T>>,
+    private val transform: (List<T>) -> R
+) : QueryRef<R> {
+
+    override val id: QueryId<R> = QueryId("auto/${uuid()}")
+
+    // FIXME: Switch to K2 mode when it becomes stable.
+    private val _state: MutableStateFlow<QueryState<R>> = MutableStateFlow(
+        value = merge(queries.map { it.state.value }.toTypedArray())
+    )
+    override val state: StateFlow<QueryState<R>> = _state
+
+    override suspend fun resume() {
+        coroutineScope {
+            queries.map { query -> async { query.resume() } }.awaitAll()
+        }
+    }
+
+    override suspend fun invalidate() {
+        coroutineScope {
+            queries.map { query -> async { query.invalidate() } }.awaitAll()
+        }
+    }
+
+    override fun launchIn(scope: CoroutineScope): Job {
+        return scope.launch {
+            combine(queries.map { it.state }, ::merge).collect { _state.value = it }
+        }
+    }
+
+    private fun merge(states: Array<QueryState<T>>): QueryState<R> {
+        return QueryState.merge(states, transform)
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SubscriptionPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SubscriptionPreviewClient.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import soil.query.SubscriptionClient
-import soil.query.SubscriptionCommand
 import soil.query.SubscriptionId
 import soil.query.SubscriptionKey
 import soil.query.SubscriptionOptions
@@ -41,18 +40,15 @@ class SubscriptionPreviewClient(
         marker: Marker
     ): SubscriptionRef<T> {
         val state = previewData[key.id] as? SubscriptionState<T> ?: SubscriptionState.initial()
-        val options = key.onConfigureOptions()?.invoke(defaultSubscriptionOptions) ?: defaultSubscriptionOptions
-        return SnapshotSubscription(key, options, marker, MutableStateFlow(state))
+        return SnapshotSubscription(key.id, MutableStateFlow(state))
     }
 
     private class SnapshotSubscription<T>(
-        override val key: SubscriptionKey<T>,
-        override val options: SubscriptionOptions,
-        override val marker: Marker,
+        override val id: SubscriptionId<T>,
         override val state: StateFlow<SubscriptionState<T>>
     ) : SubscriptionRef<T> {
         override fun launchIn(scope: CoroutineScope): Job = Job()
-        override suspend fun send(command: SubscriptionCommand<T>) = Unit
+        override suspend fun reset() = Unit
         override suspend fun resume() = Unit
         override fun cancel() = Unit
     }

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryComposableTest.kt
@@ -25,6 +25,7 @@ import soil.query.QueryChunk
 import soil.query.QueryState
 import soil.query.SwrCache
 import soil.query.SwrCacheScope
+import soil.query.buildChunks
 import soil.query.buildInfiniteQueryKey
 import soil.query.chunkedData
 import soil.query.compose.tooling.QueryPreviewClient
@@ -166,7 +167,7 @@ class InfiniteQueryComposableTest : UnitTest() {
         val client = SwrPreviewClient(
             query = QueryPreviewClient {
                 on(key.id) {
-                    QueryState.success(buildList {
+                    QueryState.success(buildChunks {
                         add(QueryChunk((0 until 10).map { "Item $it" }, PageParam(0, 10)))
                         add(QueryChunk((10 until 20).map { "Item $it" }, PageParam(1, 10)))
                         add(QueryChunk((20 until 30).map { "Item $it" }, PageParam(2, 10)))

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryObjectMapperTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryObjectMapperTest.kt
@@ -9,6 +9,7 @@ import soil.query.QueryChunk
 import soil.query.QueryFetchStatus
 import soil.query.QueryState
 import soil.query.QueryStatus
+import soil.query.buildChunks
 import soil.query.buildInfiniteQueryKey
 import soil.query.chunkedData
 import soil.query.compose.tooling.QueryPreviewClient
@@ -58,7 +59,7 @@ class InfiniteQueryObjectMapperTest : UnitTest() {
         val client = SwrPreviewClient(
             query = QueryPreviewClient {
                 on(key.id) {
-                    QueryState.success(buildList {
+                    QueryState.success(buildChunks {
                         add(QueryChunk((0 until 10).map { "Item $it" }, PageParam(0, 10)))
                         add(QueryChunk((10 until 20).map { "Item $it" }, PageParam(1, 10)))
                         add(QueryChunk((20 until 30).map { "Item $it" }, PageParam(2, 10)))

--- a/soil-query-core/src/commonMain/kotlin/soil/query/Mutation.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/Mutation.kt
@@ -15,11 +15,6 @@ import soil.query.core.Actor
 interface Mutation<T> : Actor {
 
     /**
-     * The MutationOptions configured for the mutation.
-     */
-    val options: MutationOptions
-
-    /**
      * [State Flow][StateFlow] to receive the current state of the mutation.
      */
     val state: StateFlow<MutationState<T>>

--- a/soil-query-core/src/commonMain/kotlin/soil/query/Query.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/Query.kt
@@ -16,11 +16,6 @@ import soil.query.core.Actor
 interface Query<T> : Actor {
 
     /**
-     * The QueryOptions configured for the query.
-     */
-    val options: QueryOptions
-
-    /**
      * [Shared Flow][SharedFlow] to receive query [events][QueryEvent].
      */
     val event: SharedFlow<QueryEvent>

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryChunk.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryChunk.kt
@@ -17,6 +17,18 @@ data class QueryChunk<T, S>(
 typealias QueryChunks<T, S> = List<QueryChunk<T, S>>
 
 /**
+ * Returns an empty list of chunks.
+ */
+fun <T, S> emptyChunks(): QueryChunks<T, S> = emptyList()
+
+/**
+ * Builds a list of chunks using the provided [builderAction].
+ */
+inline fun <T, S> buildChunks(
+    builderAction: MutableList<QueryChunk<T, S>>.() -> Unit
+): QueryChunks<T, S> = buildList(builderAction)
+
+/**
  * Returns the data of all chunks.
  */
 val <T, S> QueryChunks<List<T>, S>.chunkedData: List<T>

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryStateMerger.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryStateMerger.kt
@@ -1,0 +1,106 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.Reply
+import soil.query.core.combine
+import soil.query.core.getOrThrow
+import soil.query.core.isNone
+
+/**
+ * Merges multiple [QueryState] instances into a single [QueryState] instance.
+ *
+ * ## Merge specification details:
+ * [QueryState.reply] is combined by invoking [transform] only when all [QueryState] instances have [Reply.Some].
+ * [QueryState.status] is selected based on the following priority order:
+ *   1. [QueryStatus.Failure]: If priorities are the same, the one with the oldest [QueryState.errorUpdatedAt] is selected.
+ *   2. [QueryStatus.Pending]: If priorities are the same, the left-hand side is selected.
+ *   3. [QueryStatus.Success]: If priorities are the same, the left-hand side is selected.
+ *
+ * For most other fields, the data associated with the [QueryState] selected by [QueryState.status] will be used as is.
+ * However, [QueryState.replyUpdatedAt] is set to the initial value `0` only when [QueryState.reply] is [Reply.None].
+ */
+fun <T1, T2, R> QueryState.Companion.merge(
+    state1: QueryState<T1>,
+    state2: QueryState<T2>,
+    transform: (T1, T2) -> R
+): QueryState<R> {
+    val reply = Reply.combine(state1.reply, state2.reply, transform)
+    return merge(reply, pick(state1, state2))
+}
+
+/**
+ * Merges multiple [QueryState] instances into a single [QueryState] instance.
+ *
+ * ## Merge specification details:
+ * [QueryState.reply] is combined by invoking [transform] only when all [QueryState] instances have [Reply.Some].
+ * [QueryState.status] is selected based on the following priority order:
+ *   1. [QueryStatus.Failure]: If priorities are the same, the one with the oldest [QueryState.errorUpdatedAt] is selected.
+ *   2. [QueryStatus.Pending]: If priorities are the same, the left-hand side is selected.
+ *   3. [QueryStatus.Success]: If priorities are the same, the left-hand side is selected.
+ *
+ * For most other fields, the data associated with the [QueryState] selected by [QueryState.status] will be used as is.
+ * However, [QueryState.replyUpdatedAt] is set to the initial value `0` only when [QueryState.reply] is [Reply.None].
+ */
+fun <T1, T2, T3, R> QueryState.Companion.merge(
+    state1: QueryState<T1>,
+    state2: QueryState<T2>,
+    state3: QueryState<T3>,
+    transform: (T1, T2, T3) -> R
+): QueryState<R> {
+    val reply = Reply.combine(state1.reply, state2.reply, state3.reply, transform)
+    return merge(reply, pick(state1, state2, state3))
+}
+
+/**
+ * Merges multiple [QueryState] instances into a single [QueryState] instance.
+ *
+ * ## Merge specification details:
+ * [QueryState.reply] is combined by invoking [transform] only when all [QueryState] instances have [Reply.Some].
+ * [QueryState.status] is selected based on the following priority order:
+ *   1. [QueryStatus.Failure]: If priorities are the same, the one with the oldest [QueryState.errorUpdatedAt] is selected.
+ *   2. [QueryStatus.Pending]: If priorities are the same, the left-hand side is selected.
+ *   3. [QueryStatus.Success]: If priorities are the same, the left-hand side is selected.
+ *
+ * For most other fields, the data associated with the [QueryState] selected by [QueryState.status] will be used as is.
+ * However, [QueryState.replyUpdatedAt] is set to the initial value `0` only when [QueryState.reply] is [Reply.None].
+ */
+fun <T, R> QueryState.Companion.merge(
+    states: Array<QueryState<T>>,
+    transform: (List<T>) -> R
+): QueryState<R> {
+    val values = states.filter { !it.reply.isNone }.map { it.reply.getOrThrow() }
+    val reply = if (values.size == states.size) Reply.some(transform(values)) else Reply.none()
+    return merge(reply, pick(*states))
+}
+
+private fun <R> merge(
+    reply: Reply<R>,
+    base: QueryState<*>
+): QueryState<R> = QueryState(
+    reply = reply,
+    replyUpdatedAt = if (reply.isNone) 0 else base.replyUpdatedAt,
+    error = base.error,
+    errorUpdatedAt = base.errorUpdatedAt,
+    staleAt = if (reply.isNone) 0 else base.staleAt,
+    status = base.status,
+    fetchStatus = base.fetchStatus,
+    isInvalidated = base.isInvalidated
+)
+
+private fun pick(
+    vararg states: QueryState<*>
+): QueryState<*> = states.reduce { acc, st ->
+    when {
+        acc.isFailure && st.isFailure -> {
+            if (acc.errorUpdatedAt <= st.errorUpdatedAt) acc else st
+        }
+
+        acc.isFailure -> acc
+        st.isFailure -> st
+        acc.isPending -> acc
+        st.isPending -> st
+        else -> acc
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/Subscription.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/Subscription.kt
@@ -16,11 +16,6 @@ import soil.query.core.Actor
 interface Subscription<T> : Actor {
 
     /**
-     * The SubscriptionOptions configured for the subscription.
-     */
-    val options: SubscriptionOptions
-
-    /**
      * [Shared Flow][SharedFlow] to receive subscription result.
      */
     val source: SharedFlow<Result<T>>

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionOptions.kt
@@ -26,11 +26,6 @@ interface SubscriptionOptions : ActorOptions, LoggingOptions, RetryOptions {
     val gcTime: Duration
 
     /**
-     * Determines whether to subscribe automatically to the subscription when mounted.
-     */
-    val subscribeOnMount: Boolean
-
-    /**
      * This callback function will be called if some mutation encounters an error.
      */
     val onError: ((ErrorRecord, SubscriptionModel<*>) -> Unit)?
@@ -43,7 +38,6 @@ interface SubscriptionOptions : ActorOptions, LoggingOptions, RetryOptions {
 
     companion object Default : SubscriptionOptions {
         override val gcTime: Duration = 5.minutes
-        override val subscribeOnMount: Boolean = true
         override val onError: ((ErrorRecord, SubscriptionModel<*>) -> Unit)? = null
         override val shouldSuppressErrorRelay: ((ErrorRecord, SubscriptionModel<*>) -> Boolean)? = null
 
@@ -70,7 +64,6 @@ interface SubscriptionOptions : ActorOptions, LoggingOptions, RetryOptions {
  * Creates a new [SubscriptionOptions] with the specified settings.
  *
  * @param gcTime The period during which the Key's return value, if not referenced anywhere, is temporarily cached in memory.
- * @param subscribeOnMount Determines whether to subscribe automatically to the subscription when mounted.
  * @param onError This callback function will be called if some subscription encounters an error.
  * @param shouldSuppressErrorRelay Determines whether to suppress error information when relaying it using [soil.query.core.ErrorRelay].
  * @param keepAliveTime The duration to keep the actor alive after the last command is executed.
@@ -85,7 +78,6 @@ interface SubscriptionOptions : ActorOptions, LoggingOptions, RetryOptions {
  */
 fun SubscriptionOptions(
     gcTime: Duration = SubscriptionOptions.gcTime,
-    subscribeOnMount: Boolean = SubscriptionOptions.subscribeOnMount,
     onError: ((ErrorRecord, SubscriptionModel<*>) -> Unit)? = SubscriptionOptions.onError,
     shouldSuppressErrorRelay: ((ErrorRecord, SubscriptionModel<*>) -> Boolean)? = SubscriptionOptions.shouldSuppressErrorRelay,
     keepAliveTime: Duration = SubscriptionOptions.keepAliveTime,
@@ -100,7 +92,6 @@ fun SubscriptionOptions(
 ): SubscriptionOptions {
     return object : SubscriptionOptions {
         override val gcTime: Duration = gcTime
-        override val subscribeOnMount: Boolean = subscribeOnMount
         override val onError: ((ErrorRecord, SubscriptionModel<*>) -> Unit)? = onError
         override val shouldSuppressErrorRelay: ((ErrorRecord, SubscriptionModel<*>) -> Boolean)? =
             shouldSuppressErrorRelay
@@ -121,7 +112,6 @@ fun SubscriptionOptions(
  */
 fun SubscriptionOptions.copy(
     gcTime: Duration = this.gcTime,
-    subscribeOnMount: Boolean = this.subscribeOnMount,
     onError: ((ErrorRecord, SubscriptionModel<*>) -> Unit)? = this.onError,
     shouldSuppressErrorRelay: ((ErrorRecord, SubscriptionModel<*>) -> Boolean)? = this.shouldSuppressErrorRelay,
     keepAliveTime: Duration = this.keepAliveTime,
@@ -136,7 +126,6 @@ fun SubscriptionOptions.copy(
 ): SubscriptionOptions {
     return SubscriptionOptions(
         gcTime = gcTime,
-        subscribeOnMount = subscribeOnMount,
         onError = onError,
         shouldSuppressErrorRelay = shouldSuppressErrorRelay,
         keepAliveTime = keepAliveTime,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCache.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCache.kt
@@ -378,7 +378,8 @@ open class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutabl
         val query = getQuery(key, marker).also { it.launchIn(scope) }
         return coroutineScope.launch {
             try {
-                withTimeoutOrNull(query.options.prefetchWindowTime) {
+                val options = key.onConfigureOptions()?.invoke(defaultQueryOptions) ?: defaultQueryOptions
+                withTimeoutOrNull(options.prefetchWindowTime) {
                     query.resume()
                 }
             } finally {
@@ -395,7 +396,8 @@ open class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutabl
         val query = getInfiniteQuery(key, marker).also { it.launchIn(scope) }
         return coroutineScope.launch {
             try {
-                withTimeoutOrNull(query.options.prefetchWindowTime) {
+                val options = key.onConfigureOptions()?.invoke(defaultQueryOptions) ?: defaultQueryOptions
+                withTimeoutOrNull(options.prefetchWindowTime) {
                     query.resume()
                 }
             } finally {
@@ -578,7 +580,7 @@ open class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutabl
     internal class ManagedMutation<T>(
         val scope: CoroutineScope,
         val id: UniqueId,
-        override val options: MutationOptions,
+        val options: MutationOptions,
         override val state: StateFlow<MutationState<T>>,
         override val command: SendChannel<MutationCommand<T>>,
         internal val actor: ActorBlockRunner,
@@ -606,7 +608,7 @@ open class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutabl
     internal class ManagedQuery<T>(
         val scope: CoroutineScope,
         val id: UniqueId,
-        override val options: QueryOptions,
+        val options: QueryOptions,
         override val event: MutableSharedFlow<QueryEvent>,
         override val state: StateFlow<QueryState<T>>,
         override val command: SendChannel<QueryCommand<T>>,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlus.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlus.kt
@@ -170,7 +170,7 @@ class SwrCachePlus(private val policy: SwrCachePlusPolicy) : SwrCache(policy), S
     internal class ManagedSubscription<T>(
         val scope: CoroutineScope,
         val id: UniqueId,
-        override val options: SubscriptionOptions,
+        val options: SubscriptionOptions,
         override val source: SharedFlow<Result<T>>,
         override val state: StateFlow<SubscriptionState<T>>,
         override val command: SendChannel<SubscriptionCommand<T>>,

--- a/soil-query-core/src/commonTest/kotlin/soil/query/QueryStateMergerTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/QueryStateMergerTest.kt
@@ -1,0 +1,177 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class QueryStateMergerTest : UnitTest() {
+
+    @Test
+    fun testMergeForTwo() {
+        val state1 = QueryState.success(1, dataUpdatedAt = 200, dataStaleAt = 250)
+        val state2 = QueryState.success(2, dataUpdatedAt = 300, dataStaleAt = 350)
+        val merged1 = QueryState.merge(state1, state2) { a, b -> a + b }
+        val merged2 = QueryState.merge(state2, state1) { a, b -> a + b }
+        assertEquals(QueryState.success(3, 200, 250), merged1)
+        assertEquals(QueryState.success(3, 300, 350), merged2)
+    }
+
+    @Test
+    fun testMergeForTwo_withFailure() {
+        val error = RuntimeException("error")
+        val state1 = QueryState.success(1, dataUpdatedAt = 200, dataStaleAt = 250)
+        val state2 = QueryState.failure<Int>(error, errorUpdatedAt = 999)
+        val merged1 = QueryState.merge(state1, state2) { a, b -> a + b }
+        val merged2 = QueryState.merge(state2, state1) { a, b -> a + b }
+        assertEquals(QueryState.failure(error, 999), merged1)
+        assertEquals(QueryState.failure(error, 999), merged2)
+    }
+
+    @Test
+    fun testMergeForTwo_allFailure() {
+        val error = RuntimeException("error")
+        val state1 = QueryState.failure<Int>(error, errorUpdatedAt = 555)
+        val state2 = QueryState.failure<Int>(error, errorUpdatedAt = 999)
+        val merged1 = QueryState.merge(state1, state2) { a, b -> a + b }
+        val merged2 = QueryState.merge(state2, state1) { a, b -> a + b }
+        assertEquals(QueryState.failure(error, 555), merged1)
+        assertEquals(QueryState.failure(error, 555), merged2)
+    }
+
+    @Test
+    fun testMergeForTwo_withPending() {
+        val state1 = QueryState.success(1, dataUpdatedAt = 200, dataStaleAt = 250)
+        val state2 = QueryState.initial<Int>()
+        val merged1 = QueryState.merge(state1, state2) { a, b -> a + b }
+        val merged2 = QueryState.merge(state2, state1) { a, b -> a + b }
+        assertEquals(QueryState.initial(), merged1)
+        assertEquals(QueryState.initial(), merged2)
+    }
+
+    @Test
+    fun testMergeForTwo_allPending() {
+        val state1 = QueryState.initial<Int>()
+        val state2 = QueryState.initial<Int>()
+        val merged1 = QueryState.merge(state1, state2) { a, b -> a + b }
+        val merged2 = QueryState.merge(state2, state1) { a, b -> a + b }
+        assertEquals(QueryState.initial(), merged1)
+        assertEquals(QueryState.initial(), merged2)
+    }
+
+    @Test
+    fun testMergeForThree() {
+        val state1 = QueryState.success(1, dataUpdatedAt = 200, dataStaleAt = 250)
+        val state2 = QueryState.success(2, dataUpdatedAt = 300, dataStaleAt = 350)
+        val state3 = QueryState.success(3, dataUpdatedAt = 400, dataStaleAt = 450)
+        val merged1 = QueryState.merge(state1, state2, state3) { a, b, c -> a + b + c }
+        val merged2 = QueryState.merge(state2, state1, state3) { a, b, c -> a + b + c }
+        assertEquals(QueryState.success(6, 200, 250), merged1)
+        assertEquals(QueryState.success(6, 300, 350), merged2)
+    }
+
+    @Test
+    fun testMergeForThree_withFailure() {
+        val error = RuntimeException("error")
+        val state1 = QueryState.success(1, dataUpdatedAt = 200, dataStaleAt = 250)
+        val state2 = QueryState.failure<Int>(error, errorUpdatedAt = 999)
+        val state3 = QueryState.success(3, dataUpdatedAt = 400, dataStaleAt = 450)
+        val merged1 = QueryState.merge(state1, state2, state3) { a, b, c -> a + b + c }
+        val merged2 = QueryState.merge(state2, state1, state3) { a, b, c -> a + b + c }
+        assertEquals(QueryState.failure(error, 999), merged1)
+        assertEquals(QueryState.failure(error, 999), merged2)
+    }
+
+    @Test
+    fun testMergeForThree_allFailure() {
+        val error = RuntimeException("error")
+        val state1 = QueryState.failure<Int>(error, errorUpdatedAt = 555)
+        val state2 = QueryState.failure<Int>(error, errorUpdatedAt = 999)
+        val state3 = QueryState.failure<Int>(error, errorUpdatedAt = 777)
+        val merged1 = QueryState.merge(state1, state2, state3) { a, b, c -> a + b + c }
+        val merged2 = QueryState.merge(state2, state1, state3) { a, b, c -> a + b + c }
+        assertEquals(QueryState.failure(error, 555), merged1)
+        assertEquals(QueryState.failure(error, 555), merged2)
+    }
+
+    @Test
+    fun testMergeForThree_withPending() {
+        val state1 = QueryState.success(1, dataUpdatedAt = 200, dataStaleAt = 250)
+        val state2 = QueryState.initial<Int>()
+        val state3 = QueryState.success(3, dataUpdatedAt = 400, dataStaleAt = 450)
+        val merged1 = QueryState.merge(state1, state2, state3) { a, b, c -> a + b + c }
+        val merged2 = QueryState.merge(state2, state1, state3) { a, b, c -> a + b + c }
+        assertEquals(QueryState.initial(), merged1)
+        assertEquals(QueryState.initial(), merged2)
+    }
+
+    @Test
+    fun testMergeForThree_allPending() {
+        val state1 = QueryState.initial<Int>()
+        val state2 = QueryState.initial<Int>()
+        val state3 = QueryState.initial<Int>()
+        val merged1 = QueryState.merge(state1, state2, state3) { a, b, c -> a + b + c }
+        val merged2 = QueryState.merge(state2, state1, state3) { a, b, c -> a + b + c }
+        assertEquals(QueryState.initial(), merged1)
+        assertEquals(QueryState.initial(), merged2)
+    }
+
+    @Test
+    fun testMergeForN() {
+        val state1 = QueryState.success(1, dataUpdatedAt = 200, dataStaleAt = 250)
+        val state2 = QueryState.success(2, dataUpdatedAt = 300, dataStaleAt = 350)
+        val state3 = QueryState.success(3, dataUpdatedAt = 400, dataStaleAt = 450)
+        val merged1 = QueryState.merge(arrayOf(state1, state2, state3)) { it.reduce { acc, i -> acc + i } }
+        val merged2 = QueryState.merge(arrayOf(state2, state1, state3)) { it.reduce { acc, i -> acc + i } }
+        assertEquals(QueryState.success(6, 200, 250), merged1)
+        assertEquals(QueryState.success(6, 300, 350), merged2)
+    }
+
+    @Test
+    fun testMergeForN_withFailure() {
+        val error = RuntimeException("error")
+        val state1 = QueryState.success(1, dataUpdatedAt = 200, dataStaleAt = 250)
+        val state2 = QueryState.failure<Int>(error, errorUpdatedAt = 999)
+        val state3 = QueryState.success(3, dataUpdatedAt = 400, dataStaleAt = 450)
+        val merged1 = QueryState.merge(arrayOf(state1, state2, state3)) { it.reduce { acc, i -> acc + i } }
+        val merged2 = QueryState.merge(arrayOf(state2, state1, state3)) { it.reduce { acc, i -> acc + i } }
+        assertEquals(QueryState.failure(error, 999), merged1)
+        assertEquals(QueryState.failure(error, 999), merged2)
+    }
+
+    @Test
+    fun testMergeForN_allFailure() {
+        val error = RuntimeException("error")
+        val state1 = QueryState.failure<Int>(error, errorUpdatedAt = 555)
+        val state2 = QueryState.failure<Int>(error, errorUpdatedAt = 999)
+        val state3 = QueryState.failure<Int>(error, errorUpdatedAt = 777)
+        val merged1 = QueryState.merge(arrayOf(state1, state2, state3)) { it.reduce { acc, i -> acc + i } }
+        val merged2 = QueryState.merge(arrayOf(state2, state1, state3)) { it.reduce { acc, i -> acc + i } }
+        assertEquals(QueryState.failure(error, 555), merged1)
+        assertEquals(QueryState.failure(error, 555), merged2)
+    }
+
+    @Test
+    fun testMergeForN_withPending() {
+        val state1 = QueryState.success(1, dataUpdatedAt = 200, dataStaleAt = 250)
+        val state2 = QueryState.initial<Int>()
+        val state3 = QueryState.success(3, dataUpdatedAt = 400, dataStaleAt = 450)
+        val merged1 = QueryState.merge(arrayOf(state1, state2, state3)) { it.reduce { acc, i -> acc + i } }
+        val merged2 = QueryState.merge(arrayOf(state2, state1, state3)) { it.reduce { acc, i -> acc + i } }
+        assertEquals(QueryState.initial(), merged1)
+        assertEquals(QueryState.initial(), merged2)
+    }
+
+    @Test
+    fun testMergeForN_allPending() {
+        val state1 = QueryState.initial<Int>()
+        val state2 = QueryState.initial<Int>()
+        val state3 = QueryState.initial<Int>()
+        val merged1 = QueryState.merge(arrayOf(state1, state2, state3)) { it.reduce { acc, i -> acc + i } }
+        val merged2 = QueryState.merge(arrayOf(state2, state1, state3)) { it.reduce { acc, i -> acc + i } }
+        assertEquals(QueryState.initial(), merged1)
+        assertEquals(QueryState.initial(), merged2)
+    }
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionOptionsTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionOptionsTest.kt
@@ -16,7 +16,6 @@ class SubscriptionOptionsTest : UnitTest() {
     fun factory_default() {
         val actual = SubscriptionOptions()
         assertEquals(SubscriptionOptions.Default.gcTime, actual.gcTime)
-        assertEquals(SubscriptionOptions.Default.subscribeOnMount, actual.subscribeOnMount)
         assertEquals(SubscriptionOptions.Default.onError, actual.onError)
         assertEquals(SubscriptionOptions.Default.shouldSuppressErrorRelay, actual.shouldSuppressErrorRelay)
         assertEquals(SubscriptionOptions.Default.keepAliveTime, actual.keepAliveTime)
@@ -34,7 +33,6 @@ class SubscriptionOptionsTest : UnitTest() {
     fun factory_factory_specifyingArguments() {
         val actual = SubscriptionOptions(
             gcTime = 1000.seconds,
-            subscribeOnMount = false,
             onError = { _, _ -> },
             shouldSuppressErrorRelay = { _, _ -> true },
             keepAliveTime = 4000.seconds,
@@ -48,7 +46,6 @@ class SubscriptionOptionsTest : UnitTest() {
             retryRandomizer = Random(999)
         )
         assertNotEquals(SubscriptionOptions.Default.gcTime, actual.gcTime)
-        assertNotEquals(SubscriptionOptions.Default.subscribeOnMount, actual.subscribeOnMount)
         assertNotEquals(SubscriptionOptions.Default.onError, actual.onError)
         assertNotEquals(SubscriptionOptions.Default.shouldSuppressErrorRelay, actual.shouldSuppressErrorRelay)
         assertNotEquals(SubscriptionOptions.Default.keepAliveTime, actual.keepAliveTime)
@@ -66,7 +63,6 @@ class SubscriptionOptionsTest : UnitTest() {
     fun copy_default() {
         val actual = SubscriptionOptions.copy()
         assertEquals(SubscriptionOptions.Default.gcTime, actual.gcTime)
-        assertEquals(SubscriptionOptions.Default.subscribeOnMount, actual.subscribeOnMount)
         assertEquals(SubscriptionOptions.Default.onError, actual.onError)
         assertEquals(SubscriptionOptions.Default.shouldSuppressErrorRelay, actual.shouldSuppressErrorRelay)
         assertEquals(SubscriptionOptions.Default.keepAliveTime, actual.keepAliveTime)
@@ -84,7 +80,6 @@ class SubscriptionOptionsTest : UnitTest() {
     fun copy_override() {
         val actual = SubscriptionOptions.copy(
             gcTime = 1000.seconds,
-            subscribeOnMount = false,
             onError = { _, _ -> },
             shouldSuppressErrorRelay = { _, _ -> true },
             keepAliveTime = 4000.seconds,
@@ -99,7 +94,6 @@ class SubscriptionOptionsTest : UnitTest() {
         )
 
         assertNotEquals(SubscriptionOptions.Default.gcTime, actual.gcTime)
-        assertNotEquals(SubscriptionOptions.Default.subscribeOnMount, actual.subscribeOnMount)
         assertNotEquals(SubscriptionOptions.Default.onError, actual.onError)
         assertNotEquals(SubscriptionOptions.Default.shouldSuppressErrorRelay, actual.shouldSuppressErrorRelay)
         assertNotEquals(SubscriptionOptions.Default.keepAliveTime, actual.keepAliveTime)

--- a/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientTest.kt
+++ b/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientTest.kt
@@ -3,28 +3,20 @@
 
 package soil.query.test
 
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.completeWith
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import soil.query.InfiniteQueryCommands
 import soil.query.InfiniteQueryId
 import soil.query.InfiniteQueryKey
-import soil.query.InfiniteQueryRef
 import soil.query.MutationId
 import soil.query.MutationKey
-import soil.query.QueryChunks
-import soil.query.QueryCommands
 import soil.query.QueryId
 import soil.query.QueryKey
-import soil.query.QueryRef
 import soil.query.SwrCache
 import soil.query.SwrCachePolicy
 import soil.query.buildInfiniteQueryKey
 import soil.query.buildMutationKey
 import soil.query.buildQueryKey
-import soil.query.core.Marker
 import soil.query.core.getOrThrow
 import soil.testing.UnitTest
 import kotlin.test.Test
@@ -63,7 +55,7 @@ class TestSwrClientTest : UnitTest() {
         }
         val key = ExampleQueryKey()
         val query = testClient.getQuery(key).also { it.launchIn(backgroundScope) }
-        query.test()
+        query.resume()
         assertEquals("Hello, World!", query.state.value.reply.getOrThrow())
     }
 
@@ -80,7 +72,7 @@ class TestSwrClientTest : UnitTest() {
         }
         val key = ExampleInfiniteQueryKey()
         val query = testClient.getInfiniteQuery(key).also { it.launchIn(backgroundScope) }
-        query.test()
+        query.resume()
         assertEquals("Hello, World!", query.state.value.reply.getOrThrow().first().data)
     }
 }
@@ -118,16 +110,4 @@ private class ExampleInfiniteQueryKey : InfiniteQueryKey<String, Int> by buildIn
     object Id : InfiniteQueryId<String, Int>(
         namespace = "infinite-query/example"
     )
-}
-
-private suspend fun <T> QueryRef<T>.test(): T {
-    val deferred = CompletableDeferred<T>()
-    send(QueryCommands.Connect(key, marker = Marker.None, callback = deferred::completeWith))
-    return deferred.await()
-}
-
-private suspend fun <T, S> InfiniteQueryRef<T, S>.test(): QueryChunks<T, S> {
-    val deferred = CompletableDeferred<QueryChunks<T, S>>()
-    send(InfiniteQueryCommands.Connect(key, marker = Marker.None, callback = deferred::completeWith))
-    return deferred.await()
 }


### PR DESCRIPTION
To improve the efficiency of Composable functions that define multiple keys in parallel, we have implemented a new feature called Combined Query. This feature optimizes the recomposition process by treating multiple query keys as a single query, but only when a composite type can be defined from these keys.

```
val query = rememberQuery(key1 = key1, key2 = key2, key3 = key3, transform = { a, b, c -> ... })
```

By using the `CombinedQuery` class, the number of recompositions can be significantly reduced to the same level as a single query. This ensures that the performance of Composable functions remains high, even when working with multiple keys simultaneously.
