### PR TITLE
Implement the `Symbol` class to represent null

### DIFF
--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Util.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Util.kt
@@ -1,0 +1,38 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.runtime
+
+import androidx.compose.runtime.Immutable
+import soil.query.core.DataModel
+import soil.query.core.Reply
+
+@Immutable
+private sealed class Symbol<out T> : DataModel<T> {
+    data object None : Symbol<Nothing>() {
+        override val reply: Reply<Nothing> = Reply.None
+        override val replyUpdatedAt: Long = 0
+        override val error: Throwable? = null
+        override val errorUpdatedAt: Long = 0
+        override fun isAwaited(): Boolean = false
+    }
+
+    data object Pending : Symbol<Nothing>() {
+        override val reply: Reply<Nothing> = Reply.None
+        override val replyUpdatedAt: Long = 0
+        override val error: Throwable? = null
+        override val errorUpdatedAt: Long = 0
+        override fun isAwaited(): Boolean = true
+    }
+
+}
+
+/**
+ * Returns a [DataModel] that represents no data.
+ */
+fun <T> DataModel<T>?.orNone(): DataModel<T> = this ?: Symbol.None
+
+/**
+ * Returns a [DataModel] that represents pending data.
+ */
+fun <T> DataModel<T>?.orPending(): DataModel<T> = this ?: Symbol.Pending

--- a/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/AwaitTest.kt
+++ b/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/AwaitTest.kt
@@ -26,6 +26,7 @@ import soil.query.SwrCache
 import soil.query.SwrCacheScope
 import soil.query.buildInfiniteQueryKey
 import soil.query.buildQueryKey
+import soil.query.compose.QueryObject
 import soil.query.compose.SwrClientProvider
 import soil.query.compose.rememberInfiniteQuery
 import soil.query.compose.rememberQuery
@@ -225,6 +226,42 @@ class AwaitTest : UnitTest() {
         deferred2.complete("Hello, Compose!")
         waitUntilDoesNotExist(hasTestTag("fallback"))
         onNodeWithTag("await").assertTextEquals("Hello, Compose!")
+    }
+
+    @Test
+    fun testAwait_orNone() = runComposeUiTest {
+        setContent {
+            val query: QueryObject<String>? = null /* rememberQueryIf(..) */
+            Suspense(
+                fallback = { Text("Loading...", modifier = Modifier.testTag("fallback")) },
+                contentThreshold = Duration.ZERO
+            ) {
+                Await(query.orNone()) { data ->
+                    Text(data, modifier = Modifier.testTag("await"))
+                }
+            }
+        }
+        waitForIdle()
+        onNodeWithTag("await").assertDoesNotExist()
+        onNodeWithTag("fallback").assertDoesNotExist()
+    }
+
+    @Test
+    fun testAwait_orPending() = runComposeUiTest {
+        setContent {
+            val query: QueryObject<String>? = null /* rememberQueryIf(..) */
+            Suspense(
+                fallback = { Text("Loading...", modifier = Modifier.testTag("fallback")) },
+                contentThreshold = Duration.ZERO
+            ) {
+                Await(query.orPending()) { data ->
+                    Text(data, modifier = Modifier.testTag("await"))
+                }
+            }
+        }
+        waitForIdle()
+        onNodeWithTag("await").assertDoesNotExist()
+        onNodeWithTag("fallback").assertExists()
     }
 
     private class TestQueryKey(val variant: String) : QueryKey<String> by buildQueryKey(

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryComposableTest.kt
@@ -286,6 +286,7 @@ class InfiniteQueryComposableTest : UnitTest() {
         onNodeWithTag("query").assertDoesNotExist()
         onNodeWithTag("toggle").performClick()
 
+        waitForIdle()
         waitUntilAtLeastOneExists(hasTestTag("query"))
         onNodeWithTag("query").assertTextEquals("Size: 10 - Page: 0")
     }
@@ -322,6 +323,7 @@ class InfiniteQueryComposableTest : UnitTest() {
         onNodeWithTag("query").assertDoesNotExist()
         onNodeWithTag("toggle").performClick()
 
+        waitForIdle()
         waitUntilAtLeastOneExists(hasTestTag("query"))
         onAllNodes(hasTestTag("query")).assertCountEquals(10)
     }


### PR DESCRIPTION
The Symbol class has been implemented to represent null values for `DataModel<T>`. With the recent addition of Optional Query, there have been instances where a `QueryObject` can be nullable. To address this, a fallback function has been included in the runtime package module.

- orNone
- orPending

```
val query1: QueryObject<String> = rememberQuery(..)
val query2: QueryObject<String>? =  rememberQueryIf(..)
Await(query1, query2.orNone()) { data1, data2 ->
    // do something with data1 and data2
}
```

refs: #95