### PR TITLE
Introduce Comparison Functions

### DIFF
--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommand.kt
@@ -97,7 +97,7 @@ suspend inline fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.dispatchFetchC
         .map { QueryChunk(it, variable) }
         .map { chunk -> state.reply.getOrElse { emptyList() } + chunk }
         .run { key.onRecoverData()?.let(::recoverCatching) ?: this }
-        .onSuccess(::dispatchFetchSuccess)
+        .onSuccess { dispatchFetchSuccess(it, key.contentEquals) }
         .onFailure(::dispatchFetchFailure)
         .onFailure { reportQueryError(it, key.id, marker) }
         .also { callback?.invoke(it) }
@@ -122,7 +122,7 @@ suspend inline fun <T, S> QueryCommand.Context<QueryChunks<T, S>>.dispatchRevali
 ) {
     revalidate(key, chunks)
         .run { key.onRecoverData()?.let(::recoverCatching) ?: this }
-        .onSuccess(::dispatchFetchSuccess)
+        .onSuccess { dispatchFetchSuccess(it, key.contentEquals) }
         .onFailure(::dispatchFetchFailure)
         .onFailure { reportQueryError(it, key.id, marker) }
         .also { callback?.invoke(it) }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryKey.kt
@@ -41,9 +41,23 @@ interface InfiniteQueryKey<T, S> {
     val loadMoreParam: (chunks: QueryChunks<T, S>) -> S?
 
     /**
+     * Function to compare the content of the data.
+     *
+     * This function is used to determine whether the data is identical to the previous data via [InfiniteQueryCommand].
+     * If the data is considered the same, only [QueryState.staleAt] is updated.
+     * This can be useful when strict update management is needed, such as when special comparison is necessary,
+     * although it is generally not that important.
+     *
+     * @see QueryKey.contentEquals
+     */
+    val contentEquals: QueryContentEquals<QueryChunks<T, S>>? get() = null
+
+    /**
      * Function to configure the [QueryOptions].
      *
      * If unspecified, the default value of [SwrCachePolicy] is used.
+     *
+     * @see QueryKey.onConfigureOptions
      */
     fun onConfigureOptions(): QueryOptionsOverride? = null
 
@@ -52,7 +66,7 @@ interface InfiniteQueryKey<T, S> {
      *
      * Depending on the type of exception that occurred during data retrieval, it is possible to recover it as normal data.
      *
-     * @see QueryRecoverData
+     * @see QueryKey.onRecoverData
      */
     fun onRecoverData(): QueryRecoverData<QueryChunks<T, S>>? = null
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationAction.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationAction.kt
@@ -76,7 +76,7 @@ fun <T> createMutationReducer(): MutationReducer<T> = { state, action ->
                 reply = Reply(action.data),
                 replyUpdatedAt = action.dataUpdatedAt,
                 error = null,
-                errorUpdatedAt = action.dataUpdatedAt,
+                errorUpdatedAt = if (state.error != null) action.dataUpdatedAt else state.errorUpdatedAt,
                 mutatedCount = state.mutatedCount + 1
             )
         }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationClient.kt
@@ -24,5 +24,6 @@ interface MutationClient {
     ): MutationRef<T, S>
 }
 
+typealias MutationContentEquals<T> = (oldData: T, newData: T) -> Boolean
 typealias MutationOptionsOverride = (MutationOptions) -> MutationOptions
 typealias MutationCallback<T> = (Result<T>) -> Unit

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationKey.kt
@@ -30,6 +30,20 @@ interface MutationKey<T, S> {
     val mutate: suspend MutationReceiver.(variable: S) -> T
 
     /**
+     * Function to compare the content of the data.
+     *
+     * This function is used to determine whether the data is identical to the previous data via [MutationCommand].
+     * If the data is considered the same, [MutationState.replyUpdatedAt] is not updated, and the existing reply state is maintained.
+     * This can be useful when strict update management is needed, such as when special comparison is necessary,
+     * although it is generally not that important.
+     *
+     * ```kotlin
+     * override val contentEquals: MutationContentEquals<SomeType> = { a, b -> a.xx == b.xx }
+     * ```
+     */
+    val contentEquals: MutationContentEquals<T>? get() = null
+
+    /**
      * Function to configure the [MutationOptions].
      *
      * If unspecified, the default value of [SwrCachePolicy] is used.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationOptions.kt
@@ -29,6 +29,14 @@ interface MutationOptions : ActorOptions, LoggingOptions, RetryOptions {
     val isStrictMode: Boolean
 
     /**
+     * Determines whether two errors are equal.
+     *
+     * This function is used to determine whether a new error is identical to an existing error via [MutationCommand].
+     * If the errors are considered identical, [MutationState.errorUpdatedAt] is not updated, and the existing error state is maintained.
+     */
+    val errorEquals: ((Throwable, Throwable) -> Boolean)?
+
+    /**
      * This callback function will be called if some mutation encounters an error.
      */
     val onError: ((ErrorRecord, MutationModel<*>) -> Unit)?
@@ -46,6 +54,7 @@ interface MutationOptions : ActorOptions, LoggingOptions, RetryOptions {
     companion object Default : MutationOptions {
         override val isOneShot: Boolean = false
         override val isStrictMode: Boolean = false
+        override val errorEquals: ((Throwable, Throwable) -> Boolean)? = null
         override val onError: ((ErrorRecord, MutationModel<*>) -> Unit)? = null
         override val shouldSuppressErrorRelay: ((ErrorRecord, MutationModel<*>) -> Boolean)? = null
         override val shouldExecuteEffectSynchronously: Boolean = false
@@ -72,6 +81,7 @@ interface MutationOptions : ActorOptions, LoggingOptions, RetryOptions {
  *
  * @param isOneShot Only allows mutate to execute once while active (until reset).
  * @param isStrictMode Requires revision match as a precondition for executing mutate.
+ * @param errorEquals Determines whether two errors are equal.
  * @param onError This callback function will be called if some mutation encounters an error.
  * @param shouldSuppressErrorRelay Determines whether to suppress error information when relaying it using [soil.query.core.ErrorRelay].
  * @param shouldExecuteEffectSynchronously Whether the query side effect should be synchronous.
@@ -88,6 +98,7 @@ interface MutationOptions : ActorOptions, LoggingOptions, RetryOptions {
 fun MutationOptions(
     isOneShot: Boolean = MutationOptions.isOneShot,
     isStrictMode: Boolean = MutationOptions.isStrictMode,
+    errorEquals: ((Throwable, Throwable) -> Boolean)? = MutationOptions.errorEquals,
     onError: ((ErrorRecord, MutationModel<*>) -> Unit)? = MutationOptions.onError,
     shouldSuppressErrorRelay: ((ErrorRecord, MutationModel<*>) -> Boolean)? = MutationOptions.shouldSuppressErrorRelay,
     shouldExecuteEffectSynchronously: Boolean = MutationOptions.shouldExecuteEffectSynchronously,
@@ -104,6 +115,7 @@ fun MutationOptions(
     return object : MutationOptions {
         override val isOneShot: Boolean = isOneShot
         override val isStrictMode: Boolean = isStrictMode
+        override val errorEquals: ((Throwable, Throwable) -> Boolean)? = errorEquals
         override val onError: ((ErrorRecord, MutationModel<*>) -> Unit)? = onError
         override val shouldSuppressErrorRelay: ((ErrorRecord, MutationModel<*>) -> Boolean)? = shouldSuppressErrorRelay
         override val shouldExecuteEffectSynchronously: Boolean = shouldExecuteEffectSynchronously
@@ -125,6 +137,7 @@ fun MutationOptions(
 fun MutationOptions.copy(
     isOneShot: Boolean = this.isOneShot,
     isStrictMode: Boolean = this.isStrictMode,
+    errorEquals: ((Throwable, Throwable) -> Boolean)? = this.errorEquals,
     onError: ((ErrorRecord, MutationModel<*>) -> Unit)? = this.onError,
     shouldSuppressErrorRelay: ((ErrorRecord, MutationModel<*>) -> Boolean)? = this.shouldSuppressErrorRelay,
     shouldExecuteEffectSynchronously: Boolean = this.shouldExecuteEffectSynchronously,
@@ -141,6 +154,7 @@ fun MutationOptions.copy(
     return MutationOptions(
         isOneShot = isOneShot,
         isStrictMode = isStrictMode,
+        errorEquals = errorEquals,
         onError = onError,
         shouldSuppressErrorRelay = shouldSuppressErrorRelay,
         shouldExecuteEffectSynchronously = shouldExecuteEffectSynchronously,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryAction.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryAction.kt
@@ -84,7 +84,7 @@ fun <T> createQueryReducer(): QueryReducer<T> = { state, action ->
                 reply = Reply(action.data),
                 replyUpdatedAt = action.dataUpdatedAt,
                 error = null,
-                errorUpdatedAt = action.dataUpdatedAt,
+                errorUpdatedAt = if (state.error != null) action.dataUpdatedAt else state.errorUpdatedAt,
                 staleAt = action.dataStaleAt,
                 status = QueryStatus.Success,
                 fetchStatus = QueryFetchStatus.Idle,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
@@ -139,6 +139,7 @@ interface QueryMutableClient : QueryReadonlyClient {
 typealias QueryInitialData<T> = QueryReadonlyClient.() -> T?
 typealias QueryEffect = QueryMutableClient.() -> Unit
 
+typealias QueryContentEquals<T> = (oldData: T, newData: T) -> Boolean
 typealias QueryRecoverData<T> = (error: Throwable) -> T
 typealias QueryOptionsOverride = (QueryOptions) -> QueryOptions
 typealias QueryCallback<T> = (Result<T>) -> Unit

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
@@ -26,6 +26,20 @@ interface QueryKey<T> {
     val fetch: suspend QueryReceiver.() -> T
 
     /**
+     * Function to compare the content of the data.
+     *
+     * This function is used to determine whether the data is identical to the previous data via [QueryCommand].
+     * If the data is considered the same, only [QueryState.staleAt] is updated.
+     * This can be useful when strict update management is needed, such as when special comparison is necessary,
+     * although it is generally not that important.
+     *
+     * ```kotlin
+     * override val contentEquals: QueryContentEquals<SomeType> = { a, b -> a.xx == b.xx }
+     * ```
+     */
+    val contentEquals: QueryContentEquals<T>? get() = null
+
+    /**
      * Function to configure the [QueryOptions].
      *
      * If unspecified, the default value of [SwrCachePolicy] is used.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryOptions.kt
@@ -39,6 +39,14 @@ interface QueryOptions : ActorOptions, LoggingOptions, RetryOptions {
     val prefetchWindowTime: Duration
 
     /**
+     * Determines whether two errors are equal.
+     *
+     * This function is used to determine whether a new error is identical to an existing error via [QueryCommand].
+     * If the errors are considered identical, [QueryState.errorUpdatedAt] is not updated, and the existing error state is maintained.
+     */
+    val errorEquals: ((Throwable, Throwable) -> Boolean)?
+
+    /**
      * Determines whether query processing needs to be paused based on error.
      *
      * @see [shouldPause]
@@ -75,6 +83,7 @@ interface QueryOptions : ActorOptions, LoggingOptions, RetryOptions {
         override val staleTime: Duration = Duration.ZERO
         override val gcTime: Duration = 5.minutes
         override val prefetchWindowTime: Duration = 1.seconds
+        override val errorEquals: ((Throwable, Throwable) -> Boolean)? = null
         override val pauseDurationAfter: ((Throwable) -> Duration?)? = null
         override val revalidateOnReconnect: Boolean = true
         override val revalidateOnFocus: Boolean = true
@@ -106,6 +115,7 @@ interface QueryOptions : ActorOptions, LoggingOptions, RetryOptions {
  * @param staleTime The duration after which the returned value of the fetch function block is considered stale.
  * @param gcTime The period during which the Key's return value, if not referenced anywhere, is temporarily cached in memory.
  * @param prefetchWindowTime Maximum window time on prefetch processing.
+ * @param errorEquals Determines whether two errors are equal.
  * @param pauseDurationAfter Determines whether query processing needs to be paused based on error.
  * @param revalidateOnReconnect Automatically revalidate active [Query] when the network reconnects.
  * @param revalidateOnFocus Automatically revalidate active [Query] when the window is refocused.
@@ -125,6 +135,7 @@ fun QueryOptions(
     staleTime: Duration = QueryOptions.staleTime,
     gcTime: Duration = QueryOptions.gcTime,
     prefetchWindowTime: Duration = QueryOptions.prefetchWindowTime,
+    errorEquals: ((Throwable, Throwable) -> Boolean)? = QueryOptions.errorEquals,
     pauseDurationAfter: ((Throwable) -> Duration?)? = QueryOptions.pauseDurationAfter,
     revalidateOnReconnect: Boolean = QueryOptions.revalidateOnReconnect,
     revalidateOnFocus: Boolean = QueryOptions.revalidateOnFocus,
@@ -144,6 +155,7 @@ fun QueryOptions(
         override val staleTime: Duration = staleTime
         override val gcTime: Duration = gcTime
         override val prefetchWindowTime: Duration = prefetchWindowTime
+        override val errorEquals: ((Throwable, Throwable) -> Boolean)? = errorEquals
         override val pauseDurationAfter: ((Throwable) -> Duration?)? = pauseDurationAfter
         override val revalidateOnReconnect: Boolean = revalidateOnReconnect
         override val revalidateOnFocus: Boolean = revalidateOnFocus
@@ -168,6 +180,7 @@ fun QueryOptions.copy(
     staleTime: Duration = this.staleTime,
     gcTime: Duration = this.gcTime,
     prefetchWindowTime: Duration = this.prefetchWindowTime,
+    errorEquals: ((Throwable, Throwable) -> Boolean)? = this.errorEquals,
     pauseDurationAfter: ((Throwable) -> Duration?)? = this.pauseDurationAfter,
     revalidateOnReconnect: Boolean = this.revalidateOnReconnect,
     revalidateOnFocus: Boolean = this.revalidateOnFocus,
@@ -187,6 +200,7 @@ fun QueryOptions.copy(
         staleTime = staleTime,
         gcTime = gcTime,
         prefetchWindowTime = prefetchWindowTime,
+        errorEquals = errorEquals,
         pauseDurationAfter = pauseDurationAfter,
         revalidateOnReconnect = revalidateOnReconnect,
         revalidateOnFocus = revalidateOnFocus,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionAction.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionAction.kt
@@ -73,7 +73,7 @@ fun <T> createSubscriptionReducer(): SubscriptionReducer<T> = { state, action ->
                 reply = Reply(action.data),
                 replyUpdatedAt = action.dataUpdatedAt,
                 error = null,
-                errorUpdatedAt = action.dataUpdatedAt
+                errorUpdatedAt = if (state.error != null) action.dataUpdatedAt else state.errorUpdatedAt
             )
         }
 

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionClient.kt
@@ -26,5 +26,6 @@ interface SubscriptionClient {
     ): SubscriptionRef<T>
 }
 
+typealias SubscriptionContentEquals<T> = (oldData: T, newData: T) -> Boolean
 typealias SubscriptionRecoverData<T> = (error: Throwable) -> T
 typealias SubscriptionOptionsOverride = (SubscriptionOptions) -> SubscriptionOptions

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionKey.kt
@@ -28,6 +28,20 @@ interface SubscriptionKey<T> {
     val subscribe: SubscriptionReceiver.() -> Flow<T>
 
     /**
+     * Function to compare the content of the data.
+     *
+     * This function is used to determine whether the data is identical to the previous data via [SubscriptionCommand].
+     * If the data is considered the same, [SubscriptionState.replyUpdatedAt] is not updated, and the existing reply state is maintained.
+     * This can be useful when strict update management is needed, such as when special comparison is necessary,
+     * although it is generally not that important.
+     *
+     * ```kotlin
+     * override val contentEquals: SubscriptionContentEquals<SomeType> = { a, b -> a.xx == b.xx }
+     * ```
+     */
+    val contentEquals: SubscriptionContentEquals<T>? get() = null
+
+    /**
      * Function to configure the [SubscriptionOptions].
      *
      * If unspecified, the default value of [SubscriptionOptions] is used.

--- a/soil-query-core/src/commonTest/kotlin/soil/query/MutationOptionsTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/MutationOptionsTest.kt
@@ -17,6 +17,7 @@ class MutationOptionsTest : UnitTest() {
         val actual = MutationOptions()
         assertEquals(MutationOptions.Default.isOneShot, actual.isOneShot)
         assertEquals(MutationOptions.Default.isStrictMode, actual.isStrictMode)
+        assertEquals(MutationOptions.Default.errorEquals, actual.errorEquals)
         assertEquals(MutationOptions.Default.onError, actual.onError)
         assertEquals(MutationOptions.Default.shouldSuppressErrorRelay, actual.shouldSuppressErrorRelay)
         assertEquals(MutationOptions.Default.shouldExecuteEffectSynchronously, actual.shouldExecuteEffectSynchronously)
@@ -36,6 +37,7 @@ class MutationOptionsTest : UnitTest() {
         val actual = MutationOptions(
             isOneShot = true,
             isStrictMode = true,
+            errorEquals = { _, _ -> true },
             onError = { _, _ -> },
             shouldSuppressErrorRelay = { _, _ -> true },
             shouldExecuteEffectSynchronously = true,
@@ -51,6 +53,7 @@ class MutationOptionsTest : UnitTest() {
         )
         assertNotEquals(MutationOptions.Default.isOneShot, actual.isOneShot)
         assertNotEquals(MutationOptions.Default.isStrictMode, actual.isStrictMode)
+        assertNotEquals(MutationOptions.Default.errorEquals, actual.errorEquals)
         assertNotEquals(MutationOptions.Default.onError, actual.onError)
         assertNotEquals(MutationOptions.Default.shouldSuppressErrorRelay, actual.shouldSuppressErrorRelay)
         assertNotEquals(MutationOptions.Default.shouldExecuteEffectSynchronously, actual.shouldExecuteEffectSynchronously)
@@ -70,6 +73,7 @@ class MutationOptionsTest : UnitTest() {
         val actual = MutationOptions.Default.copy()
         assertEquals(MutationOptions.Default.isOneShot, actual.isOneShot)
         assertEquals(MutationOptions.Default.isStrictMode, actual.isStrictMode)
+        assertEquals(MutationOptions.Default.errorEquals, actual.errorEquals)
         assertEquals(MutationOptions.Default.onError, actual.onError)
         assertEquals(MutationOptions.Default.shouldSuppressErrorRelay, actual.shouldSuppressErrorRelay)
         assertEquals(MutationOptions.Default.shouldExecuteEffectSynchronously, actual.shouldExecuteEffectSynchronously)
@@ -89,6 +93,7 @@ class MutationOptionsTest : UnitTest() {
         val actual = MutationOptions.Default.copy(
             isOneShot = true,
             isStrictMode = true,
+            errorEquals = { _, _ -> true },
             onError = { _, _ -> },
             shouldSuppressErrorRelay = { _, _ -> true },
             shouldExecuteEffectSynchronously = true,
@@ -104,6 +109,7 @@ class MutationOptionsTest : UnitTest() {
         )
         assertNotEquals(MutationOptions.Default.isOneShot, actual.isOneShot)
         assertNotEquals(MutationOptions.Default.isStrictMode, actual.isStrictMode)
+        assertNotEquals(MutationOptions.Default.errorEquals, actual.errorEquals)
         assertNotEquals(MutationOptions.Default.onError, actual.onError)
         assertNotEquals(MutationOptions.Default.shouldSuppressErrorRelay, actual.shouldSuppressErrorRelay)
         assertNotEquals(MutationOptions.Default.shouldExecuteEffectSynchronously, actual.shouldExecuteEffectSynchronously)

--- a/soil-query-core/src/commonTest/kotlin/soil/query/QueryOptionsTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/QueryOptionsTest.kt
@@ -18,6 +18,7 @@ class QueryOptionsTest : UnitTest() {
         assertEquals(QueryOptions.Default.staleTime, actual.staleTime)
         assertEquals(QueryOptions.Default.gcTime, actual.gcTime)
         assertEquals(QueryOptions.Default.prefetchWindowTime, actual.prefetchWindowTime)
+        assertEquals(QueryOptions.Default.errorEquals, actual.errorEquals)
         assertEquals(QueryOptions.Default.pauseDurationAfter, actual.pauseDurationAfter)
         assertEquals(QueryOptions.Default.revalidateOnReconnect, actual.revalidateOnReconnect)
         assertEquals(QueryOptions.Default.revalidateOnFocus, actual.revalidateOnFocus)
@@ -40,6 +41,7 @@ class QueryOptionsTest : UnitTest() {
             staleTime = 1000.seconds,
             gcTime = 2000.seconds,
             prefetchWindowTime = 3000.seconds,
+            errorEquals = { _, _ -> true },
             pauseDurationAfter = { null },
             revalidateOnReconnect = false,
             revalidateOnFocus = false,
@@ -58,6 +60,7 @@ class QueryOptionsTest : UnitTest() {
         assertNotEquals(QueryOptions.Default.staleTime, actual.staleTime)
         assertNotEquals(QueryOptions.Default.gcTime, actual.gcTime)
         assertNotEquals(QueryOptions.Default.prefetchWindowTime, actual.prefetchWindowTime)
+        assertNotEquals(QueryOptions.Default.errorEquals, actual.errorEquals)
         assertNotEquals(QueryOptions.Default.pauseDurationAfter, actual.pauseDurationAfter)
         assertNotEquals(QueryOptions.Default.revalidateOnReconnect, actual.revalidateOnReconnect)
         assertNotEquals(QueryOptions.Default.revalidateOnFocus, actual.revalidateOnFocus)
@@ -80,6 +83,7 @@ class QueryOptionsTest : UnitTest() {
         assertEquals(QueryOptions.Default.staleTime, actual.staleTime)
         assertEquals(QueryOptions.Default.gcTime, actual.gcTime)
         assertEquals(QueryOptions.Default.prefetchWindowTime, actual.prefetchWindowTime)
+        assertEquals(QueryOptions.Default.errorEquals, actual.errorEquals)
         assertEquals(QueryOptions.Default.pauseDurationAfter, actual.pauseDurationAfter)
         assertEquals(QueryOptions.Default.revalidateOnReconnect, actual.revalidateOnReconnect)
         assertEquals(QueryOptions.Default.revalidateOnFocus, actual.revalidateOnFocus)
@@ -102,6 +106,7 @@ class QueryOptionsTest : UnitTest() {
             staleTime = 1000.seconds,
             gcTime = 2000.seconds,
             prefetchWindowTime = 3000.seconds,
+            errorEquals = { _, _ -> true },
             pauseDurationAfter = { null },
             revalidateOnReconnect = false,
             revalidateOnFocus = false,
@@ -120,6 +125,7 @@ class QueryOptionsTest : UnitTest() {
         assertNotEquals(QueryOptions.Default.staleTime, actual.staleTime)
         assertNotEquals(QueryOptions.Default.gcTime, actual.gcTime)
         assertNotEquals(QueryOptions.Default.prefetchWindowTime, actual.prefetchWindowTime)
+        assertNotEquals(QueryOptions.Default.errorEquals, actual.errorEquals)
         assertNotEquals(QueryOptions.Default.pauseDurationAfter, actual.pauseDurationAfter)
         assertNotEquals(QueryOptions.Default.revalidateOnReconnect, actual.revalidateOnReconnect)
         assertNotEquals(QueryOptions.Default.revalidateOnFocus, actual.revalidateOnFocus)

--- a/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionOptionsTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionOptionsTest.kt
@@ -16,6 +16,7 @@ class SubscriptionOptionsTest : UnitTest() {
     fun factory_default() {
         val actual = SubscriptionOptions()
         assertEquals(SubscriptionOptions.Default.gcTime, actual.gcTime)
+        assertEquals(SubscriptionOptions.Default.errorEquals, actual.errorEquals)
         assertEquals(SubscriptionOptions.Default.onError, actual.onError)
         assertEquals(SubscriptionOptions.Default.shouldSuppressErrorRelay, actual.shouldSuppressErrorRelay)
         assertEquals(SubscriptionOptions.Default.keepAliveTime, actual.keepAliveTime)
@@ -33,6 +34,7 @@ class SubscriptionOptionsTest : UnitTest() {
     fun factory_factory_specifyingArguments() {
         val actual = SubscriptionOptions(
             gcTime = 1000.seconds,
+            errorEquals = { _, _ -> true },
             onError = { _, _ -> },
             shouldSuppressErrorRelay = { _, _ -> true },
             keepAliveTime = 4000.seconds,
@@ -46,6 +48,7 @@ class SubscriptionOptionsTest : UnitTest() {
             retryRandomizer = Random(999)
         )
         assertNotEquals(SubscriptionOptions.Default.gcTime, actual.gcTime)
+        assertNotEquals(SubscriptionOptions.Default.errorEquals, actual.errorEquals)
         assertNotEquals(SubscriptionOptions.Default.onError, actual.onError)
         assertNotEquals(SubscriptionOptions.Default.shouldSuppressErrorRelay, actual.shouldSuppressErrorRelay)
         assertNotEquals(SubscriptionOptions.Default.keepAliveTime, actual.keepAliveTime)
@@ -63,6 +66,7 @@ class SubscriptionOptionsTest : UnitTest() {
     fun copy_default() {
         val actual = SubscriptionOptions.copy()
         assertEquals(SubscriptionOptions.Default.gcTime, actual.gcTime)
+        assertEquals(SubscriptionOptions.Default.errorEquals, actual.errorEquals)
         assertEquals(SubscriptionOptions.Default.onError, actual.onError)
         assertEquals(SubscriptionOptions.Default.shouldSuppressErrorRelay, actual.shouldSuppressErrorRelay)
         assertEquals(SubscriptionOptions.Default.keepAliveTime, actual.keepAliveTime)
@@ -80,6 +84,7 @@ class SubscriptionOptionsTest : UnitTest() {
     fun copy_override() {
         val actual = SubscriptionOptions.copy(
             gcTime = 1000.seconds,
+            errorEquals = { _, _ -> true },
             onError = { _, _ -> },
             shouldSuppressErrorRelay = { _, _ -> true },
             keepAliveTime = 4000.seconds,
@@ -94,6 +99,7 @@ class SubscriptionOptionsTest : UnitTest() {
         )
 
         assertNotEquals(SubscriptionOptions.Default.gcTime, actual.gcTime)
+        assertNotEquals(SubscriptionOptions.Default.errorEquals, actual.errorEquals)
         assertNotEquals(SubscriptionOptions.Default.onError, actual.onError)
         assertNotEquals(SubscriptionOptions.Default.shouldSuppressErrorRelay, actual.shouldSuppressErrorRelay)
         assertNotEquals(SubscriptionOptions.Default.keepAliveTime, actual.keepAliveTime)


### PR DESCRIPTION
To suppress updates of data and exceptions considered identical and to reduce recompositions, I have implemented the following two functions:

- contentEquals
- errorEquals

These are intended to be used similarly to the [compare](https://swr.vercel.app/docs/advanced/performance#deep-comparison) function in the [SWR](https://github.com/vercel/swr) library.