### PR TITLE
Implement Conditional Caching

### DIFF
--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryKey.kt
@@ -53,6 +53,20 @@ interface InfiniteQueryKey<T, S> {
     val contentEquals: QueryContentEquals<QueryChunks<T, S>>? get() = null
 
     /**
+     * Function to determine if the data should be cached.
+     *
+     * This function evaluates the provided data to decide whether it is suitable for caching.
+     * If the function returns `true`, the data is considered cacheable; otherwise, it is not.
+     * This can be useful in cases where caching is conditional based on specific data attributes
+     * or properties that indicate the content should be stored temporarily.
+     *
+     * ```kotlin
+     * override val contentCacheable: QueryContentCacheable<SomeType> = { data -> data.isNotEmpty() }
+     * ```
+     */
+    val contentCacheable: QueryContentCacheable<QueryChunks<T, S>>? get() = null
+
+    /**
      * Function to configure the [QueryOptions].
      *
      * If unspecified, the default value of [SwrCachePolicy] is used.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
@@ -140,6 +140,7 @@ typealias QueryInitialData<T> = QueryReadonlyClient.() -> T?
 typealias QueryEffect = QueryMutableClient.() -> Unit
 
 typealias QueryContentEquals<T> = (oldData: T, newData: T) -> Boolean
+typealias QueryContentCacheable<T> = (currentData: T) -> Boolean
 typealias QueryRecoverData<T> = (error: Throwable) -> T
 typealias QueryOptionsOverride = (QueryOptions) -> QueryOptions
 typealias QueryCallback<T> = (Result<T>) -> Unit

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
@@ -40,6 +40,20 @@ interface QueryKey<T> {
     val contentEquals: QueryContentEquals<T>? get() = null
 
     /**
+     * Function to determine if the data should be cached.
+     *
+     * This function evaluates the provided data to decide whether it is suitable for caching.
+     * If the function returns `true`, the data is considered cacheable; otherwise, it is not.
+     * This can be useful in cases where caching is conditional based on specific data attributes
+     * or properties that indicate the content should be stored temporarily.
+     *
+     * ```kotlin
+     * override val contentCacheable: QueryContentCacheable<SomeType> = { data -> data.isNotEmpty() }
+     * ```
+     */
+    val contentCacheable: QueryContentCacheable<T>? get() = null
+
+    /**
      * Function to configure the [QueryOptions].
      *
      * If unspecified, the default value of [SwrCachePolicy] is used.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionClient.kt
@@ -27,5 +27,6 @@ interface SubscriptionClient {
 }
 
 typealias SubscriptionContentEquals<T> = (oldData: T, newData: T) -> Boolean
+typealias SubscriptionContentCacheable<T> = (currentData: T) -> Boolean
 typealias SubscriptionRecoverData<T> = (error: Throwable) -> T
 typealias SubscriptionOptionsOverride = (SubscriptionOptions) -> SubscriptionOptions

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionKey.kt
@@ -42,6 +42,20 @@ interface SubscriptionKey<T> {
     val contentEquals: SubscriptionContentEquals<T>? get() = null
 
     /**
+     * Function to determine if the data should be cached.
+     *
+     * This function evaluates the provided data to decide whether it is suitable for caching.
+     * If the function returns `true`, the data is considered cacheable; otherwise, it is not.
+     * This can be useful in cases where caching is conditional based on specific data attributes
+     * or properties that indicate the content should be stored temporarily.
+     *
+     * ```kotlin
+     * override val contentCacheable: SubscriptionContentCacheable<SomeType> = { data -> data.isNotEmpty() }
+     * ```
+     */
+    val contentCacheable: SubscriptionContentCacheable<T>? get() = null
+
+    /**
      * Function to configure the [SubscriptionOptions].
      *
      * If unspecified, the default value of [SubscriptionOptions] is used.


### PR DESCRIPTION
Added a `contentCacheable` property to the key definitions for queries and subscriptions with caching mechanisms. 

With this change, in addition to defining the cache retention period based on options, it's now possible to determine whether caching is enabled for each key based on the content. This allows for usage patterns aligned with content freshness, such as "Do not cache if the list data is empty."