### PR TITLE
Optimization of Recomposition

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import soil.query.InfiniteQueryKey
 import soil.query.QueryChunks
 import soil.query.QueryClient
+import soil.query.compose.internal.newInfiniteQuery
 
 /**
  * Remember a [InfiniteQueryObject] and subscribes to the query state of [key].
@@ -27,7 +28,7 @@ fun <T, S> rememberInfiniteQuery(
     client: QueryClient = LocalQueryClient.current
 ): InfiniteQueryObject<QueryChunks<T, S>, S> {
     val scope = rememberCoroutineScope()
-    val query = remember(key.id) { client.getInfiniteQuery(key, config.marker).also { it.launchIn(scope) } }
+    val query = remember(key.id) { newInfiniteQuery(key, config, client, scope) }
     return with(config.mapper) {
         config.strategy.collectAsState(query).toObject(query = query, select = { it })
     }
@@ -52,7 +53,7 @@ fun <T, S, U> rememberInfiniteQuery(
     client: QueryClient = LocalQueryClient.current
 ): InfiniteQueryObject<U, S> {
     val scope = rememberCoroutineScope()
-    val query = remember(key.id) { client.getInfiniteQuery(key, config.marker).also { it.launchIn(scope) } }
+    val query = remember(key.id) { newInfiniteQuery(key, config, client, scope) }
     return with(config.mapper) {
         config.strategy.collectAsState(query).toObject(query = query, select = select)
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryConfig.kt
@@ -9,23 +9,33 @@ import soil.query.core.Marker
 /**
  * Configuration for the infinite query.
  *
+ * @property mapper The mapper for converting query data.
+ * @property optimizer The optimizer for recomposing the query data.
  * @property strategy The strategy for caching query data.
  * @property marker The marker with additional information based on the caller of a query.
  */
 @Immutable
 data class InfiniteQueryConfig internal constructor(
-    val strategy: InfiniteQueryStrategy,
     val mapper: InfiniteQueryObjectMapper,
+    val optimizer: InfiniteQueryRecompositionOptimizer,
+    val strategy: InfiniteQueryStrategy,
     val marker: Marker
 ) {
 
-    class Builder {
-        var strategy: InfiniteQueryStrategy = Default.strategy
-        var mapper: InfiniteQueryObjectMapper = Default.mapper
-        var marker: Marker = Default.marker
+    /**
+     * Creates a new [InfiniteQueryConfig] with the provided [block].
+     */
+    fun builder(block: Builder.() -> Unit) = Builder(this).apply(block).build()
+
+    class Builder(config: InfiniteQueryConfig = Default) {
+        var mapper: InfiniteQueryObjectMapper = config.mapper
+        var optimizer: InfiniteQueryRecompositionOptimizer = config.optimizer
+        var strategy: InfiniteQueryStrategy = config.strategy
+        var marker: Marker = config.marker
 
         fun build() = InfiniteQueryConfig(
             strategy = strategy,
+            optimizer = optimizer,
             mapper = mapper,
             marker = marker
         )
@@ -33,8 +43,9 @@ data class InfiniteQueryConfig internal constructor(
 
     companion object {
         val Default = InfiniteQueryConfig(
-            strategy = InfiniteQueryStrategy.Default,
             mapper = InfiniteQueryObjectMapper.Default,
+            optimizer = InfiniteQueryRecompositionOptimizer.Default,
+            strategy = InfiniteQueryStrategy.Default,
             marker = Marker.None
         )
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizer.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizer.kt
@@ -1,0 +1,71 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import soil.query.QueryChunks
+import soil.query.QueryState
+import soil.query.QueryStatus
+
+/**
+ * A recomposition optimizer for [QueryState] with [QueryChunks].
+ */
+interface InfiniteQueryRecompositionOptimizer {
+
+    /**
+     * Omit the specified keys from the [QueryState] with [QueryChunks].
+     *
+     * @param state The infinite query state.
+     * @return The optimized infinite query state.
+     */
+    fun <T, S> omit(state: QueryState<QueryChunks<T, S>>): QueryState<QueryChunks<T, S>>
+
+    companion object
+}
+
+/**
+ * Optimizer implementation for [InfiniteQueryStrategy.Companion.Default].
+ */
+val InfiniteQueryRecompositionOptimizer.Companion.Default: InfiniteQueryRecompositionOptimizer
+    get() = DefaultInfiniteQueryRecompositionOptimizer
+
+private object DefaultInfiniteQueryRecompositionOptimizer : InfiniteQueryRecompositionOptimizer {
+    override fun <T, S> omit(state: QueryState<QueryChunks<T, S>>): QueryState<QueryChunks<T, S>> {
+        val keys = buildSet {
+            add(QueryState.OmitKey.replyUpdatedAt)
+            add(QueryState.OmitKey.staleAt)
+            when (state.status) {
+                QueryStatus.Pending -> {
+                    add(QueryState.OmitKey.errorUpdatedAt)
+                    add(QueryState.OmitKey.fetchStatus)
+                }
+
+                QueryStatus.Success -> {
+                    add(QueryState.OmitKey.errorUpdatedAt)
+                    if (!state.isInvalidated) {
+                        add(QueryState.OmitKey.fetchStatus)
+                    }
+                }
+
+                QueryStatus.Failure -> {
+                    if (!state.isInvalidated) {
+                        add(QueryState.OmitKey.fetchStatus)
+                    }
+                }
+            }
+        }
+        return state.omit(keys)
+    }
+}
+
+/**
+ * Option that performs no optimization.
+ */
+val InfiniteQueryRecompositionOptimizer.Companion.Disabled: InfiniteQueryRecompositionOptimizer
+    get() = DisabledInfiniteQueryRecompositionOptimizer
+
+private object DisabledInfiniteQueryRecompositionOptimizer : InfiniteQueryRecompositionOptimizer {
+    override fun <T, S> omit(state: QueryState<QueryChunks<T, S>>): QueryState<QueryChunks<T, S>> {
+        return state
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationComposable.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import soil.query.MutationClient
 import soil.query.MutationKey
+import soil.query.compose.internal.newMutation
 
 /**
  * Remember a [MutationObject] and subscribes to the mutation state of [key].
@@ -26,7 +27,7 @@ fun <T, S> rememberMutation(
     client: MutationClient = LocalMutationClient.current
 ): MutationObject<T, S> {
     val scope = rememberCoroutineScope()
-    val mutation = remember(key.id) { client.getMutation(key, config.marker).also { it.launchIn(scope) } }
+    val mutation = remember(key.id) { newMutation(key, config, client, scope) }
     return with(config.mapper) {
         config.strategy.collectAsState(mutation).toObject(mutation = mutation)
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationConfig.kt
@@ -9,31 +9,43 @@ import soil.query.core.Marker
 /**
  * Configuration for the mutation.
  *
+ * @property mapper The mapper for converting mutation data.
+ * @property optimizer The optimizer for recomposing the mutation data.
+ * @property strategy The strategy for caching mutation data.
  * @property marker The marker with additional information based on the caller of a mutation.
  */
 @Immutable
 data class MutationConfig internal constructor(
-    val strategy: MutationStrategy,
     val mapper: MutationObjectMapper,
+    val optimizer: MutationRecompositionOptimizer,
+    val strategy: MutationStrategy,
     val marker: Marker
 ) {
 
-    class Builder {
-        var strategy: MutationStrategy = Default.strategy
-        var mapper: MutationObjectMapper = Default.mapper
-        var marker: Marker = Default.marker
+    /**
+     * Creates a new [MutationConfig] with the provided [block].
+     */
+    fun builder(block: Builder.() -> Unit) = Builder(this).apply(block).build()
+
+    class Builder(config: MutationConfig = Default) {
+        var mapper: MutationObjectMapper = config.mapper
+        var optimizer: MutationRecompositionOptimizer = config.optimizer
+        var strategy: MutationStrategy = config.strategy
+        var marker: Marker = config.marker
 
         fun build() = MutationConfig(
-            strategy = strategy,
             mapper = mapper,
+            optimizer = optimizer,
+            strategy = strategy,
             marker = marker
         )
     }
 
     companion object {
         val Default = MutationConfig(
-            strategy = MutationStrategy.Default,
             mapper = MutationObjectMapper.Default,
+            optimizer = MutationRecompositionOptimizer.Default,
+            strategy = MutationStrategy.Default,
             marker = Marker.None
         )
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationRecompositionOptimizer.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationRecompositionOptimizer.kt
@@ -1,0 +1,68 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import soil.query.MutationState
+import soil.query.MutationStatus
+
+/**
+ * A recomposition optimizer for [MutationState].
+ */
+interface MutationRecompositionOptimizer {
+
+    /**
+     * Omit the specified keys from the [MutationState].
+     *
+     * @param state The mutation state.
+     * @return The optimized mutation state.
+     */
+    fun <T> omit(state: MutationState<T>): MutationState<T>
+
+    companion object
+}
+
+/**
+ * Optimizer implementation for [MutationStrategy.Companion.Default].
+ */
+val MutationRecompositionOptimizer.Companion.Default: MutationRecompositionOptimizer
+    get() = DefaultMutationRecompositionOptimizer
+
+private object DefaultMutationRecompositionOptimizer : MutationRecompositionOptimizer {
+    override fun <T> omit(state: MutationState<T>): MutationState<T> {
+        val keys = buildSet {
+            add(MutationState.OmitKey.replyUpdatedAt)
+            add(MutationState.OmitKey.mutatedCount)
+            when (state.status) {
+                MutationStatus.Idle -> {
+                    add(MutationState.OmitKey.errorUpdatedAt)
+                }
+
+                MutationStatus.Pending -> {
+                    if (state.error == null) {
+                        add(MutationState.OmitKey.errorUpdatedAt)
+                    }
+                }
+
+                MutationStatus.Success -> {
+                    add(MutationState.OmitKey.errorUpdatedAt)
+                }
+
+                MutationStatus.Failure -> Unit
+            }
+        }
+        return state.omit(keys)
+    }
+}
+
+/**
+ * Option that performs no optimization.
+ */
+val MutationRecompositionOptimizer.Companion.Disabled: MutationRecompositionOptimizer
+    get() = DisabledMutationRecompositionOptimizer
+
+private object DisabledMutationRecompositionOptimizer : MutationRecompositionOptimizer {
+    override fun <T> omit(state: MutationState<T>): MutationState<T> {
+        return state
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryConfig.kt
@@ -9,32 +9,43 @@ import soil.query.core.Marker
 /**
  * Configuration for the query.
  *
+ * @property mapper The mapper for converting query data.
+ * @property optimizer The optimizer for recomposing the query data.
  * @property strategy The strategy for caching query data.
  * @property marker The marker with additional information based on the caller of a query.
  */
 @Immutable
 data class QueryConfig internal constructor(
-    val strategy: QueryStrategy,
     val mapper: QueryObjectMapper,
+    val optimizer: QueryRecompositionOptimizer,
+    val strategy: QueryStrategy,
     val marker: Marker
 ) {
 
-    class Builder {
-        var strategy: QueryStrategy = Default.strategy
-        var mapper: QueryObjectMapper = Default.mapper
-        var marker: Marker = Default.marker
+    /**
+     * Creates a new [QueryConfig] with the provided [block].
+     */
+    fun builder(block: Builder.() -> Unit) = Builder(this).apply(block).build()
+
+    class Builder(config: QueryConfig = Default) {
+        var mapper: QueryObjectMapper = config.mapper
+        var optimizer: QueryRecompositionOptimizer = config.optimizer
+        var strategy: QueryStrategy = config.strategy
+        var marker: Marker = config.marker
 
         fun build() = QueryConfig(
-            strategy = strategy,
             mapper = mapper,
+            optimizer = optimizer,
+            strategy = strategy,
             marker = marker
         )
     }
 
     companion object {
         val Default = QueryConfig(
-            strategy = QueryStrategy.Default,
             mapper = QueryObjectMapper.Default,
+            optimizer = QueryRecompositionOptimizer.Default,
+            strategy = QueryStrategy.Default,
             marker = Marker.None
         )
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryRecompositionOptimizer.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryRecompositionOptimizer.kt
@@ -1,0 +1,70 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import soil.query.QueryState
+import soil.query.QueryStatus
+
+/**
+ * A recomposition optimizer for [QueryState].
+ */
+interface QueryRecompositionOptimizer {
+
+    /**
+     * Omit the specified keys from the [QueryState].
+     *
+     * @param state The query state.
+     * @return The optimized query state.
+     */
+    fun <T> omit(state: QueryState<T>): QueryState<T>
+
+    companion object
+}
+
+/**
+ * Optimizer implementation for [QueryStrategy.Companion.Default].
+ */
+val QueryRecompositionOptimizer.Companion.Default: QueryRecompositionOptimizer
+    get() = DefaultQueryRecompositionOptimizer
+
+private object DefaultQueryRecompositionOptimizer : QueryRecompositionOptimizer {
+    override fun <T> omit(state: QueryState<T>): QueryState<T> {
+        val keys = buildSet {
+            add(QueryState.OmitKey.replyUpdatedAt)
+            add(QueryState.OmitKey.staleAt)
+            when (state.status) {
+                QueryStatus.Pending -> {
+                    add(QueryState.OmitKey.errorUpdatedAt)
+                    add(QueryState.OmitKey.fetchStatus)
+                }
+
+                QueryStatus.Success -> {
+                    add(QueryState.OmitKey.errorUpdatedAt)
+                    if (!state.isInvalidated) {
+                        add(QueryState.OmitKey.fetchStatus)
+                    }
+                }
+
+                QueryStatus.Failure -> {
+                    if (!state.isInvalidated) {
+                        add(QueryState.OmitKey.fetchStatus)
+                    }
+                }
+            }
+        }
+        return state.omit(keys)
+    }
+}
+
+/**
+ * Option that performs no optimization.
+ */
+val QueryRecompositionOptimizer.Companion.Disabled: QueryRecompositionOptimizer
+    get() = DisabledQueryRecompositionOptimizer
+
+private object DisabledQueryRecompositionOptimizer : QueryRecompositionOptimizer {
+    override fun <T> omit(state: QueryState<T>): QueryState<T> {
+        return state
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionComposable.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import soil.query.SubscriptionClient
 import soil.query.SubscriptionKey
 import soil.query.annotation.ExperimentalSoilQueryApi
+import soil.query.compose.internal.newSubscription
 
 /**
  * Remember a [SubscriptionObject] and subscribes to the subscription state of [key].
@@ -27,7 +28,7 @@ fun <T> rememberSubscription(
     client: SubscriptionClient = LocalSubscriptionClient.current
 ): SubscriptionObject<T> {
     val scope = rememberCoroutineScope()
-    val subscription = remember(key.id) { client.getSubscription(key, config.marker).also { it.launchIn(scope) } }
+    val subscription = remember(key.id) { newSubscription(key, config, client, scope) }
     return with(config.mapper) {
         config.strategy.collectAsState(subscription).toObject(subscription = subscription, select = { it })
     }
@@ -53,7 +54,7 @@ fun <T, U> rememberSubscription(
     client: SubscriptionClient = LocalSubscriptionClient.current
 ): SubscriptionObject<U> {
     val scope = rememberCoroutineScope()
-    val subscription = remember(key.id) { client.getSubscription(key, config.marker).also { it.launchIn(scope) } }
+    val subscription = remember(key.id) { newSubscription(key, config, client, scope) }
     return with(config.mapper) {
         config.strategy.collectAsState(subscription).toObject(subscription = subscription, select = select)
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionConfig.kt
@@ -9,32 +9,50 @@ import soil.query.core.Marker
 /**
  * Configuration for the subscription.
  *
+ * @property mapper The mapper for converting subscription data.
+ * @property optimizer The optimizer for recomposing the subscription data.
  * @property strategy The strategy for caching subscription data.
  * @property marker The marker with additional information based on the caller of a subscription.
  */
 @Immutable
 data class SubscriptionConfig internal constructor(
-    val strategy: SubscriptionStrategy,
     val mapper: SubscriptionObjectMapper,
+    val optimizer: SubscriptionRecompositionOptimizer,
+    val strategy: SubscriptionStrategy,
     val marker: Marker
 ) {
 
-    class Builder {
-        var strategy: SubscriptionStrategy = SubscriptionStrategy.Default
-        var mapper: SubscriptionObjectMapper = SubscriptionObjectMapper.Default
-        var marker: Marker = Default.marker
+    /**
+     * Creates a new [SubscriptionConfig] with the provided [block].
+     */
+    fun builder(block: Builder.() -> Unit) = Builder(this).apply(block).build()
+
+    class Builder(config: SubscriptionConfig = Default) {
+        var mapper: SubscriptionObjectMapper = config.mapper
+        var optimizer: SubscriptionRecompositionOptimizer = config.optimizer
+        var strategy: SubscriptionStrategy = config.strategy
+        var marker: Marker = config.marker
 
         fun build() = SubscriptionConfig(
-            strategy = strategy,
             mapper = mapper,
+            optimizer = optimizer,
+            strategy = strategy,
             marker = marker
         )
     }
 
     companion object {
         val Default = SubscriptionConfig(
-            strategy = SubscriptionStrategy.Default,
             mapper = SubscriptionObjectMapper.Default,
+            optimizer = SubscriptionRecompositionOptimizer.Default,
+            strategy = SubscriptionStrategy.Default,
+            marker = Marker.None
+        )
+
+        val Lazy = SubscriptionConfig(
+            mapper = SubscriptionObjectMapper.Default,
+            optimizer = SubscriptionRecompositionOptimizer.Lazy,
+            strategy = SubscriptionStrategy.Lazy,
             marker = Marker.None
         )
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionRecompositionOptimizer.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionRecompositionOptimizer.kt
@@ -1,0 +1,79 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import soil.query.SubscriberStatus
+import soil.query.SubscriptionState
+import soil.query.SubscriptionStatus
+
+/**
+ * A recomposition optimizer for [SubscriptionState].
+ */
+interface SubscriptionRecompositionOptimizer {
+
+    /**
+     * Omit the specified keys from the [SubscriptionState].
+     *
+     * @param state The subscription state.
+     * @return The optimized subscription state.
+     */
+    fun <T> omit(state: SubscriptionState<T>): SubscriptionState<T>
+
+    companion object
+}
+
+/**
+ * Optimizer implementation for [SubscriptionStrategy.Companion.Default].
+ */
+val SubscriptionRecompositionOptimizer.Companion.Default: SubscriptionRecompositionOptimizer
+    get() = DefaultSubscriptionRecompositionOptimizer
+
+private object DefaultSubscriptionRecompositionOptimizer :
+    AbstractSubscriptionRecompositionOptimizer(SubscriberStatus.Active)
+
+/**
+ * Optimizer implementation for [SubscriptionStrategy.Companion.Lazy].
+ */
+val SubscriptionRecompositionOptimizer.Companion.Lazy: SubscriptionRecompositionOptimizer
+    get() = LazySubscriptionRecompositionOptimizer
+
+private object LazySubscriptionRecompositionOptimizer :
+    AbstractSubscriptionRecompositionOptimizer()
+
+private abstract class AbstractSubscriptionRecompositionOptimizer(
+    private val subscriberStatus: SubscriberStatus? = null
+) : SubscriptionRecompositionOptimizer {
+    override fun <T> omit(state: SubscriptionState<T>): SubscriptionState<T> {
+        val keys = buildSet {
+            add(SubscriptionState.OmitKey.replyUpdatedAt)
+            if (subscriberStatus != null) {
+                add(SubscriptionState.OmitKey.subscriberStatus)
+            }
+            when (state.status) {
+                SubscriptionStatus.Pending -> {
+                    add(SubscriptionState.OmitKey.errorUpdatedAt)
+                }
+
+                SubscriptionStatus.Success -> {
+                    add(SubscriptionState.OmitKey.errorUpdatedAt)
+                }
+
+                SubscriptionStatus.Failure -> Unit
+            }
+        }
+        return state.omit(keys, subscriberStatus ?: SubscriberStatus.NoSubscribers)
+    }
+}
+
+/**
+ * Option that performs no optimization.
+ */
+val SubscriptionRecompositionOptimizer.Companion.Disabled: SubscriptionRecompositionOptimizer
+    get() = DisabledSubscriptionRecompositionOptimizer
+
+private object DisabledSubscriptionRecompositionOptimizer : SubscriptionRecompositionOptimizer {
+    override fun <T> omit(state: SubscriptionState<T>): SubscriptionState<T> {
+        return state
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/CombinedQuery2.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/CombinedQuery2.kt
@@ -3,6 +3,7 @@
 
 package soil.query.compose.internal
 
+import androidx.compose.runtime.RememberObserver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -12,24 +13,37 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import soil.query.QueryClient
 import soil.query.QueryId
+import soil.query.QueryKey
 import soil.query.QueryRef
 import soil.query.QueryState
+import soil.query.compose.QueryConfig
 import soil.query.core.uuid
 import soil.query.merge
 
 
-internal fun <T1, T2, R> combineQuery(
-    query1: QueryRef<T1>,
-    query2: QueryRef<T2>,
-    transform: (T1, T2) -> R
-): QueryRef<R> = CombinedQuery2(query1, query2, transform)
+internal fun <T1, T2, R> newCombinedQuery(
+    key1: QueryKey<T1>,
+    key2: QueryKey<T2>,
+    transform: (T1, T2) -> R,
+    config: QueryConfig,
+    client: QueryClient,
+    scope: CoroutineScope
+): QueryRef<R> = CombinedQuery2(key1, key2, transform, config, client, scope)
 
 private class CombinedQuery2<T1, T2, R>(
-    private val query1: QueryRef<T1>,
-    private val query2: QueryRef<T2>,
-    private val transform: (T1, T2) -> R
-) : QueryRef<R> {
+    key1: QueryKey<T1>,
+    key2: QueryKey<T2>,
+    private val transform: (T1, T2) -> R,
+    config: QueryConfig,
+    client: QueryClient,
+    private val scope: CoroutineScope
+) : QueryRef<R>, RememberObserver {
+
+    private val query1: QueryRef<T1> = client.getQuery(key1, config.marker)
+    private val query2: QueryRef<T2> = client.getQuery(key2, config.marker)
+    private val optimize: (QueryState<R>) -> QueryState<R> = config.optimizer::omit
 
     override val id: QueryId<R> = QueryId("auto/${uuid()}")
 
@@ -62,6 +76,30 @@ private class CombinedQuery2<T1, T2, R>(
     }
 
     private fun merge(state1: QueryState<T1>, state2: QueryState<T2>): QueryState<R> {
-        return QueryState.merge(state1, state2, transform)
+        return optimize(QueryState.merge(state1, state2, transform))
+    }
+
+    // ----- RememberObserver -----//
+    private var jobs: List<Job>? = null
+
+    override fun onAbandoned() = stop()
+
+    override fun onForgotten() = stop()
+
+    override fun onRemembered() {
+        stop()
+        start()
+    }
+
+    private fun start() {
+        val job1 = query1.launchIn(scope)
+        val job2 = query2.launchIn(scope)
+        val job3 = launchIn(scope)
+        jobs = listOf(job1, job2, job3)
+    }
+
+    private fun stop() {
+        jobs?.forEach { it.cancel() }
+        jobs = null
     }
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/CombinedQueryN.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/CombinedQueryN.kt
@@ -3,6 +3,7 @@
 
 package soil.query.compose.internal
 
+import androidx.compose.runtime.RememberObserver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -12,22 +13,33 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import soil.query.QueryClient
 import soil.query.QueryId
+import soil.query.QueryKey
 import soil.query.QueryRef
 import soil.query.QueryState
+import soil.query.compose.QueryConfig
 import soil.query.core.uuid
 import soil.query.merge
 
-
-internal fun <T, R> combineQuery(
-    queries: Array<QueryRef<T>>,
-    transform: (List<T>) -> R
-): QueryRef<R> = CombinedQueryN(queries, transform)
+internal fun <T, R> newCombinedQuery(
+    keys: List<QueryKey<T>>,
+    transform: (List<T>) -> R,
+    config: QueryConfig,
+    client: QueryClient,
+    scope: CoroutineScope
+): QueryRef<R> = CombinedQueryN(keys, transform, config, client, scope)
 
 private class CombinedQueryN<T, R>(
-    private val queries: Array<QueryRef<T>>,
-    private val transform: (List<T>) -> R
-) : QueryRef<R> {
+    keys: List<QueryKey<T>>,
+    private val transform: (List<T>) -> R,
+    config: QueryConfig,
+    client: QueryClient,
+    private val scope: CoroutineScope
+) : QueryRef<R>, RememberObserver {
+
+    private val queries: List<QueryRef<T>> = keys.map { key -> client.getQuery(key, config.marker) }
+    private val optimize: (QueryState<R>) -> QueryState<R> = config.optimizer::omit
 
     override val id: QueryId<R> = QueryId("auto/${uuid()}")
 
@@ -56,6 +68,27 @@ private class CombinedQueryN<T, R>(
     }
 
     private fun merge(states: Array<QueryState<T>>): QueryState<R> {
-        return QueryState.merge(states, transform)
+        return optimize(QueryState.merge(states, transform))
+    }
+
+    // ----- RememberObserver -----//
+    private var jobs: List<Job>? = null
+
+    override fun onAbandoned() = stop()
+
+    override fun onForgotten() = stop()
+
+    override fun onRemembered() {
+        stop()
+        start()
+    }
+
+    private fun start() {
+        jobs = queries.map { it.launchIn(scope) } + launchIn(scope)
+    }
+
+    private fun stop() {
+        jobs?.forEach { it.cancel() }
+        jobs = null
     }
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/InfiniteQuery.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/InfiniteQuery.kt
@@ -1,0 +1,80 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.internal
+
+import androidx.compose.runtime.RememberObserver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import soil.query.InfiniteQueryId
+import soil.query.InfiniteQueryKey
+import soil.query.InfiniteQueryRef
+import soil.query.QueryChunks
+import soil.query.QueryClient
+import soil.query.QueryState
+import soil.query.compose.InfiniteQueryConfig
+
+internal fun <T, S> newInfiniteQuery(
+    key: InfiniteQueryKey<T, S>,
+    config: InfiniteQueryConfig,
+    client: QueryClient,
+    scope: CoroutineScope
+): InfiniteQueryRef<T, S> = InfiniteQuery(key, config, client, scope)
+
+private class InfiniteQuery<T, S>(
+    key: InfiniteQueryKey<T, S>,
+    config: InfiniteQueryConfig,
+    client: QueryClient,
+    private val scope: CoroutineScope
+) : InfiniteQueryRef<T, S>, RememberObserver {
+
+    private val query: InfiniteQueryRef<T, S> = client.getInfiniteQuery(key, config.marker)
+    private val optimize: (QueryState<QueryChunks<T, S>>) -> QueryState<QueryChunks<T, S>> = config.optimizer::omit
+
+    override val id: InfiniteQueryId<T, S> = query.id
+
+    private val _state: MutableStateFlow<QueryState<QueryChunks<T, S>>> = MutableStateFlow(
+        value = optimize(query.state.value)
+    )
+    override val state: StateFlow<QueryState<QueryChunks<T, S>>> = _state
+
+    override fun nextParam(data: QueryChunks<T, S>): S? = query.nextParam(data)
+
+    override suspend fun resume() = query.resume()
+
+    override suspend fun loadMore(param: S) = query.loadMore(param)
+
+    override suspend fun invalidate() = query.invalidate()
+
+    override fun launchIn(scope: CoroutineScope): Job {
+        return scope.launch {
+            query.state.collect { _state.value = optimize(it) }
+        }
+    }
+
+    // ----- RememberObserver -----//
+    private var jobs: List<Job>? = null
+
+    override fun onAbandoned() = stop()
+
+    override fun onForgotten() = stop()
+
+    override fun onRemembered() {
+        stop()
+        start()
+    }
+
+    private fun start() {
+        val job1 = query.launchIn(scope)
+        val job2 = launchIn(scope)
+        jobs = listOf(job1, job2)
+    }
+
+    private fun stop() {
+        jobs?.forEach { it.cancel() }
+        jobs = null
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/Mutation.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/Mutation.kt
@@ -1,0 +1,78 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.internal
+
+import androidx.compose.runtime.RememberObserver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import soil.query.MutationClient
+import soil.query.MutationId
+import soil.query.MutationKey
+import soil.query.MutationRef
+import soil.query.MutationState
+import soil.query.compose.MutationConfig
+
+internal fun <T, S> newMutation(
+    key: MutationKey<T, S>,
+    config: MutationConfig,
+    client: MutationClient,
+    scope: CoroutineScope
+): MutationRef<T, S> = Mutation(key, config, client, scope)
+
+private class Mutation<T, S>(
+    key: MutationKey<T, S>,
+    config: MutationConfig,
+    client: MutationClient,
+    private val scope: CoroutineScope
+) : MutationRef<T, S>, RememberObserver {
+
+    private val mutation: MutationRef<T, S> = client.getMutation(key, config.marker)
+    private val optimize: (MutationState<T>) -> MutationState<T> = config.optimizer::omit
+
+    override val id: MutationId<T, S> = mutation.id
+
+    private val _state: MutableStateFlow<MutationState<T>> = MutableStateFlow(
+        value = optimize(mutation.state.value)
+    )
+
+    override val state: StateFlow<MutationState<T>> = _state
+
+    override suspend fun mutate(variable: S): T = mutation.mutate(variable)
+
+    override suspend fun mutateAsync(variable: S) = mutation.mutateAsync(variable)
+
+    override suspend fun reset() = mutation.reset()
+
+    override fun launchIn(scope: CoroutineScope): Job {
+        return scope.launch {
+            mutation.state.collect { _state.value = optimize(it) }
+        }
+    }
+
+    // ----- RememberObserver -----//
+    private var jobs: List<Job>? = null
+
+    override fun onAbandoned() = stop()
+
+    override fun onForgotten() = stop()
+
+    override fun onRemembered() {
+        stop()
+        start()
+    }
+
+    private fun start() {
+        val job1 = mutation.launchIn(scope)
+        val job2 = launchIn(scope)
+        jobs = listOf(job1, job2)
+    }
+
+    private fun stop() {
+        jobs?.forEach { it.cancel() }
+        jobs = null
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/Query.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/Query.kt
@@ -1,0 +1,76 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.internal
+
+import androidx.compose.runtime.RememberObserver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import soil.query.QueryClient
+import soil.query.QueryId
+import soil.query.QueryKey
+import soil.query.QueryRef
+import soil.query.QueryState
+import soil.query.compose.QueryConfig
+
+internal fun <T> newQuery(
+    key: QueryKey<T>,
+    config: QueryConfig,
+    client: QueryClient,
+    scope: CoroutineScope
+): QueryRef<T> = Query(key, config, client, scope)
+
+private class Query<T>(
+    key: QueryKey<T>,
+    config: QueryConfig,
+    client: QueryClient,
+    private val scope: CoroutineScope,
+) : QueryRef<T>, RememberObserver {
+
+    private val query: QueryRef<T> = client.getQuery(key, config.marker)
+    private val optimize: (QueryState<T>) -> QueryState<T> = config.optimizer::omit
+
+    override val id: QueryId<T> = query.id
+
+    // FIXME: Switch to K2 mode when it becomes stable.
+    private val _state: MutableStateFlow<QueryState<T>> = MutableStateFlow(
+        value = optimize(query.state.value)
+    )
+    override val state: StateFlow<QueryState<T>> = _state
+
+    override suspend fun resume() = query.resume()
+
+    override suspend fun invalidate() = query.invalidate()
+
+    override fun launchIn(scope: CoroutineScope): Job {
+        return scope.launch {
+            query.state.collect { _state.value = optimize(it) }
+        }
+    }
+
+    // ----- RememberObserver -----//
+    private var jobs: List<Job>? = null
+
+    override fun onAbandoned() = stop()
+
+    override fun onForgotten() = stop()
+
+    override fun onRemembered() {
+        stop()
+        start()
+    }
+
+    private fun start() {
+        val job1 = query.launchIn(scope)
+        val job2 = launchIn(scope)
+        jobs = listOf(job1, job2)
+    }
+
+    private fun stop() {
+        jobs?.forEach { it.cancel() }
+        jobs = null
+    }
+}

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/Subscription.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/Subscription.kt
@@ -1,0 +1,80 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.internal
+
+import androidx.compose.runtime.RememberObserver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import soil.query.SubscriptionClient
+import soil.query.SubscriptionId
+import soil.query.SubscriptionKey
+import soil.query.SubscriptionRef
+import soil.query.SubscriptionState
+import soil.query.annotation.ExperimentalSoilQueryApi
+import soil.query.compose.SubscriptionConfig
+
+@ExperimentalSoilQueryApi
+internal fun <T> newSubscription(
+    key: SubscriptionKey<T>,
+    config: SubscriptionConfig,
+    client: SubscriptionClient,
+    scope: CoroutineScope
+): SubscriptionRef<T> = Subscription(key, config, client, scope)
+
+@ExperimentalSoilQueryApi
+private class Subscription<T>(
+    key: SubscriptionKey<T>,
+    config: SubscriptionConfig,
+    client: SubscriptionClient,
+    private val scope: CoroutineScope
+) : SubscriptionRef<T>, RememberObserver {
+
+    private val subscription: SubscriptionRef<T> = client.getSubscription(key, config.marker)
+    private val optimize: (SubscriptionState<T>) -> SubscriptionState<T> = config.optimizer::omit
+
+    override val id: SubscriptionId<T> = subscription.id
+
+    private val _state: MutableStateFlow<SubscriptionState<T>> = MutableStateFlow(
+        value = optimize(subscription.state.value)
+    )
+    override val state: StateFlow<SubscriptionState<T>> = _state
+
+    override suspend fun reset() = subscription.reset()
+
+    override suspend fun resume() = subscription.resume()
+
+    override fun cancel() = subscription.cancel()
+
+    override fun launchIn(scope: CoroutineScope): Job {
+        return scope.launch {
+            subscription.state.collect { _state.value = optimize(it) }
+        }
+    }
+
+    // ----- RememberObserver -----//
+    private var jobs: List<Job>? = null
+
+    override fun onAbandoned() = stop()
+
+    override fun onForgotten() = stop()
+
+    override fun onRemembered() {
+        stop()
+        start()
+    }
+
+    private fun start() {
+        val job1 = subscription.launchIn(scope)
+        val job2 = launchIn(scope)
+        jobs = listOf(job1, job2)
+    }
+
+    private fun stop() {
+        jobs?.forEach { it.cancel() }
+        jobs = null
+    }
+}

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryComposableTest.kt
@@ -50,8 +50,9 @@ class InfiniteQueryComposableTest : UnitTest() {
         setContent {
             SwrClientProvider(client) {
                 val query = rememberInfiniteQuery(key, config = InfiniteQueryConfig {
-                    strategy = InfiniteQueryStrategy.Default
                     mapper = InfiniteQueryObjectMapper.Default
+                    optimizer = InfiniteQueryRecompositionOptimizer.Default
+                    strategy = InfiniteQueryStrategy.Default
                     marker = Marker.None
                 })
                 when (val reply = query.reply) {

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizerTest.kt
@@ -1,0 +1,297 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Text
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
+import kotlinx.coroutines.delay
+import soil.query.InfiniteQueryId
+import soil.query.InfiniteQueryKey
+import soil.query.QueryChunks
+import soil.query.QueryFetchStatus
+import soil.query.QueryState
+import soil.query.QueryStatus
+import soil.query.SwrCache
+import soil.query.SwrCacheScope
+import soil.query.buildInfiniteQueryKey
+import soil.query.core.Reply
+import soil.query.emptyChunks
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(ExperimentalTestApi::class)
+class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
+
+    @Test
+    fun testRecompositionCount_default() = runComposeUiTest {
+        val key = TestInfiniteQueryKey()
+        val client = SwrCache(coroutineScope = SwrCacheScope())
+        var recompositionCount = 0
+        setContent {
+            SwrClientProvider(client) {
+                val query = rememberInfiniteQuery(key)
+                SideEffect { recompositionCount++ }
+                when (val reply = query.reply) {
+                    is Reply.Some -> {
+                        Column {
+                            reply.value.forEach { chunk ->
+                                Text(
+                                    "Size: ${chunk.data.size} - Page: ${chunk.param.page}",
+                                    modifier = Modifier.testTag("query")
+                                )
+                            }
+                        }
+                    }
+
+                    is Reply.None -> Unit
+                }
+            }
+        }
+
+        waitUntilAtLeastOneExists(hasTestTag("query"))
+
+        // pending -> success
+        assertEquals(2, recompositionCount)
+    }
+
+    @Test
+    fun testRecompositionCount_disabled() = runComposeUiTest {
+        val key = TestInfiniteQueryKey()
+        val client = SwrCache(coroutineScope = SwrCacheScope())
+        var recompositionCount = 0
+        setContent {
+            SwrClientProvider(client) {
+                val query = rememberInfiniteQuery(key, config = InfiniteQueryConfig {
+                    optimizer = InfiniteQueryRecompositionOptimizer.Disabled
+                })
+                SideEffect { recompositionCount++ }
+                when (val reply = query.reply) {
+                    is Reply.Some -> {
+                        Column {
+                            reply.value.forEach { chunk ->
+                                Text(
+                                    "Size: ${chunk.data.size} - Page: ${chunk.param.page}",
+                                    modifier = Modifier.testTag("query")
+                                )
+                            }
+                        }
+                    }
+
+                    is Reply.None -> Unit
+                }
+            }
+        }
+
+        waitUntilAtLeastOneExists(hasTestTag("query"))
+
+        // pending -> pending(fetching) -> success
+        assertEquals(3, recompositionCount)
+    }
+
+    @Test
+    fun testOmit_pending() {
+        val state = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.None,
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Pending,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = false
+        )
+        val actual = InfiniteQueryRecompositionOptimizer.Default.omit(state)
+        val expected = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.None,
+            replyUpdatedAt = 0,
+            errorUpdatedAt = 0,
+            staleAt = 0,
+            status = QueryStatus.Pending,
+            fetchStatus = QueryFetchStatus.Idle,
+            isInvalidated = false
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_success() {
+        val state = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = false
+        )
+        val actual = InfiniteQueryRecompositionOptimizer.Default.omit(state)
+        val expected = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 0,
+            errorUpdatedAt = 0,
+            staleAt = 0,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Idle,
+            isInvalidated = false
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_success_isInvalidated() {
+        val state = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = true
+        )
+        val actual = InfiniteQueryRecompositionOptimizer.Default.omit(state)
+        val expected = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 0,
+            errorUpdatedAt = 0,
+            staleAt = 0,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = true
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_failure() {
+        val error = RuntimeException("error")
+        val state = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = false
+        )
+        val actual = InfiniteQueryRecompositionOptimizer.Default.omit(state)
+        val expected = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 0,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 0,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Idle,
+            isInvalidated = false
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_failure_isInvalidated() {
+        val error = RuntimeException("error")
+        val state = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = true
+        )
+        val actual = InfiniteQueryRecompositionOptimizer.Default.omit(state)
+        val expected = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 0,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 0,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = true
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_pending() {
+        val expected = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.None,
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Pending,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = false
+        )
+        val actual = InfiniteQueryRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_success() {
+        val expected = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = false
+        )
+        val actual = InfiniteQueryRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_failure() {
+        val error = RuntimeException("error")
+        val expected = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = false
+        )
+        val actual = InfiniteQueryRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+
+    private class TestInfiniteQueryKey(
+        private val delayTime: Duration = 100.milliseconds
+    ) : InfiniteQueryKey<List<String>, PageParam> by buildInfiniteQueryKey(
+        id = InfiniteQueryId("test/infinite-query"),
+        fetch = { param ->
+            delay(delayTime)
+            val startPosition = param.page * param.size
+            (startPosition..<startPosition + param.size).map {
+                "Item $it"
+            }
+        },
+        initialParam = { PageParam(0, 10) },
+        loadMoreParam = {
+            val chunk = it.last()
+            PageParam(chunk.param.page + 1, 10)
+        }
+    )
+
+    private data class PageParam(
+        val page: Int,
+        val size: Int
+    )
+}

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationComposableTest.kt
@@ -45,8 +45,9 @@ class MutationComposableTest : UnitTest() {
         setContent {
             SwrClientProvider(client) {
                 val mutation = rememberMutation(key, config = MutationConfig {
-                    strategy = MutationStrategy.Default
                     mapper = MutationObjectMapper.Default
+                    optimizer = MutationRecompositionOptimizer.Default
+                    strategy = MutationStrategy.Default
                     marker = Marker.None
                 })
                 when (val reply = mutation.reply) {

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationRecompositionOptimizerTest.kt
@@ -1,0 +1,160 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import soil.query.MutationState
+import soil.query.MutationStatus
+import soil.query.core.Reply
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MutationRecompositionOptimizerTest : UnitTest() {
+
+    @Test
+    fun testOmit_default_idle() {
+        val state = MutationState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = null,
+            errorUpdatedAt = 200,
+            status = MutationStatus.Idle,
+            mutatedCount = 1
+        )
+        val actual = MutationRecompositionOptimizer.Default.omit(state)
+        val expected = MutationState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            error = null,
+            errorUpdatedAt = 0,
+            status = MutationStatus.Idle,
+            mutatedCount = 0
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_pending() {
+        val state = MutationState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = null,
+            errorUpdatedAt = 200,
+            status = MutationStatus.Pending,
+            mutatedCount = 1
+        )
+        val actual = MutationRecompositionOptimizer.Default.omit(state)
+        val expected = MutationState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            error = null,
+            errorUpdatedAt = 0,
+            status = MutationStatus.Pending,
+            mutatedCount = 0
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_success() {
+        val state = MutationState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = null,
+            errorUpdatedAt = 200,
+            status = MutationStatus.Success,
+            mutatedCount = 1
+        )
+        val actual = MutationRecompositionOptimizer.Default.omit(state)
+        val expected = MutationState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            error = null,
+            errorUpdatedAt = 0,
+            status = MutationStatus.Success,
+            mutatedCount = 0
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_failure() {
+        val error = RuntimeException("error")
+        val state = MutationState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            status = MutationStatus.Failure,
+            mutatedCount = 1
+        )
+        val actual = MutationRecompositionOptimizer.Default.omit(state)
+        val expected = MutationState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            error = error,
+            errorUpdatedAt = 200,
+            status = MutationStatus.Failure,
+            mutatedCount = 0
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_idle() {
+        val expected = MutationState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = null,
+            errorUpdatedAt = 200,
+            status = MutationStatus.Idle,
+            mutatedCount = 1
+        )
+        val actual = MutationRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_pending() {
+        val expected = MutationState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = null,
+            errorUpdatedAt = 200,
+            status = MutationStatus.Pending,
+            mutatedCount = 1
+        )
+        val actual = MutationRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_success() {
+        val expected = MutationState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = null,
+            errorUpdatedAt = 200,
+            status = MutationStatus.Success,
+            mutatedCount = 1
+        )
+        val actual = MutationRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_failure() {
+        val error = RuntimeException("error")
+        val expected = MutationState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            status = MutationStatus.Failure,
+            mutatedCount = 1
+        )
+        val actual = MutationRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+}

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryComposableTest.kt
@@ -44,8 +44,9 @@ class QueryComposableTest : UnitTest() {
         setContent {
             SwrClientProvider(client) {
                 val query = rememberQuery(key, config = QueryConfig {
-                    strategy = QueryStrategy.Default
                     mapper = QueryObjectMapper.Default
+                    optimizer = QueryRecompositionOptimizer.Default
+                    strategy = QueryStrategy.Default
                     marker = Marker.None
                 })
                 when (val reply = query.reply) {

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryRecompositionOptimizerTest.kt
@@ -1,0 +1,262 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import kotlinx.coroutines.delay
+import soil.query.QueryFetchStatus
+import soil.query.QueryId
+import soil.query.QueryKey
+import soil.query.QueryState
+import soil.query.QueryStatus
+import soil.query.SwrCache
+import soil.query.SwrCacheScope
+import soil.query.buildQueryKey
+import soil.query.core.Reply
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(ExperimentalTestApi::class)
+class QueryRecompositionOptimizerTest : UnitTest() {
+
+    @Test
+    fun testRecompositionCount_default() = runComposeUiTest {
+        val key = TestQueryKey()
+        val client = SwrCache(coroutineScope = SwrCacheScope())
+        var recompositionCount = 0
+        setContent {
+            SwrClientProvider(client) {
+                val query = rememberQuery(key)
+                SideEffect { recompositionCount++ }
+                when (val reply = query.reply) {
+                    is Reply.Some -> Text(reply.value, modifier = Modifier.testTag("query"))
+                    is Reply.None -> Unit
+                }
+            }
+        }
+
+        waitUntilExactlyOneExists(hasTestTag("query"))
+
+        // pending -> success
+        assertEquals(2, recompositionCount)
+    }
+
+    @Test
+    fun testRecompositionCount_disabled() = runComposeUiTest {
+        val key = TestQueryKey()
+        val client = SwrCache(coroutineScope = SwrCacheScope())
+        var recompositionCount = 0
+        setContent {
+            SwrClientProvider(client) {
+                val query = rememberQuery(key, config = QueryConfig {
+                    optimizer = QueryRecompositionOptimizer.Disabled
+                })
+                SideEffect { recompositionCount++ }
+                when (val reply = query.reply) {
+                    is Reply.Some -> Text(reply.value, modifier = Modifier.testTag("query"))
+                    is Reply.None -> Unit
+                }
+            }
+        }
+
+        waitUntilExactlyOneExists(hasTestTag("query"))
+
+        // pending -> pending(fetching) -> success
+        assertEquals(3, recompositionCount)
+    }
+
+    @Test
+    fun testOmit_pending() {
+        val state = QueryState.test(
+            reply = Reply.None,
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Pending,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = false
+        )
+        val actual = QueryRecompositionOptimizer.Default.omit(state)
+        val expected = QueryState.test(
+            reply = Reply.None,
+            replyUpdatedAt = 0,
+            errorUpdatedAt = 0,
+            staleAt = 0,
+            status = QueryStatus.Pending,
+            fetchStatus = QueryFetchStatus.Idle,
+            isInvalidated = false
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_success() {
+        val state = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = false
+        )
+        val actual = QueryRecompositionOptimizer.Default.omit(state)
+        val expected = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            errorUpdatedAt = 0,
+            staleAt = 0,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Idle,
+            isInvalidated = false
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_success_isInvalidated() {
+        val state = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = true
+        )
+        val actual = QueryRecompositionOptimizer.Default.omit(state)
+        val expected = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            errorUpdatedAt = 0,
+            staleAt = 0,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = true
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_failure() {
+        val error = RuntimeException("error")
+        val state = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = false
+        )
+        val actual = QueryRecompositionOptimizer.Default.omit(state)
+        val expected = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 0,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Idle,
+            isInvalidated = false
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_failure_isInvalidated() {
+        val error = RuntimeException("error")
+        val state = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = true
+        )
+        val actual = QueryRecompositionOptimizer.Default.omit(state)
+        val expected = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 0,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = true
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_pending() {
+        val expected = QueryState.test(
+            reply = Reply.None,
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Pending,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = false
+        )
+        val actual = QueryRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_success() {
+        val expected = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = false
+        )
+        val actual = QueryRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_failure() {
+        val error = RuntimeException("error")
+        val expected = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = false
+        )
+        val actual = QueryRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+
+    private class TestQueryKey(
+        number: Int = 1,
+        private val delayTime: Duration = 100.milliseconds
+    ) : QueryKey<String> by buildQueryKey(
+        id = QueryId("test/query/$number"),
+        fetch = {
+            delay(delayTime)
+            "Hello, Soil!"
+        }
+    )
+}

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionComposableTest.kt
@@ -48,8 +48,9 @@ class SubscriptionComposableTest : UnitTest() {
         setContent {
             SwrClientProvider(client) {
                 val subscription = rememberSubscription(key, config = SubscriptionConfig {
-                    strategy = SubscriptionStrategy.Default
                     mapper = SubscriptionObjectMapper.Default
+                    optimizer = SubscriptionRecompositionOptimizer.Default
+                    strategy = SubscriptionStrategy.Default
                     marker = Marker.None
                 })
                 when (val reply = subscription.reply) {
@@ -116,7 +117,7 @@ class SubscriptionComposableTest : UnitTest() {
         )
         setContent {
             SwrClientProvider(client) {
-                when (rememberSubscription(key)) {
+                when (rememberSubscription(key, config = SubscriptionConfig.Lazy)) {
                     is SubscriptionIdleObject -> Text("idle", modifier = Modifier.testTag("subscription"))
                     else -> Unit
                 }

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionRecompositionOptimizerTest.kt
@@ -1,0 +1,259 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import soil.query.SubscriberStatus
+import soil.query.SubscriptionId
+import soil.query.SubscriptionKey
+import soil.query.SubscriptionState
+import soil.query.SubscriptionStatus
+import soil.query.SwrCachePlus
+import soil.query.SwrCacheScope
+import soil.query.annotation.ExperimentalSoilQueryApi
+import soil.query.buildSubscriptionKey
+import soil.query.core.Reply
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(ExperimentalTestApi::class, ExperimentalSoilQueryApi::class)
+class SubscriptionRecompositionOptimizerTest : UnitTest() {
+
+    @Test
+    fun testRecomposition_default() = runComposeUiTest {
+        val key = TestSubscriptionKey()
+        val client = SwrCachePlus(coroutineScope = SwrCacheScope())
+        var recompositionCount = 0
+        setContent {
+            SwrClientProvider(client) {
+                val subscription = rememberSubscription(key)
+                SideEffect { recompositionCount++ }
+                when (val reply = subscription.reply) {
+                    is Reply.Some -> Text(reply.value, modifier = Modifier.testTag("subscription"))
+                    is Reply.None -> Unit
+                }
+            }
+        }
+
+        waitUntilExactlyOneExists(hasTestTag("subscription"))
+
+        // pending(active) -> success
+        assertEquals(2, recompositionCount)
+    }
+
+    @Test
+    fun testRecomposition_disabled() = runComposeUiTest {
+        val key = TestSubscriptionKey()
+        val client = SwrCachePlus(coroutineScope = SwrCacheScope())
+        var recompositionCount = 0
+        setContent {
+            SwrClientProvider(client) {
+                val subscription = rememberSubscription(key, config = SubscriptionConfig {
+                    optimizer = SubscriptionRecompositionOptimizer.Disabled
+                })
+                SideEffect { recompositionCount++ }
+                when (val reply = subscription.reply) {
+                    is Reply.Some -> Text(reply.value, modifier = Modifier.testTag("subscription"))
+                    is Reply.None -> Unit
+                }
+            }
+        }
+
+        waitUntilExactlyOneExists(hasTestTag("subscription"))
+
+        // pending(no-subscribers) -> pending(active) -> success
+        assertEquals(3, recompositionCount)
+    }
+
+    @Test
+    fun testOmit_default_pending() {
+        val state = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            status = SubscriptionStatus.Pending,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        val actual = SubscriptionRecompositionOptimizer.Default.omit(state)
+        val expected = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            errorUpdatedAt = 0,
+            status = SubscriptionStatus.Pending,
+            subscriberStatus = SubscriberStatus.Active
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_success() {
+        val state = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            status = SubscriptionStatus.Success,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        val actual = SubscriptionRecompositionOptimizer.Default.omit(state)
+        val expected = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            errorUpdatedAt = 0,
+            status = SubscriptionStatus.Success,
+            subscriberStatus = SubscriberStatus.Active
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_failure() {
+        val error = RuntimeException("error")
+        val state = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            status = SubscriptionStatus.Failure,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        val actual = SubscriptionRecompositionOptimizer.Default.omit(state)
+        val expected = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            error = error,
+            errorUpdatedAt = 200,
+            status = SubscriptionStatus.Failure,
+            subscriberStatus = SubscriberStatus.Active
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_lazy_pending() {
+        val state = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            status = SubscriptionStatus.Pending,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        val actual = SubscriptionRecompositionOptimizer.Lazy.omit(state)
+        val expected = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            errorUpdatedAt = 0,
+            status = SubscriptionStatus.Pending,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_lazy_success() {
+        val state = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            status = SubscriptionStatus.Success,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        val actual = SubscriptionRecompositionOptimizer.Lazy.omit(state)
+        val expected = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            errorUpdatedAt = 0,
+            status = SubscriptionStatus.Success,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_lazy_failure() {
+        val error = RuntimeException("error")
+        val state = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            status = SubscriptionStatus.Failure,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        val actual = SubscriptionRecompositionOptimizer.Lazy.omit(state)
+        val expected = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            error = error,
+            errorUpdatedAt = 200,
+            status = SubscriptionStatus.Failure,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_pending() {
+        val expected = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            status = SubscriptionStatus.Pending,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        val actual = SubscriptionRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_success() {
+        val expected = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            status = SubscriptionStatus.Success,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        val actual = SubscriptionRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_disabled_failure() {
+        val error = RuntimeException("error")
+        val expected = SubscriptionState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            status = SubscriptionStatus.Failure,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        val actual = SubscriptionRecompositionOptimizer.Disabled.omit(expected)
+        assertEquals(expected, actual)
+    }
+
+    private class TestSubscriptionKey(
+        private val delayTime: Duration = 100.milliseconds
+    ) : SubscriptionKey<String> by buildSubscriptionKey(
+        id = SubscriptionId("test/subscription"),
+        subscribe = {
+            flow {
+                delay(delayTime)
+                emit("Hello, Soil!")
+            }
+        }
+    )
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationState.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationState.kt
@@ -5,6 +5,7 @@ package soil.query
 
 import soil.query.core.Reply
 import soil.query.core.epoch
+import kotlin.jvm.JvmInline
 
 /**
  * State for managing the execution result of [Mutation].
@@ -17,6 +18,30 @@ data class MutationState<T> internal constructor(
     override val status: MutationStatus = MutationStatus.Idle,
     override val mutatedCount: Int = 0
 ) : MutationModel<T> {
+
+    /**
+     * Returns a new [MutationState] with the items included in [keys] omitted from the current [MutationState].
+     *
+     * NOTE: This function is provided to optimize recomposition for Compose APIs.
+     */
+    fun omit(keys: Set<OmitKey>): MutationState<T> {
+        if (keys.isEmpty()) return this
+        return copy(
+            replyUpdatedAt = if (keys.contains(OmitKey.replyUpdatedAt)) 0 else replyUpdatedAt,
+            errorUpdatedAt = if (keys.contains(OmitKey.errorUpdatedAt)) 0 else errorUpdatedAt,
+            mutatedCount = if (keys.contains(OmitKey.mutatedCount)) 0 else mutatedCount
+        )
+    }
+
+    @JvmInline
+    value class OmitKey(val name: String) {
+        companion object {
+            val replyUpdatedAt = OmitKey("replyUpdatedAt")
+            val errorUpdatedAt = OmitKey("errorUpdatedAt")
+            val mutatedCount = OmitKey("mutatedCount")
+        }
+    }
+
     companion object {
 
         /**
@@ -94,6 +119,29 @@ data class MutationState<T> internal constructor(
                 error = error,
                 errorUpdatedAt = errorUpdatedAt,
                 status = MutationStatus.Failure,
+                mutatedCount = mutatedCount
+            )
+        }
+
+        /**
+         * Creates a new [MutationState] for Testing.
+         *
+         * NOTE: **This method is for testing purposes only.**
+         */
+        fun <T> test(
+            reply: Reply<T> = Reply.None,
+            replyUpdatedAt: Long = 0,
+            error: Throwable? = null,
+            errorUpdatedAt: Long = 0,
+            status: MutationStatus = MutationStatus.Idle,
+            mutatedCount: Int = 0
+        ): MutationState<T> {
+            return MutationState(
+                reply = reply,
+                replyUpdatedAt = replyUpdatedAt,
+                error = error,
+                errorUpdatedAt = errorUpdatedAt,
+                status = status,
                 mutatedCount = mutatedCount
             )
         }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionState.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionState.kt
@@ -5,6 +5,7 @@ package soil.query
 
 import soil.query.core.Reply
 import soil.query.core.epoch
+import kotlin.jvm.JvmInline
 
 /**
  * State for managing the execution result of [Subscription].
@@ -17,6 +18,32 @@ data class SubscriptionState<T> internal constructor(
     override val status: SubscriptionStatus = SubscriptionStatus.Pending,
     override val subscriberStatus: SubscriberStatus = SubscriberStatus.NoSubscribers
 ) : SubscriptionModel<T> {
+
+    /**
+     * Returns a new [SubscriptionState] with the items included in [keys] omitted from the current [SubscriptionState].
+     *
+     * NOTE: This function is provided to optimize recomposition for Compose APIs.
+     */
+    fun omit(
+        keys: Set<OmitKey>,
+        defaultSubscriberStatus: SubscriberStatus = SubscriberStatus.NoSubscribers
+    ): SubscriptionState<T> {
+        if (keys.isEmpty()) return this
+        return copy(
+            replyUpdatedAt = if (keys.contains(OmitKey.replyUpdatedAt)) 0 else replyUpdatedAt,
+            errorUpdatedAt = if (keys.contains(OmitKey.errorUpdatedAt)) 0 else errorUpdatedAt,
+            subscriberStatus = if (keys.contains(OmitKey.subscriberStatus)) defaultSubscriberStatus else subscriberStatus
+        )
+    }
+
+    @JvmInline
+    value class OmitKey(val name: String) {
+        companion object {
+            val replyUpdatedAt = OmitKey("replyUpdatedAt")
+            val errorUpdatedAt = OmitKey("errorUpdatedAt")
+            val subscriberStatus = OmitKey("subscriberStatus")
+        }
+    }
 
     companion object {
 
@@ -95,6 +122,29 @@ data class SubscriptionState<T> internal constructor(
                 error = error,
                 errorUpdatedAt = errorUpdatedAt,
                 status = SubscriptionStatus.Failure,
+                subscriberStatus = subscriberStatus
+            )
+        }
+
+        /**
+         * Creates a new [SubscriptionState] for Testing.
+         *
+         * NOTE: **This method is for testing purposes only.**
+         */
+        fun <T> test(
+            reply: Reply<T> = Reply.None,
+            replyUpdatedAt: Long = 0,
+            error: Throwable? = null,
+            errorUpdatedAt: Long = 0,
+            status: SubscriptionStatus = SubscriptionStatus.Pending,
+            subscriberStatus: SubscriberStatus = SubscriberStatus.NoSubscribers
+        ): SubscriptionState<T> {
+            return SubscriptionState(
+                reply = reply,
+                replyUpdatedAt = replyUpdatedAt,
+                error = error,
+                errorUpdatedAt = errorUpdatedAt,
+                status = status,
                 subscriberStatus = subscriberStatus
             )
         }

--- a/soil-query-core/src/commonTest/kotlin/soil/query/MutationStateTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/MutationStateTest.kt
@@ -1,0 +1,47 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.Reply
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MutationStateTest : UnitTest() {
+
+    @Test
+    fun testOmit() {
+        val state = MutationState(
+            reply = Reply(1),
+            replyUpdatedAt = 300,
+            error = null,
+            errorUpdatedAt = 400,
+            status = MutationStatus.Success,
+            mutatedCount = 1
+        )
+        val actual = state.omit(
+            keys = setOf(
+                MutationState.OmitKey.replyUpdatedAt,
+                MutationState.OmitKey.errorUpdatedAt,
+                MutationState.OmitKey.mutatedCount
+            )
+        )
+        val expected = MutationState(
+            reply = Reply(1),
+            replyUpdatedAt = 0,
+            error = null,
+            errorUpdatedAt = 0,
+            status = MutationStatus.Success,
+            mutatedCount = 0
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_empty() {
+        val expectedState = MutationState.success(1, dataUpdatedAt = 300, mutatedCount = 1)
+        val actualState = expectedState.omit(emptySet())
+        assertEquals(expectedState, actualState)
+    }
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/QueryStateTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/QueryStateTest.kt
@@ -1,0 +1,48 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.Reply
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class QueryStateTest : UnitTest() {
+
+    @Test
+    fun testOmit() {
+        val state = QueryState(
+            reply = Reply(1),
+            replyUpdatedAt = 100,
+            error = null,
+            errorUpdatedAt = 200,
+            staleAt = 300,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching,
+            isInvalidated = true
+        )
+        val actual = state.omit(
+            keys = setOf(
+                QueryState.OmitKey.replyUpdatedAt,
+                QueryState.OmitKey.staleAt,
+                QueryState.OmitKey.errorUpdatedAt,
+                QueryState.OmitKey.fetchStatus
+            )
+        )
+        val expected = QueryState(
+            reply = Reply(1),
+            error = null,
+            status = QueryStatus.Success,
+            isInvalidated = true
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_emptyKeys() {
+        val expectedState = QueryState.success(1, dataUpdatedAt = 300, dataStaleAt = 400)
+        val actualState = expectedState.omit(emptySet())
+        assertEquals(expectedState, actualState)
+    }
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionStateTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionStateTest.kt
@@ -1,0 +1,77 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.Reply
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SubscriptionStateTest : UnitTest() {
+
+    @Test
+    fun testOmit() {
+        val state = SubscriptionState(
+            reply = Reply(1),
+            replyUpdatedAt = 300,
+            error = null,
+            errorUpdatedAt = 400,
+            status = SubscriptionStatus.Success,
+            subscriberStatus = SubscriberStatus.Active
+        )
+        val actual = state.omit(
+            keys = setOf(
+                SubscriptionState.OmitKey.replyUpdatedAt,
+                SubscriptionState.OmitKey.errorUpdatedAt,
+                SubscriptionState.OmitKey.subscriberStatus
+            )
+        )
+        val expected = SubscriptionState(
+            reply = Reply(1),
+            replyUpdatedAt = 0,
+            error = null,
+            errorUpdatedAt = 0,
+            status = SubscriptionStatus.Success,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_defaultSubscriberStatus() {
+        val state = SubscriptionState(
+            reply = Reply(1),
+            replyUpdatedAt = 300,
+            error = null,
+            errorUpdatedAt = 400,
+            status = SubscriptionStatus.Success,
+            subscriberStatus = SubscriberStatus.NoSubscribers
+        )
+        val actual = state.omit(
+            keys = setOf(
+                SubscriptionState.OmitKey.replyUpdatedAt,
+                SubscriptionState.OmitKey.errorUpdatedAt,
+                SubscriptionState.OmitKey.subscriberStatus
+            ),
+            defaultSubscriberStatus = SubscriberStatus.Active
+        )
+        val expected = SubscriptionState(
+            reply = Reply(1),
+            replyUpdatedAt = 0,
+            error = null,
+            errorUpdatedAt = 0,
+            status = SubscriptionStatus.Success,
+            subscriberStatus = SubscriberStatus.Active
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_empty() {
+        val expected = SubscriptionState.success(1, dataUpdatedAt = 300)
+        val actual = expected.omit(emptySet())
+        assertEquals(expected, actual)
+    }
+
+}


### PR DESCRIPTION
Within the Composable functions provided by the Query library, recomposition occurs due to changes in the internal state related to data loading. To reduce unnecessary state updates in the UI, we have implemented a RecompositionOptimizer that omits certain state changes based on conditions.

This RecompositionOptimizer can be configured on a per-Composable function basis, and the optimization is enabled by default. If you need to reference the omitted state items in the UI, you can disable the optimization through the configuration settings.