### PR TITLE
Behavior Test for iOS Artifacts

### DIFF
--- a/.github/workflows/publish-local.yml
+++ b/.github/workflows/publish-local.yml
@@ -1,0 +1,29 @@
+name: Publish Local for Testing
+on:
+  workflow_dispatch
+
+jobs:
+  publish:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Publish to Local
+        run: ./gradlew publishToMavenLocal --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}


### PR DESCRIPTION
The generation of the iOS target artifact was unsuccessful during the library upload to Maven Central from the GitHub Actions.  A review of the GitHub Actions execution logs revealed warnings indicating automatic skipping of the process due to the machine type used for execution. refs: #110

```
> Configure project :soil-form
w: The following Kotlin/Native targets cannot be built on this machine and are disabled:
iosArm64, iosSimulatorArm64, iosX64
To hide this message, add 'kotlin.native.ignoreDisabledTargets=true' to the Gradle properties.
```

To address this issue and ensure proper functionality, we will first output the library artifacts locally instead of directly to Maven Central. This will allow us to verify the correct operation in a test job before proceeding with any changes to the CI environment machine type.