### PR TITLE
Add `purgeAll` API

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SwrPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SwrPreviewClient.kt
@@ -34,6 +34,7 @@ class SwrPreviewClient(
     override val errorRelay: Flow<ErrorRecord> = flow { }
 ) : SwrClient, SwrClientPlus, QueryClient by query, MutationClient by mutation, SubscriptionClient by subscription {
     override fun gc(level: MemoryPressureLevel) = Unit
+    override fun purgeAll() = Unit
     override fun perform(sideEffects: QueryEffect): Job = Job()
     override fun onMount(id: String) = Unit
     override fun onUnmount(id: String) = Unit

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCache.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCache.kt
@@ -95,6 +95,24 @@ open class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutabl
         }
     }
 
+    override fun purgeAll() {
+        purgeAllQueries()
+        purgeAllMutations()
+    }
+
+    private fun purgeAllQueries() {
+        val queryStoreCopy = queryStore.toMap()
+        queryStore.clear()
+        queryCache.clear()
+        queryStoreCopy.values.forEach { it.close() }
+    }
+
+    private fun purgeAllMutations() {
+        val mutationStoreCopy = mutationStore.toMap()
+        mutationStore.clear()
+        mutationStoreCopy.values.forEach { it.close() }
+    }
+
     override fun perform(sideEffects: QueryEffect): Job {
         return coroutineScope.launch {
             with(this@SwrCache) { sideEffects() }
@@ -576,6 +594,7 @@ open class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutabl
         }
         return model?.let(predicate) ?: false
     }
+
 
     internal class ManagedMutation<T>(
         val scope: CoroutineScope,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlus.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlus.kt
@@ -48,6 +48,9 @@ class SwrCachePlus(private val policy: SwrCachePlusPolicy) : SwrCache(policy), S
     )
     private val batchScheduler: BatchScheduler = policy.batchSchedulerFactory.create(coroutineScope)
 
+
+    // ----- SwrClientPlus ----- //
+
     override val defaultSubscriptionOptions: SubscriptionOptions = policy.subscriptionOptions
 
     override fun gc(level: MemoryPressureLevel) {
@@ -56,6 +59,18 @@ class SwrCachePlus(private val policy: SwrCachePlusPolicy) : SwrCache(policy), S
             MemoryPressureLevel.Low -> subscriptionCache.evict()
             MemoryPressureLevel.High -> subscriptionCache.clear()
         }
+    }
+
+    override fun purgeAll() {
+        super.purgeAll()
+        purgeAllSubscriptions()
+    }
+
+    private fun purgeAllSubscriptions() {
+        val subscriptionStoreCopy = subscriptionStore.toMap()
+        subscriptionStore.clear()
+        subscriptionCache.clear()
+        subscriptionStoreCopy.values.forEach { it.close() }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrClient.kt
@@ -29,6 +29,15 @@ interface SwrClient : MutationClient, QueryClient {
     fun gc(level: MemoryPressureLevel = MemoryPressureLevel.Low)
 
     /**
+     * Removes all queries and mutations from the in-memory stored data.
+     *
+     * **Note:**
+     * If there are any active queries or mutations, they will be stopped as well.
+     * This method should only be used for full resets, such as during sign-out.
+     */
+    fun purgeAll()
+
+    /**
      * Executes side effects for queries.
      */
     fun perform(sideEffects: QueryEffect): Job

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrClientPlus.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrClientPlus.kt
@@ -6,4 +6,14 @@ package soil.query
 /**
  * An enhanced version of [SwrClient] that integrates [SubscriptionClient] into SwrClient.
  */
-interface SwrClientPlus : SwrClient, SubscriptionClient
+interface SwrClientPlus : SwrClient, SubscriptionClient {
+
+    /**
+     * Removes all queries, mutations and subscriptions from the in-memory stored data.
+     *
+     * **Note:**
+     * If there are any active queries or mutations or subscriptions, they will be stopped as well.
+     * This method should only be used for full resets, such as during sign-out.
+     */
+    override fun purgeAll()
+}


### PR DESCRIPTION
Currently, it is possible to explicitly delete in-memory data for queries through the `perform` function or the mutation update process.

In #89, we added support for the Subscription API, but there is still no API available to clear in-memory data for subscriptions. Therefore, we have implemented the `purgeAll` function, which is intended for full reset operations, such as during sign-out processes.