### PR TITLE
Tiny fix to Automatic Namespace Generation

### DIFF
--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberExampleSubscription.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberExampleSubscription.kt
@@ -7,11 +7,12 @@ import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.compose.SubscriptionObject
 import soil.query.compose.auto
 import soil.query.compose.rememberSubscription
+import soil.query.core.Namespace
 
 @OptIn(ExperimentalSoilQueryApi::class)
 @Composable
 fun rememberExampleSubscription(): SubscriptionObject<String> {
-    val auto = auto()
+    val auto = Namespace.auto()
     val key = remember { ExampleSubscriptionKey(auto) }
     return rememberSubscription(key)
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/ExampleSubscriptionKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/ExampleSubscriptionKey.kt
@@ -5,10 +5,10 @@ import kotlinx.coroutines.flow.flow
 import soil.query.SubscriptionId
 import soil.query.SubscriptionKey
 import soil.query.buildSubscriptionKey
-import soil.query.core.Auto
+import soil.query.core.Namespace
 
-class ExampleSubscriptionKey(auto: Auto) : SubscriptionKey<String> by buildSubscriptionKey(
-    id = SubscriptionId(auto.namespace),
+class ExampleSubscriptionKey(auto: Namespace) : SubscriptionKey<String> by buildSubscriptionKey(
+    id = SubscriptionId(auto.value),
     subscribe = {
         flow {
             delay(1000)

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/CreatePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/CreatePostKey.kt
@@ -5,12 +5,14 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import soil.playground.query.data.Post
 import soil.query.InfiniteQueryId
+import soil.query.MutationId
 import soil.query.MutationKey
 import soil.query.QueryEffect
+import soil.query.core.Namespace
 import soil.query.receivers.ktor.buildKtorMutationKey
 
-class CreatePostKey : MutationKey<Post, PostForm> by buildKtorMutationKey(
-    /* id = MutationId.auto(), */
+class CreatePostKey(auto: Namespace) : MutationKey<Post, PostForm> by buildKtorMutationKey(
+    id = MutationId(auto.value),
     mutate = { body ->
         post("https://jsonplaceholder.typicode.com/posts") {
             setBody(body)

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/DeletePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/DeletePostKey.kt
@@ -6,11 +6,11 @@ import soil.query.MutationId
 import soil.query.MutationKey
 import soil.query.QueryEffect
 import soil.query.QueryId
-import soil.query.core.Auto
+import soil.query.core.Namespace
 import soil.query.receivers.ktor.buildKtorMutationKey
 
-class DeletePostKey(auto: Auto) : MutationKey<Unit, Int> by buildKtorMutationKey(
-    id = MutationId(auto.namespace),
+class DeletePostKey(auto: Namespace) : MutationKey<Unit, Int> by buildKtorMutationKey(
+    id = MutationId(auto.value),
     mutate = { postId ->
         delete("https://jsonplaceholder.typicode.com/posts/$postId")
     }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/UpdatePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/UpdatePostKey.kt
@@ -9,12 +9,12 @@ import soil.query.MutationId
 import soil.query.MutationKey
 import soil.query.QueryEffect
 import soil.query.QueryId
-import soil.query.core.Auto
+import soil.query.core.Namespace
 import soil.query.modifyData
 import soil.query.receivers.ktor.buildKtorMutationKey
 
-class UpdatePostKey(auto: Auto) : MutationKey<Post, Post> by buildKtorMutationKey(
-    id = MutationId(auto.namespace),
+class UpdatePostKey(auto: Namespace) : MutationKey<Post, Post> by buildKtorMutationKey(
+    id = MutationId(auto.value),
     mutate = { body ->
         put("https://jsonplaceholder.typicode.com/posts/${body.id}") {
             setBody(body)

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/Util.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/Util.kt
@@ -15,7 +15,8 @@ import soil.query.QueryClient
 import soil.query.QueryKey
 import soil.query.ResumeQueriesFilter
 import soil.query.SwrClient
-import soil.query.core.Auto
+import soil.query.core.Namespace
+import soil.query.core.uuid
 
 
 typealias QueriesErrorReset = () -> Unit
@@ -95,13 +96,17 @@ fun KeepAlive(
 /**
  * Automatically generated value for mutationId and subscriptionId.
  *
- * @see Auto
+ * This function is useful for generating a unique namespace when a key, such as MutationKey or SubscriptionKey, is used in a single Composable function.
+ *
+ * @see Namespace
  */
 @Composable
-fun auto(): Auto = rememberSaveable(saver = Auto.Saver) { Auto() }
+fun Namespace.Companion.auto(): Namespace {
+    return rememberSaveable(saver = Namespace.Saver) { Namespace("auto/${uuid()}") }
+}
 
-internal val Auto.Companion.Saver
-    get() = Saver<Auto, String>(
+internal val Namespace.Companion.Saver
+    get() = Saver<Namespace, String>(
         save = { it.value },
-        restore = { Auto(it) }
+        restore = { Namespace(it) }
     )

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/UniqueId.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/UniqueId.kt
@@ -3,6 +3,8 @@
 
 package soil.query.core
 
+import kotlin.jvm.JvmInline
+
 /**
  * Interface for unique identifiers.
  *
@@ -49,28 +51,8 @@ typealias SurrogateKey = Any
  *
  * This class is useful for generating a unique namespace when a key, such as MutationKey or SubscriptionKey, is used in a single Composable function.
  */
-class Auto(val value: String = uuid()) {
-
-    val namespace: String
-        get() = "auto/$value"
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as Auto
-
-        return value == other.value
-    }
-
-    override fun hashCode(): Int {
-        return value.hashCode()
-    }
-
-    override fun toString(): String {
-        return namespace
-    }
-
+@JvmInline
+value class Namespace(val value: String) {
     // For Compose saver extension, to be extended by query.compose module
     companion object
 }


### PR DESCRIPTION
This PR includes modifications to the implementation merged in #115:

- Defined a new `Namespace` value class
- Moved the `auto` function to an extension function within the companion object of `Namespace`