### PR TITLE
Move `Util.kt` to `query.compose.util` package

### DIFF
--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberExampleSubscription.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberExampleSubscription.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.remember
 import soil.playground.query.key.ExampleSubscriptionKey
 import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.compose.SubscriptionObject
-import soil.query.compose.auto
 import soil.query.compose.rememberSubscription
+import soil.query.compose.util.auto
 import soil.query.core.Namespace
 
 @OptIn(ExperimentalSoilQueryApi::class)

--- a/sample/composeApp/src/commonMain/kotlin/soil/kmp/screen/HelloQueryDetailScreen.kt
+++ b/sample/composeApp/src/commonMain/kotlin/soil/kmp/screen/HelloQueryDetailScreen.kt
@@ -21,11 +21,11 @@ import soil.playground.query.compose.rememberGetUserQuery
 import soil.playground.query.data.Post
 import soil.playground.query.data.Posts
 import soil.playground.query.data.User
-import soil.query.compose.rememberQueriesErrorReset
 import soil.query.compose.runtime.Await
 import soil.query.compose.runtime.Catch
 import soil.query.compose.runtime.ErrorBoundary
 import soil.query.compose.runtime.Suspense
+import soil.query.compose.util.rememberQueriesErrorReset
 import soil.query.core.getOrElse
 
 @Composable

--- a/sample/composeApp/src/commonMain/kotlin/soil/kmp/screen/HelloQueryScreen.kt
+++ b/sample/composeApp/src/commonMain/kotlin/soil/kmp/screen/HelloQueryScreen.kt
@@ -23,12 +23,12 @@ import soil.playground.query.data.PageParam
 import soil.playground.query.data.Posts
 import soil.playground.router.NavLink
 import soil.playground.style.withAppTheme
-import soil.query.compose.rememberQueriesErrorReset
 import soil.query.compose.runtime.Await
 import soil.query.compose.runtime.Catch
 import soil.query.compose.runtime.ErrorBoundary
 import soil.query.compose.runtime.LazyLoadEffect
 import soil.query.compose.runtime.Suspense
+import soil.query.compose.util.rememberQueriesErrorReset
 
 @Composable
 fun HelloQueryScreen() {

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/util/KeepAlive.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/util/KeepAlive.kt
@@ -1,43 +1,18 @@
 // Copyright 2024 Soil Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-package soil.query.compose
+package soil.query.compose.util
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.rememberSaveable
 import soil.query.InfiniteQueryKey
 import soil.query.MutationClient
 import soil.query.MutationKey
 import soil.query.QueryClient
 import soil.query.QueryKey
-import soil.query.ResumeQueriesFilter
-import soil.query.SwrClient
-import soil.query.core.Namespace
-import soil.query.core.uuid
-
-
-typealias QueriesErrorReset = () -> Unit
-
-/**
- * Remember a [QueriesErrorReset] to resume all queries with [filter] matched.
- *
- * @param filter The filter to match queries.
- * @param client The [SwrClient] to resume queries. By default, it uses the [LocalSwrClient].
- * @return A [QueriesErrorReset] to resume queries.
- */
-@Composable
-fun rememberQueriesErrorReset(
-    filter: ResumeQueriesFilter = remember { ResumeQueriesFilter(predicate = { it.isFailure }) },
-    client: SwrClient = LocalSwrClient.current
-): QueriesErrorReset {
-    val reset = remember<() -> Unit>(client) {
-        { client.perform { resumeQueries(filter) } }
-    }
-    return reset
-}
+import soil.query.compose.LocalMutationClient
+import soil.query.compose.LocalQueryClient
 
 /**
  * Keep the query alive.
@@ -91,22 +66,3 @@ fun KeepAlive(
     val scope = rememberCoroutineScope()
     remember(key) { client.getMutation(key).also { it.launchIn(scope) } }
 }
-
-
-/**
- * Automatically generated value for mutationId and subscriptionId.
- *
- * This function is useful for generating a unique namespace when a key, such as MutationKey or SubscriptionKey, is used in a single Composable function.
- *
- * @see Namespace
- */
-@Composable
-fun Namespace.Companion.auto(): Namespace {
-    return rememberSaveable(saver = Namespace.Saver) { Namespace("auto/${uuid()}") }
-}
-
-internal val Namespace.Companion.Saver
-    get() = Saver<Namespace, String>(
-        save = { it.value },
-        restore = { Namespace(it) }
-    )

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/util/NamespaceGeneration.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/util/NamespaceGeneration.kt
@@ -1,0 +1,28 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import soil.query.core.Namespace
+import soil.query.core.uuid
+
+/**
+ * Automatically generated value for mutationId and subscriptionId.
+ *
+ * This function is useful for generating a unique namespace when a key, such as MutationKey or SubscriptionKey, is used in a single Composable function.
+ *
+ * @see Namespace
+ */
+@Composable
+fun Namespace.Companion.auto(): Namespace {
+    return rememberSaveable(saver = Namespace.Saver) { Namespace("auto/${uuid()}") }
+}
+
+internal val Namespace.Companion.Saver
+    get() = Saver<Namespace, String>(
+        save = { it.value },
+        restore = { Namespace(it) }
+    )

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/util/QueriesErrorReset.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/util/QueriesErrorReset.kt
@@ -1,0 +1,31 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.compose.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import soil.query.ResumeQueriesFilter
+import soil.query.SwrClient
+import soil.query.compose.LocalSwrClient
+
+
+typealias QueriesErrorReset = () -> Unit
+
+/**
+ * Remember a [QueriesErrorReset] to resume all queries with [filter] matched.
+ *
+ * @param filter The filter to match queries.
+ * @param client The [SwrClient] to resume queries. By default, it uses the [LocalSwrClient].
+ * @return A [QueriesErrorReset] to resume queries.
+ */
+@Composable
+fun rememberQueriesErrorReset(
+    filter: ResumeQueriesFilter = remember { ResumeQueriesFilter(predicate = { it.isFailure }) },
+    client: SwrClient = LocalSwrClient.current
+): QueriesErrorReset {
+    val reset = remember<() -> Unit>(client) {
+        { client.perform { resumeQueries(filter) } }
+    }
+    return reset
+}


### PR DESCRIPTION
As the amount of Util.kt code has grown, we decided to create a dedicated package space for it.

There are three composable functions that are affected:

- rememberQueriesErrorReset
- KeepAlive
- Namespace.auto (New API; essentially unaffected)
