### PR TITLE
Introduce Optional Query

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposables.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposables.kt
@@ -1,0 +1,47 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import soil.query.InfiniteQueryKey
+import soil.query.QueryChunks
+import soil.query.QueryClient
+
+/**
+ * Provides a conditional [rememberInfiniteQuery].
+ *
+ * Calls [rememberInfiniteQuery] only if [keyFactory] returns a [InfiniteQueryKey] from [value].
+ *
+ * @see rememberInfiniteQuery
+ */
+@Composable
+fun <T, S, V> rememberInfiniteQueryIf(
+    value: V,
+    keyFactory: (value: V) -> InfiniteQueryKey<T, S>?,
+    config: InfiniteQueryConfig = InfiniteQueryConfig.Default,
+    client: QueryClient = LocalQueryClient.current
+): InfiniteQueryObject<QueryChunks<T, S>, S>? {
+    val key = remember(value) { keyFactory(value) } ?: return null
+    return rememberInfiniteQuery(key, config, client)
+}
+
+/**
+ * Provides a conditional [rememberInfiniteQuery].
+ *
+ * Calls [rememberInfiniteQuery] only if [keyFactory] returns a [InfiniteQueryKey] from [value].
+ *
+ * @see rememberInfiniteQuery
+ */
+@Composable
+fun <T, S, U, V> rememberInfiniteQueryIf(
+    value: V,
+    keyFactory: (value: V) -> InfiniteQueryKey<T, S>?,
+    select: (chunks: QueryChunks<T, S>) -> U,
+    config: InfiniteQueryConfig = InfiniteQueryConfig.Default,
+    client: QueryClient = LocalQueryClient.current
+): InfiniteQueryObject<U, S>? {
+    val key = remember(value) { keyFactory(value) } ?: return null
+    return rememberInfiniteQuery(key, select, config, client)
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposables.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposables.kt
@@ -1,0 +1,27 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import soil.query.MutationClient
+import soil.query.MutationKey
+
+/**
+ * Provides a conditional [rememberMutation].
+ *
+ * Calls [rememberMutation] only if [keyFactory] returns a [MutationKey] from [value].
+ *
+ * @see rememberMutation
+ */
+@Composable
+fun <T, S, V> rememberMutationIf(
+    value: V,
+    keyFactory: (value: V) -> MutationKey<T, S>?,
+    config: MutationConfig = MutationConfig.Default,
+    client: MutationClient = LocalMutationClient.current
+): MutationObject<T, S>? {
+    val key = remember(value) { keyFactory(value) } ?: return null
+    return rememberMutation(key, config, client)
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposables.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposables.kt
@@ -1,0 +1,107 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import soil.query.QueryClient
+import soil.query.QueryKey
+import kotlin.jvm.JvmName
+
+/**
+ * Provides a conditional [rememberQuery].
+ *
+ * Calls [rememberQuery] only if [keyFactory] returns a [QueryKey] from [value].
+ *
+ * @see rememberQuery
+ */
+@Composable
+fun <T, V> rememberQueryIf(
+    value: V,
+    keyFactory: (value: V) -> QueryKey<T>?,
+    config: QueryConfig = QueryConfig.Default,
+    client: QueryClient = LocalQueryClient.current
+): QueryObject<T>? {
+    val key = remember(value) { keyFactory(value) } ?: return null
+    return rememberQuery(key, config, client)
+}
+
+/**
+ * Provides a conditional [rememberQuery].
+ *
+ * Calls [rememberQuery] only if [keyFactory] returns a [QueryKey] from [value].
+ *
+ * @see rememberQuery
+ */
+@Composable
+fun <T, U, V> rememberQueryIf(
+    value: V,
+    keyFactory: (value: V) -> QueryKey<T>?,
+    select: (T) -> U,
+    config: QueryConfig = QueryConfig.Default,
+    client: QueryClient = LocalQueryClient.current
+): QueryObject<U>? {
+    val key = remember(value) { keyFactory(value) } ?: return null
+    return rememberQuery(key, select, config, client)
+}
+
+/**
+ * Provides a conditional [rememberQuery].
+ *
+ * Calls [rememberQuery] only if [keyPairFactory] returns a [Pair] of [QueryKey]s from [value].
+ *
+ * @see rememberQuery
+ */
+@JvmName("rememberQueryIfWithPair")
+@Composable
+fun <T1, T2, R, V> rememberQueryIf(
+    value: V,
+    keyPairFactory: (value: V) -> Pair<QueryKey<T1>, QueryKey<T2>>?,
+    transform: (T1, T2) -> R,
+    config: QueryConfig = QueryConfig.Default,
+    client: QueryClient = LocalQueryClient.current
+): QueryObject<R>? {
+    val keyPair = remember(value) { keyPairFactory(value) } ?: return null
+    return rememberQuery(keyPair.first, keyPair.second, transform, config, client)
+}
+
+/**
+ * Provides a conditional [rememberQuery].
+ *
+ * Calls [rememberQuery] only if [keyTripleFactory] returns a [Triple] of [QueryKey]s from [value].
+ *
+ * @see rememberQuery
+ */
+@JvmName("rememberQueryIfWithTriple")
+@Composable
+fun <T1, T2, T3, R, V> rememberQueryIf(
+    value: V,
+    keyTripleFactory: (value: V) -> Triple<QueryKey<T1>, QueryKey<T2>, QueryKey<T3>>?,
+    transform: (T1, T2, T3) -> R,
+    config: QueryConfig = QueryConfig.Default,
+    client: QueryClient = LocalQueryClient.current
+): QueryObject<R>? {
+    val keyTriple = remember(value) { keyTripleFactory(value) } ?: return null
+    return rememberQuery(keyTriple.first, keyTriple.second, keyTriple.third, transform, config, client)
+}
+
+/**
+ * Provides a conditional [rememberQuery].
+ *
+ * Calls [rememberQuery] only if [keyListFactory] returns a [List] of [QueryKey]s from [value].
+ *
+ * @see rememberQuery
+ */
+@JvmName("rememberQueryIfWithList")
+@Composable
+fun <T, R, V> rememberQueryIf(
+    value: V,
+    keyListFactory: (value: V) -> List<QueryKey<T>>?,
+    transform: (List<T>) -> R,
+    config: QueryConfig = QueryConfig.Default,
+    client: QueryClient = LocalQueryClient.current
+): QueryObject<R>? {
+    val keys = remember(value) { keyListFactory(value) } ?: return null
+    return rememberQuery(keys, transform, config, client)
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionComposables.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionComposables.kt
@@ -1,0 +1,49 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import soil.query.SubscriptionClient
+import soil.query.SubscriptionKey
+import soil.query.annotation.ExperimentalSoilQueryApi
+
+/**
+ * Provides a conditional [rememberSubscription].
+ *
+ * Calls [rememberSubscription] only if [keyFactory] returns a [SubscriptionKey] from [value].
+ *
+ * @see rememberSubscription
+ */
+@ExperimentalSoilQueryApi
+@Composable
+fun <T, V> rememberSubscriptionIf(
+    value: V,
+    keyFactory: (value: V) -> SubscriptionKey<T>?,
+    config: SubscriptionConfig = SubscriptionConfig.Default,
+    client: SubscriptionClient = LocalSubscriptionClient.current
+): SubscriptionObject<T>? {
+    val key = remember(value) { keyFactory(value) } ?: return null
+    return rememberSubscription(key, config, client)
+}
+
+/**
+ * Provides a conditional [rememberSubscription].
+ *
+ * Calls [rememberSubscription] only if [keyFactory] returns a [SubscriptionKey] from [value].
+ *
+ * @see rememberSubscription
+ */
+@ExperimentalSoilQueryApi
+@Composable
+fun <T, U, V> rememberSubscriptionIf(
+    value: V,
+    keyFactory: (value: V) -> SubscriptionKey<T>?,
+    select: (T) -> U,
+    config: SubscriptionConfig = SubscriptionConfig.Default,
+    client: SubscriptionClient = LocalSubscriptionClient.current
+): SubscriptionObject<U>? {
+    val key = remember(value) { keyFactory(value) } ?: return null
+    return rememberSubscription(key, select, config, client)
+}

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryComposableTest.kt
@@ -3,13 +3,20 @@
 
 package soil.query.compose
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Button
 import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import soil.query.QueryId
@@ -22,6 +29,7 @@ import soil.query.compose.tooling.QueryPreviewClient
 import soil.query.compose.tooling.SwrPreviewClient
 import soil.query.core.Marker
 import soil.query.core.Reply
+import soil.query.core.orNone
 import soil.query.test.test
 import soil.testing.UnitTest
 import kotlin.test.Test
@@ -164,7 +172,6 @@ class QueryComposableTest : UnitTest() {
         onNodeWithTag("query").assertTextEquals("Hello, Compose!|Hello, Soil!|Hello, Kotlin!")
     }
 
-
     @Test
     fun testRememberQuery_loadingPreview() = runComposeUiTest {
         val key = TestQueryKey()
@@ -247,6 +254,177 @@ class QueryComposableTest : UnitTest() {
 
         waitForIdle()
         onNodeWithTag("query").assertTextEquals("Hello, Query!")
+    }
+
+    @Test
+    fun testRememberQueryIf() = runComposeUiTest {
+        val key = TestQueryKey()
+        val client = SwrCache(coroutineScope = SwrCacheScope())
+        setContent {
+            SwrClientProvider(client) {
+                var enabled by remember { mutableStateOf(false) }
+                val query = rememberQueryIf(enabled, keyFactory = { if (it) key else null })
+                Column {
+                    Button(onClick = { enabled = !enabled }, modifier = Modifier.testTag("toggle")) {
+                        Text("Toggle")
+                    }
+                    when (val reply = query?.reply.orNone()) {
+                        is Reply.Some -> Text(reply.value, modifier = Modifier.testTag("query"))
+                        is Reply.None -> Unit
+                    }
+                }
+            }
+        }
+
+        waitForIdle()
+        onNodeWithTag("query").assertDoesNotExist()
+        onNodeWithTag("toggle").performClick()
+
+        waitUntilExactlyOneExists(hasTestTag("query"))
+        onNodeWithTag("query").assertTextEquals("Hello, Soil!")
+    }
+
+    @Test
+    fun testRememberQueryIf_select() = runComposeUiTest {
+        val key = TestQueryKey()
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test {
+            on(key.id) { "Hello, Compose!" }
+        }
+        setContent {
+            SwrClientProvider(client) {
+                var enabled by remember { mutableStateOf(false) }
+                val query = rememberQueryIf(
+                    value = enabled,
+                    keyFactory = { if (it) key else null },
+                    select = { it.uppercase() }
+                )
+                Column {
+                    Button(onClick = { enabled = !enabled }, modifier = Modifier.testTag("toggle")) {
+                        Text("Toggle")
+                    }
+                    when (val reply = query?.reply.orNone()) {
+                        is Reply.Some -> Text(reply.value, modifier = Modifier.testTag("query"))
+                        is Reply.None -> Unit
+                    }
+                }
+            }
+        }
+
+        waitForIdle()
+        onNodeWithTag("query").assertDoesNotExist()
+        onNodeWithTag("toggle").performClick()
+
+        waitUntilExactlyOneExists(hasTestTag("query"))
+        onNodeWithTag("query").assertTextEquals("HELLO, COMPOSE!")
+    }
+
+    @Test
+    fun testRememberQueryIf_combineTwo() = runComposeUiTest {
+        val key1 = TestQueryKey(number = 1)
+        val key2 = TestQueryKey(number = 2)
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test {
+            on(key1.id) { "Hello, Compose!" }
+            on(key2.id) { "Hello, Soil!" }
+        }
+        setContent {
+            SwrClientProvider(client) {
+                var enabled by remember { mutableStateOf(false) }
+                val query = rememberQueryIf(
+                    value = enabled,
+                    keyPairFactory = { if (it) key1 to key2 else null },
+                    transform = { a, b -> a + b })
+                Column {
+                    Button(onClick = { enabled = !enabled }, modifier = Modifier.testTag("toggle")) {
+                        Text("Toggle")
+                    }
+                    when (val reply = query?.reply.orNone()) {
+                        is Reply.Some -> Text(reply.value, modifier = Modifier.testTag("query"))
+                        is Reply.None -> Unit
+                    }
+                }
+            }
+        }
+
+        waitForIdle()
+        onNodeWithTag("query").assertDoesNotExist()
+        onNodeWithTag("toggle").performClick()
+
+        waitUntilExactlyOneExists(hasTestTag("query"))
+        onNodeWithTag("query").assertTextEquals("Hello, Compose!Hello, Soil!")
+    }
+
+    @Test
+    fun testRememberQueryIf_combineThree() = runComposeUiTest {
+        val key1 = TestQueryKey(number = 1)
+        val key2 = TestQueryKey(number = 2)
+        val key3 = TestQueryKey(number = 3)
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test {
+            on(key1.id) { "Hello, Compose!" }
+            on(key2.id) { "Hello, Soil!" }
+            on(key3.id) { "Hello, Kotlin!" }
+        }
+        setContent {
+            SwrClientProvider(client) {
+                var enabled by remember { mutableStateOf(false) }
+                val query = rememberQueryIf(
+                    value = enabled,
+                    keyTripleFactory = { if (it) Triple(key1, key2, key3) else null },
+                    transform = { a, b, c -> a + b + c })
+                Column {
+                    Button(onClick = { enabled = !enabled }, modifier = Modifier.testTag("toggle")) {
+                        Text("Toggle")
+                    }
+                    when (val reply = query?.reply.orNone()) {
+                        is Reply.Some -> Text(reply.value, modifier = Modifier.testTag("query"))
+                        is Reply.None -> Unit
+                    }
+                }
+            }
+        }
+
+        waitForIdle()
+        onNodeWithTag("query").assertDoesNotExist()
+        onNodeWithTag("toggle").performClick()
+
+        waitUntilExactlyOneExists(hasTestTag("query"))
+        onNodeWithTag("query").assertTextEquals("Hello, Compose!Hello, Soil!Hello, Kotlin!")
+    }
+
+    @Test
+    fun testRememberQueryIf_combineN() = runComposeUiTest {
+        val key1 = TestQueryKey(number = 1)
+        val key2 = TestQueryKey(number = 2)
+        val key3 = TestQueryKey(number = 3)
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test {
+            on(key1.id) { "Hello, Compose!" }
+            on(key2.id) { "Hello, Soil!" }
+            on(key3.id) { "Hello, Kotlin!" }
+        }
+        setContent {
+            SwrClientProvider(client) {
+                var enabled by remember { mutableStateOf(false) }
+                val query = rememberQueryIf(
+                    value = enabled,
+                    keyListFactory = { if (it) listOf(key1, key2, key3) else null },
+                    transform = { it.joinToString("|") })
+                Column {
+                    Button(onClick = { enabled = !enabled }, modifier = Modifier.testTag("toggle")) {
+                        Text("Toggle")
+                    }
+                    when (val reply = query?.reply.orNone()) {
+                        is Reply.Some -> Text(reply.value, modifier = Modifier.testTag("query"))
+                        is Reply.None -> Unit
+                    }
+                }
+            }
+        }
+
+        waitForIdle()
+        onNodeWithTag("query").assertDoesNotExist()
+        onNodeWithTag("toggle").performClick()
+
+        waitUntilExactlyOneExists(hasTestTag("query"))
+        onNodeWithTag("query").assertTextEquals("Hello, Compose!|Hello, Soil!|Hello, Kotlin!")
     }
 
     private class TestQueryKey(

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/Reply.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/Reply.kt
@@ -51,6 +51,11 @@ fun <T> Reply<T>.getOrElse(default: () -> T): T = when (this) {
 }
 
 /**
+ * Returns the value of the [Reply.Some] instance, or the [default] value if there is no reply yet ([Reply.None]).
+ */
+inline fun <T> Reply<T>?.orNone(): Reply<T> = this ?: Reply.none()
+
+/**
  * Transforms the value of the [Reply.Some] instance using the provided [transform] function,
  * or returns [Reply.None] if there is no reply yet ([Reply.None]).
  */


### PR DESCRIPTION
The popular TanStack Query library in the React ecosystem has a feature known as [Dependent Query](https://tanstack.com/query/v5/docs/framework/react/guides/dependent-queries).

Currently, Soil Query does not have an API for conditionally executing queries. Therefore, we have implemented the Optional Query feature to enable queries based on certain conditions, such as the results of other queries.

Previously, developers could achieve similar functionality by manually implementing conditional branching, but this new feature can replace that approach.

```
val query = rememberQueryIf(someValue, keyFactory = { someValue -> if (someValue.isEnabled) SomeQueryKey() else null })
```