### PR TITLE
Automatic namespace generation

### DIFF
--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberExampleSubscription.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberExampleSubscription.kt
@@ -5,11 +5,13 @@ import androidx.compose.runtime.remember
 import soil.playground.query.key.ExampleSubscriptionKey
 import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.compose.SubscriptionObject
+import soil.query.compose.auto
 import soil.query.compose.rememberSubscription
 
 @OptIn(ExperimentalSoilQueryApi::class)
 @Composable
 fun rememberExampleSubscription(): SubscriptionObject<String> {
-    val key = remember { ExampleSubscriptionKey() }
+    val auto = auto()
+    val key = remember { ExampleSubscriptionKey(auto) }
     return rememberSubscription(key)
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/ExampleSubscriptionKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/ExampleSubscriptionKey.kt
@@ -5,9 +5,10 @@ import kotlinx.coroutines.flow.flow
 import soil.query.SubscriptionId
 import soil.query.SubscriptionKey
 import soil.query.buildSubscriptionKey
+import soil.query.core.Auto
 
-class ExampleSubscriptionKey : SubscriptionKey<String> by buildSubscriptionKey(
-    id = SubscriptionId("test/id"),
+class ExampleSubscriptionKey(auto: Auto) : SubscriptionKey<String> by buildSubscriptionKey(
+    id = SubscriptionId(auto.namespace),
     subscribe = {
         flow {
             delay(1000)

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/DeletePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/DeletePostKey.kt
@@ -2,13 +2,15 @@ package soil.playground.query.key.posts
 
 import io.ktor.client.request.delete
 import soil.query.InfiniteQueryId
+import soil.query.MutationId
 import soil.query.MutationKey
 import soil.query.QueryEffect
 import soil.query.QueryId
+import soil.query.core.Auto
 import soil.query.receivers.ktor.buildKtorMutationKey
 
-class DeletePostKey : MutationKey<Unit, Int> by buildKtorMutationKey(
-    /* id = MutationId.auto(), */
+class DeletePostKey(auto: Auto) : MutationKey<Unit, Int> by buildKtorMutationKey(
+    id = MutationId(auto.namespace),
     mutate = { postId ->
         delete("https://jsonplaceholder.typicode.com/posts/$postId")
     }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/UpdatePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/UpdatePostKey.kt
@@ -5,14 +5,16 @@ import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import soil.playground.query.data.Post
 import soil.query.InfiniteQueryId
+import soil.query.MutationId
 import soil.query.MutationKey
 import soil.query.QueryEffect
 import soil.query.QueryId
+import soil.query.core.Auto
 import soil.query.modifyData
 import soil.query.receivers.ktor.buildKtorMutationKey
 
-class UpdatePostKey : MutationKey<Post, Post> by buildKtorMutationKey(
-    /* id = MutationId.auto(), */
+class UpdatePostKey(auto: Auto) : MutationKey<Post, Post> by buildKtorMutationKey(
+    id = MutationId(auto.namespace),
     mutate = { body ->
         put("https://jsonplaceholder.typicode.com/posts/${body.id}") {
             setBody(body)

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/Util.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/Util.kt
@@ -6,6 +6,8 @@ package soil.query.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import soil.query.InfiniteQueryKey
 import soil.query.MutationClient
 import soil.query.MutationKey
@@ -13,6 +15,8 @@ import soil.query.QueryClient
 import soil.query.QueryKey
 import soil.query.ResumeQueriesFilter
 import soil.query.SwrClient
+import soil.query.core.Auto
+
 
 typealias QueriesErrorReset = () -> Unit
 
@@ -86,3 +90,18 @@ fun KeepAlive(
     val scope = rememberCoroutineScope()
     remember(key) { client.getMutation(key).also { it.launchIn(scope) } }
 }
+
+
+/**
+ * Automatically generated value for mutationId and subscriptionId.
+ *
+ * @see Auto
+ */
+@Composable
+fun auto(): Auto = rememberSaveable(saver = Auto.Saver) { Auto() }
+
+internal val Auto.Companion.Saver
+    get() = Saver<Auto, String>(
+        save = { it.value },
+        restore = { Auto(it) }
+    )

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationKey.kt
@@ -108,6 +108,13 @@ open class MutationId<T, S>(
          *
          * FIXME: Since this function is for automatic ID assignment, it might be better not to have arguments.
          */
+        @Deprecated(
+            """
+            This function is deprecated because it does not retain automatically generated values when used within Compose.
+            As a result, values are regenerated after configuration changes, leading to different values.
+            Consider using an alternative approach that preserves state across recompositions.
+        """, ReplaceWith("MutationId(namespace, *tags)", "soil.query.MutationId")
+        )
         fun <T, S> auto(
             namespace: String = "auto/${uuid()}",
             vararg tags: SurrogateKey

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionKey.kt
@@ -103,6 +103,13 @@ open class SubscriptionId<T>(
     }
 
     companion object {
+        @Deprecated(
+            """
+            This function is deprecated because it does not retain automatically generated values when used within Compose.
+            As a result, values are regenerated after configuration changes, leading to different values.
+            Consider using an alternative approach that preserves state across recompositions.
+        """, ReplaceWith("SubscriptionId(namespace, *tags)", "soil.query.SubscriptionId")
+        )
         fun <T> auto(
             namespace: String = "auto/${uuid()}",
             vararg tags: SurrogateKey

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/UniqueId.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/UniqueId.kt
@@ -42,3 +42,35 @@ interface UniqueId {
  * A surrogate key for unique identifiers.
  */
 typealias SurrogateKey = Any
+
+
+/**
+ * Automatically generated value for mutationId and subscriptionId.
+ *
+ * This class is useful for generating a unique namespace when a key, such as MutationKey or SubscriptionKey, is used in a single Composable function.
+ */
+class Auto(val value: String = uuid()) {
+
+    val namespace: String
+        get() = "auto/$value"
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as Auto
+
+        return value == other.value
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+    override fun toString(): String {
+        return namespace
+    }
+
+    // For Compose saver extension, to be extended by query.compose module
+    companion object
+}


### PR DESCRIPTION
Currently, the companion objects of `MutationId` and `SubscriptionId` have an `auto` function defined.

```kotlin
fun <T, S> auto(
    namespace: String = "auto/${uuid()}",
    vararg tags: SurrogateKey
): MutationId<T, S> {
    return MutationId(namespace, *tags)
}
```

However, when this function is used for defining keys in a Compose runtime environment, values cannot be restored after configuration changes on the Android platform.

Therefore, we have decided to deprecate the `auto` function in the companion objects and instead provide a Compose function with the same name.