### PR TITLE
Improve Receiver Extensibility

### DIFF
--- a/sample/composeApp/src/androidMain/kotlin/soil/kmp/SoilApplication.kt
+++ b/sample/composeApp/src/androidMain/kotlin/soil/kmp/SoilApplication.kt
@@ -8,12 +8,13 @@ import soil.playground.createHttpClient
 import soil.query.AndroidMemoryPressure
 import soil.query.AndroidNetworkConnectivity
 import soil.query.AndroidWindowVisibility
-import soil.query.SwrCacheScope
+import soil.query.QueryOptions
 import soil.query.SwrCachePlus
 import soil.query.SwrCachePlusPolicy
+import soil.query.SwrCacheScope
 import soil.query.SwrClientPlus
 import soil.query.annotation.ExperimentalSoilQueryApi
-import soil.query.receivers.ktor.KtorReceiver
+import soil.query.receivers.ktor.httpClient
 
 class SoilApplication : Application(), SwrClientFactory {
 
@@ -22,24 +23,23 @@ class SoilApplication : Application(), SwrClientFactory {
         SwrCachePlus(
             policy = SwrCachePlusPolicy(
                 coroutineScope = SwrCacheScope(),
+                queryOptions = QueryOptions(
+                    logger = { println(it) }
+                ),
                 memoryPressure = AndroidMemoryPressure(this),
                 networkConnectivity = AndroidNetworkConnectivity(this),
-                windowVisibility = AndroidWindowVisibility(),
-                queryReceiver = ktorReceiver,
-                mutationReceiver = ktorReceiver
-            )
-        )
-    }
-
-    private val ktorReceiver: KtorReceiver by lazy {
-        KtorReceiver(client = createHttpClient {
-            install(ContentNegotiation) {
-                json(Json {
-                    prettyPrint = true
-                    isLenient = true
-                    ignoreUnknownKeys = true
-                })
+                windowVisibility = AndroidWindowVisibility()
+            ) {
+                httpClient = createHttpClient {
+                    install(ContentNegotiation) {
+                        json(Json {
+                            prettyPrint = true
+                            isLenient = true
+                            ignoreUnknownKeys = true
+                        })
+                    }
+                }
             }
-        })
+        )
     }
 }

--- a/sample/composeApp/src/desktopMain/kotlin/main.kt
+++ b/sample/composeApp/src/desktopMain/kotlin/main.kt
@@ -4,30 +4,28 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import soil.playground.createHttpClient
-import soil.query.SwrCacheScope
 import soil.query.SwrCachePlus
 import soil.query.SwrCachePlusPolicy
+import soil.query.SwrCacheScope
 import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.compose.SwrClientProvider
-import soil.query.receivers.ktor.KtorReceiver
-
-private val ktorReceiver: KtorReceiver = KtorReceiver(client = createHttpClient {
-    install(ContentNegotiation) {
-        json(Json {
-            prettyPrint = true
-            isLenient = true
-            ignoreUnknownKeys = true
-        })
-    }
-})
+import soil.query.receivers.ktor.httpClient
 
 @OptIn(ExperimentalSoilQueryApi::class)
 private val swrClient = SwrCachePlus(
     policy = SwrCachePlusPolicy(
-        coroutineScope = SwrCacheScope(),
-        mutationReceiver = ktorReceiver,
-        queryReceiver = ktorReceiver
-    )
+        coroutineScope = SwrCacheScope()
+    ) {
+        httpClient = createHttpClient {
+            install(ContentNegotiation) {
+                json(Json {
+                    prettyPrint = true
+                    isLenient = true
+                    ignoreUnknownKeys = true
+                })
+            }
+        }
+    }
 )
 
 @OptIn(ExperimentalSoilQueryApi::class)

--- a/sample/composeApp/src/iosMain/kotlin/MainViewController.kt
+++ b/sample/composeApp/src/iosMain/kotlin/MainViewController.kt
@@ -5,32 +5,30 @@ import kotlinx.serialization.json.Json
 import soil.playground.createHttpClient
 import soil.query.IosMemoryPressure
 import soil.query.IosWindowVisibility
-import soil.query.SwrCacheScope
 import soil.query.SwrCachePlus
 import soil.query.SwrCachePlusPolicy
+import soil.query.SwrCacheScope
 import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.compose.SwrClientProvider
-import soil.query.receivers.ktor.KtorReceiver
-
-private val ktorReceiver: KtorReceiver = KtorReceiver(client = createHttpClient {
-    install(ContentNegotiation) {
-        json(Json {
-            prettyPrint = true
-            isLenient = true
-            ignoreUnknownKeys = true
-        })
-    }
-})
+import soil.query.receivers.ktor.httpClient
 
 @OptIn(ExperimentalSoilQueryApi::class)
 private val swrClient = SwrCachePlus(
     policy = SwrCachePlusPolicy(
         coroutineScope = SwrCacheScope(),
         memoryPressure = IosMemoryPressure(),
-        windowVisibility = IosWindowVisibility(),
-        queryReceiver = ktorReceiver,
-        mutationReceiver = ktorReceiver
-    )
+        windowVisibility = IosWindowVisibility()
+    ) {
+        httpClient = createHttpClient {
+            install(ContentNegotiation) {
+                json(Json {
+                    prettyPrint = true
+                    isLenient = true
+                    ignoreUnknownKeys = true
+                })
+            }
+        }
+    }
 )
 
 @OptIn(ExperimentalSoilQueryApi::class)

--- a/sample/composeApp/src/wasmJsMain/kotlin/main.kt
+++ b/sample/composeApp/src/wasmJsMain/kotlin/main.kt
@@ -4,34 +4,32 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import soil.playground.createHttpClient
-import soil.query.SwrCacheScope
 import soil.query.SwrCachePlus
 import soil.query.SwrCachePlusPolicy
+import soil.query.SwrCacheScope
 import soil.query.WasmJsNetworkConnectivity
 import soil.query.WasmJsWindowVisibility
 import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.compose.SwrClientProvider
-import soil.query.receivers.ktor.KtorReceiver
-
-private val ktorReceiver = KtorReceiver(client = createHttpClient {
-    install(ContentNegotiation) {
-        json(Json {
-            prettyPrint = true
-            isLenient = true
-            ignoreUnknownKeys = true
-        })
-    }
-})
+import soil.query.receivers.ktor.httpClient
 
 @OptIn(ExperimentalSoilQueryApi::class)
 private val swrClient = SwrCachePlus(
     policy = SwrCachePlusPolicy(
         coroutineScope = SwrCacheScope(),
         networkConnectivity = WasmJsNetworkConnectivity(),
-        windowVisibility = WasmJsWindowVisibility(),
-        queryReceiver = ktorReceiver,
-        mutationReceiver = ktorReceiver
-    )
+        windowVisibility = WasmJsWindowVisibility()
+    ) {
+        httpClient = createHttpClient {
+            install(ContentNegotiation) {
+                json(Json {
+                    prettyPrint = true
+                    isLenient = true
+                    ignoreUnknownKeys = true
+                })
+            }
+        }
+    }
 )
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalSoilQueryApi::class)

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationReceiver.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationReceiver.kt
@@ -3,21 +3,82 @@
 
 package soil.query
 
+import soil.query.core.ContextPropertyKey
+import soil.query.core.ContextReceiver
+import soil.query.core.ContextReceiverBase
+import soil.query.core.ContextReceiverBuilder
+import soil.query.core.ContextReceiverBuilderBase
+
 /**
  * Extension receiver for referencing external instances needed when executing [mutate][MutationKey.mutate].
  *
  * Usage:
  *
+ * For receiver provider
  * ```kotlin
- * class KtorReceiver(
- *     val client: HttpClient
- * ) : QueryReceiver, MutationReceiver
+ * internal val customClientKey = ContextPropertyKey<CustomClient>()
+ *
+ * val ContextReceiver.customClient: CustomClient?
+ *     get() = get(customClientKey)
+ *
+ * var ContextReceiverBuilder.customClient: CustomClient
+ *     get() = error("You cannot retrieve a builder property directly.")
+ *     set(value) = set(customClientKey, value)
+ *
+ * inline fun <T, S> buildCustomMutationKey(
+ *     id: MutationId<T, S>,
+ *     crossinline mutate: suspend CustomClient.(variable: S) -> T
+ * ): MutationKey<T, S> = buildMutationKey(
+ *     id = id,
+ *     mutate = {
+ *         val client = checkNotNull(customClient) { "customClient isn't available. Did you forget to set it up?" }
+ *         with(client) { mutate(it) }
+ *     }
+ * )
+ * ```
+ *
+ * For receiver builder
+ * ```kotlin
+ * MutationReceiver {
+ *     customClient = newCustomClient()
+ * }
+ * ```
+ *
+ * For receiver executor
+ * ```kotlin
+ * class CreatePostKey : MutationKey<Post, PostForm> by buildCustomMutationKey(
+ *     mutate = { body -> // CustomClient.(PostForm) -> Post
+ *         doSomething(body)
+ *     }
+ * )
  * ```
  */
-interface MutationReceiver {
+interface MutationReceiver : ContextReceiver {
 
     /**
      * Default implementation for [MutationReceiver].
      */
-    companion object : MutationReceiver
+    companion object : MutationReceiver {
+        override fun <T : Any> get(key: ContextPropertyKey<T>): T? = null
+    }
+}
+
+/**
+ * Creates a [MutationReceiver] using the provided [builder].
+ */
+fun MutationReceiver(builder: MutationReceiverBuilder.() -> Unit): MutationReceiver {
+    return MutationReceiverBuilderImpl().apply(builder).build()
+}
+
+/**
+ * Builder for creating a [MutationReceiver].
+ */
+interface MutationReceiverBuilder : ContextReceiverBuilder
+
+private class MutationReceiverImpl(
+    context: Map<ContextPropertyKey<*>, Any>
+) : ContextReceiverBase(context), MutationReceiver
+
+private class MutationReceiverBuilderImpl : ContextReceiverBuilderBase(), MutationReceiverBuilder {
+    override fun build(): MutationReceiver = MutationReceiverImpl(context)
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryReceiver.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryReceiver.kt
@@ -3,21 +3,83 @@
 
 package soil.query
 
+import soil.query.core.ContextPropertyKey
+import soil.query.core.ContextReceiver
+import soil.query.core.ContextReceiverBase
+import soil.query.core.ContextReceiverBuilder
+import soil.query.core.ContextReceiverBuilderBase
+
 /**
  * Extension receiver for referencing external instances needed when executing query.
  *
  * Usage:
  *
+ * For receiver provider
  * ```kotlin
- * class KtorReceiver(
- *     val client: HttpClient
- * ) : QueryReceiver, MutationReceiver
+ * internal val customClientKey = ContextPropertyKey<CustomClient>()
+ *
+ * val ContextReceiver.customClient: CustomClient?
+ *     get() = get(customClientKey)
+ *
+ * var ContextReceiverBuilder.customClient: CustomClient
+ *     get() = error("You cannot retrieve a builder property directly.")
+ *     set(value) = set(customClientKey, value)
+ *
+ * inline fun <T> buildCustomQueryKey(
+ *     id: QueryId<T>,
+ *     crossinline fetch: suspend CustomClient.() -> T
+ * ): QueryKey<T> = buildQueryKey(
+ *     id = id,
+ *     fetch = {
+ *         val client = checkNotNull(customClient) { "customClient isn't available. Did you forget to set it up?" }
+ *         with(client) { fetch() }
+ *     }
+ * )
+ * ```
+ *
+ * For receiver builder
+ * ```kotlin
+ * QueryReceiver {
+ *     customClient = newCustomClient()
+ * }
+ * ```
+ *
+ * For receiver executor
+ * ```kotlin
+ * class GetPostKey(private val postId: Int) : QueryKey<Post> by buildCustomQueryKey(
+ *     id = ..,
+ *     fetch = { // CustomClient.() -> Post
+ *         doSomething()
+ *     }
+ * )
  * ```
  */
-interface QueryReceiver {
+interface QueryReceiver : ContextReceiver {
 
     /**
      * Default implementation for [QueryReceiver].
      */
-    companion object : QueryReceiver
+    companion object : QueryReceiver {
+        override fun <T : Any> get(key: ContextPropertyKey<T>): T? = null
+    }
+}
+
+/**
+ * Creates a [QueryReceiver] using the provided [builder].
+ */
+fun QueryReceiver(builder: QueryReceiverBuilder.() -> Unit): QueryReceiver {
+    return QueryReceiverBuilderImpl().apply(builder).build()
+}
+
+/**
+ * Builder for creating a [QueryReceiver].
+ */
+interface QueryReceiverBuilder : ContextReceiverBuilder
+
+private class QueryReceiverImpl(
+    context: Map<ContextPropertyKey<*>, Any>
+) : ContextReceiverBase(context), QueryReceiver
+
+private class QueryReceiverBuilderImpl : ContextReceiverBuilderBase(), QueryReceiverBuilder {
+    override fun build(): QueryReceiver = QueryReceiverImpl(context)
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionReceiver.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionReceiver.kt
@@ -3,21 +3,75 @@
 
 package soil.query
 
+import soil.query.core.ContextPropertyKey
+import soil.query.core.ContextReceiver
+import soil.query.core.ContextReceiverBase
+import soil.query.core.ContextReceiverBuilder
+import soil.query.core.ContextReceiverBuilderBase
+
 /**
  * Extension receiver for referencing external instances needed when receiving subscription.
  *
- * Usage:
- *
+ * For receiver provider
  * ```kotlin
- * class SubscriptionReceiver(
- *     val client: SubscriptionClient
- * ) : SubscriptionReceiver
+ * internal val customClientKey = ContextPropertyKey<CustomClient>()
+ *
+ * val ContextReceiver.customClient: CustomClient?
+ *     get() = get(customClientKey)
+ *
+ * var ContextReceiverBuilder.customClient: CustomClient
+ *     get() = error("You cannot retrieve a builder property directly.")
+ *     set(value) = set(customClientKey, value)
+ *
+ * inline fun <T> buildCustomSubscriptionKey(
+ *     id: SubscriptionId<T>,
+ *     crossinline subscribe: CustomClient.() -> Flow<T>
+ * ): SubscriptionKey<T> = buildSubscriptionKey(
+ *     id = id,
+ *     subscribe = {
+ *         val client = checkNotNull(customClient) { "customClient isn't available. Did you forget to set it up?" }
+ *         with(client) { subscribe() }
+ *     }
+ * )
+ * ```
+ *
+ * For receiver builder
+ * ```kotlin
+ * SubscriptionReceiver {
+ *     customClient = newCustomClient()
+ * }
+ * ```
+ *
+ * For receiver executor
+ * ```kotlin
+ * class ExampleSubscriptionKey(auto: Namespace) : SubscriptionKey<String> by buildCustomSubscriptionKey(
+ *     id = SubscriptionId(auto.value),
+ *     subscribe = { // CustomClient.() -> Flow<String>
+ *         doSomethingFlow()
+ *     }
+ * )
  * ```
  */
-interface SubscriptionReceiver {
+interface SubscriptionReceiver : ContextReceiver {
 
     /**
      * Default implementation for [SubscriptionReceiver].
      */
-    companion object : SubscriptionReceiver
+    companion object : SubscriptionReceiver {
+        override fun <T : Any> get(key: ContextPropertyKey<T>): T? = null
+    }
+}
+
+fun SubscriptionReceiver(builder: SubscriptionReceiverBuilder.() -> Unit): SubscriptionReceiver {
+    return SubscriptionReceiverBuilderImpl().apply(builder).build()
+}
+
+interface SubscriptionReceiverBuilder : ContextReceiverBuilder
+
+private class SubscriptionReceiverImpl(
+    context: Map<ContextPropertyKey<*>, Any>
+) : ContextReceiverBase(context), SubscriptionReceiver
+
+private class SubscriptionReceiverBuilderImpl : ContextReceiverBuilderBase(), SubscriptionReceiverBuilder {
+    override fun build(): SubscriptionReceiver = SubscriptionReceiverImpl(context)
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlusPolicy.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlusPolicy.kt
@@ -104,6 +104,72 @@ fun SwrCachePlusPolicy(
     windowResumeQueriesFilter = windowResumeQueriesFilter
 )
 
+/**
+ * Create a new [SwrCachePlusPolicy] instance with a receiver builder.
+ *
+ * @param coroutineScope [CoroutineScope] for coroutines executed on the [SwrCachePlus].
+ * @param mainDispatcher [CoroutineDispatcher] for the main thread.
+ * @param mutationOptions Default [MutationOptions] applied to [Mutation].
+ * @param queryOptions Default [QueryOptions] applied to [Query].
+ * @param queryCache Management of cached data for inactive [Query] instances.
+ * @param subscriptionOptions Default [SubscriptionOptions] applied to [Subscription].
+ * @param subscriptionCache Management of cached data for inactive [Subscription] instances.
+ * @param batchSchedulerFactory Factory for creating a [soil.query.core.BatchScheduler].
+ * @param errorRelay Relay for error handling.
+ * @param memoryPressure Management of memory pressure.
+ * @param networkConnectivity Management of network connectivity.
+ * @param networkResumeAfterDelay Duration after which the network resumes.
+ * @param networkResumeQueriesFilter Filter for resuming queries after a network error.
+ * @param windowVisibility Management of window visibility.
+ * @param windowResumeQueriesFilter Filter for resuming queries after a window focus.
+ * @param receiverBuilder Receiver builder for [MutationReceiver], [QueryReceiver] and [SubscriptionReceiver].
+ */
+@ExperimentalSoilQueryApi
+fun SwrCachePlusPolicy(
+    coroutineScope: CoroutineScope,
+    mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
+    mutationOptions: MutationOptions = MutationOptions,
+    queryOptions: QueryOptions = QueryOptions,
+    queryCache: QueryCache = QueryCache(),
+    subscriptionOptions: SubscriptionOptions = SubscriptionOptions,
+    subscriptionCache: SubscriptionCache = SubscriptionCache(),
+    batchSchedulerFactory: BatchSchedulerFactory = BatchSchedulerFactory.default(mainDispatcher),
+    errorRelay: ErrorRelay? = null,
+    memoryPressure: MemoryPressure = MemoryPressure,
+    networkConnectivity: NetworkConnectivity = NetworkConnectivity,
+    networkResumeAfterDelay: Duration = 2.seconds,
+    networkResumeQueriesFilter: ResumeQueriesFilter = ResumeQueriesFilter(
+        predicate = { it.isFailure }
+    ),
+    windowVisibility: WindowVisibility = WindowVisibility,
+    windowResumeQueriesFilter: ResumeQueriesFilter = ResumeQueriesFilter(
+        predicate = { it.isStaled() }
+    ),
+    receiverBuilder: SwrReceiverBuilderPlus.() -> Unit
+): SwrCachePlusPolicy {
+    val commonReceiver = SwrReceiverBuilderPlusImpl().apply(receiverBuilder).build()
+    return SwrCachePlusPolicyImpl(
+        coroutineScope = coroutineScope,
+        mainDispatcher = mainDispatcher,
+        mutationOptions = mutationOptions,
+        mutationReceiver = commonReceiver,
+        queryOptions = queryOptions,
+        queryReceiver = commonReceiver,
+        queryCache = queryCache,
+        subscriptionOptions = subscriptionOptions,
+        subscriptionReceiver = commonReceiver,
+        subscriptionCache = subscriptionCache,
+        batchSchedulerFactory = batchSchedulerFactory,
+        errorRelay = errorRelay,
+        memoryPressure = memoryPressure,
+        networkConnectivity = networkConnectivity,
+        networkResumeAfterDelay = networkResumeAfterDelay,
+        networkResumeQueriesFilter = networkResumeQueriesFilter,
+        windowVisibility = windowVisibility,
+        windowResumeQueriesFilter = windowResumeQueriesFilter
+    )
+}
+
 @ExperimentalSoilQueryApi
 internal class SwrCachePlusPolicyImpl(
     override val coroutineScope: CoroutineScope,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrReceiver.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrReceiver.kt
@@ -1,0 +1,34 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.ContextPropertyKey
+import soil.query.core.ContextReceiverBase
+import soil.query.core.ContextReceiverBuilderBase
+
+/**
+ * **Note:** This interface is used internally to pass the same property settings to [QueryReceiver] and [MutationReceiver].
+ *
+ * @see SwrCachePolicy
+ */
+internal interface SwrReceiver : QueryReceiver, MutationReceiver
+
+/**
+ * Builder for creating a [QueryReceiver] and [MutationReceiver].
+ *
+ * **Note:** This interface is only used in the [SwrCachePolicy] function to pass the same property settings to [QueryReceiver] and [MutationReceiver].
+ * For defining extensions for common [ContextPropertyKey], please use [soil.query.core.ContextReceiverBuilder] and [soil.query.core.ContextReceiver].
+ * Adding extension definitions to this interface will not make them accessible from the receivers within [QueryKey] or [MutationKey].
+ *
+ * @see SwrCachePolicy
+ */
+interface SwrReceiverBuilder : QueryReceiverBuilder, MutationReceiverBuilder
+
+internal class SwrReceiverImpl(
+    context: Map<ContextPropertyKey<*>, Any>
+) : ContextReceiverBase(context), SwrReceiver
+
+internal class SwrReceiverBuilderImpl : ContextReceiverBuilderBase(), SwrReceiverBuilder {
+    override fun build(): SwrReceiver = SwrReceiverImpl(context)
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrReceiverPlus.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrReceiverPlus.kt
@@ -1,0 +1,34 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.ContextPropertyKey
+import soil.query.core.ContextReceiverBase
+import soil.query.core.ContextReceiverBuilderBase
+
+/**
+ * **Note:** This interface is used internally to pass the same property settings to [QueryReceiver], [MutationReceiver], and [SubscriptionReceiver].
+ *
+ * @see SwrCachePlusPolicy
+ */
+internal interface SwrReceiverPlus : SwrReceiver, SubscriptionReceiver
+
+/**
+ * Builder for creating a [QueryReceiver], [MutationReceiver] and [SubscriptionReceiver].
+ *
+ * **Note:** This interface is only used in the [SwrCachePlusPolicy] function to pass the same property settings to [QueryReceiver], [MutationReceiver], and [SubscriptionReceiver].
+ * For defining extensions for common [ContextPropertyKey], please use [soil.query.core.ContextReceiverBuilder] and [soil.query.core.ContextReceiver].
+ * Adding extension definitions to this interface will not make them accessible from the receivers within [QueryKey], [MutationKey] or [SubscriptionKey].
+ *
+ * @see SwrCachePlusPolicy
+ */
+interface SwrReceiverBuilderPlus : SwrReceiverBuilder, SubscriptionReceiverBuilder
+
+internal class SwrReceiverPlusImpl(
+    context: Map<ContextPropertyKey<*>, Any>
+) : ContextReceiverBase(context), SwrReceiverPlus
+
+internal class SwrReceiverBuilderPlusImpl : ContextReceiverBuilderBase(), SwrReceiverBuilderPlus {
+    override fun build(): SwrReceiverPlus = SwrReceiverPlusImpl(context)
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/ContextReceiver.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/ContextReceiver.kt
@@ -1,0 +1,64 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+/**
+ * Receiver for referencing external instances needed when executing query, mutation and more.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val ContextReceiver.customClient: CustomClient?
+ *     get() = get(customClientKey)
+ * ```
+ *
+ * @see ContextPropertyKey
+ */
+interface ContextReceiver {
+    operator fun <T : Any> get(key: ContextPropertyKey<T>): T?
+}
+
+/**
+ * Builder for setting external instances needed when executing query, mutation and more.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * var ContextReceiverBuilder.customClient: CustomClient
+ *     get() = error("You cannot retrieve a builder property directly.")
+ *     set(value) = set(customClientKey, value)
+ * ```
+ *
+ * @see ContextPropertyKey
+ */
+interface ContextReceiverBuilder {
+    operator fun <T : Any> set(key: ContextPropertyKey<T>, value: T)
+}
+
+/**
+ * Key for referencing external instances needed when executing query, mutation and more.
+ *
+ * ```kotlin
+ * internal val customClientKey = ContextPropertyKey<CustomClient>()
+ * ```
+ */
+class ContextPropertyKey<T : Any>
+
+internal abstract class ContextReceiverBase(
+    protected val context: Map<ContextPropertyKey<*>, Any>
+) : ContextReceiver {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> get(key: ContextPropertyKey<T>): T? = context[key] as T?
+}
+
+internal abstract class ContextReceiverBuilderBase(
+    protected val context: MutableMap<ContextPropertyKey<*>, Any> = mutableMapOf()
+) : ContextReceiverBuilder {
+
+    override fun <T : Any> set(key: ContextPropertyKey<T>, value: T) {
+        context[key] = value
+    }
+
+    abstract fun build(): ContextReceiver
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/MutationReceiverTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/MutationReceiverTest.kt
@@ -1,0 +1,49 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.ContextPropertyKey
+import soil.query.core.ContextReceiver
+import soil.query.core.ContextReceiverBuilder
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MutationReceiverTest : UnitTest() {
+
+    @Test
+    fun testBuilder() {
+        val foo = FooClient()
+        val bar = BarClient()
+        val actual = MutationReceiver {
+            fooClient = foo
+            barClient = bar
+        }
+        assertEquals(foo, actual.fooClient)
+        assertEquals(bar, actual.barClient)
+    }
+
+    private class FooClient
+
+    private class BarClient
+
+    private val ContextReceiver.fooClient: FooClient?
+        get() = get(fooClientKey)
+
+    private val MutationReceiver.barClient: BarClient?
+        get() = get(barClientKey)
+
+    private var ContextReceiverBuilder.fooClient: FooClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(fooClientKey, value)
+
+    private var MutationReceiverBuilder.barClient: BarClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(barClientKey, value)
+
+    companion object {
+        private val fooClientKey = ContextPropertyKey<FooClient>()
+        private val barClientKey = ContextPropertyKey<BarClient>()
+    }
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/QueryReceiverTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/QueryReceiverTest.kt
@@ -1,0 +1,50 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.ContextPropertyKey
+import soil.query.core.ContextReceiver
+import soil.query.core.ContextReceiverBuilder
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class QueryReceiverTest : UnitTest() {
+
+    @Test
+    fun testBuilder() {
+        val foo = FooClient()
+        val bar = BarClient()
+        val actual = QueryReceiver {
+            fooClient = foo
+            barClient = bar
+        }
+        assertEquals(foo, actual.fooClient)
+        assertEquals(bar, actual.barClient)
+    }
+
+    private class FooClient
+
+    private class BarClient
+
+    private val ContextReceiver.fooClient: FooClient?
+        get() = get(fooClientKey)
+
+    private val QueryReceiver.barClient: BarClient?
+        get() = get(barClientKey)
+
+    private var ContextReceiverBuilder.fooClient: FooClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(fooClientKey, value)
+
+    private var QueryReceiverBuilder.barClient: BarClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(barClientKey, value)
+
+    companion object {
+        private val fooClientKey = ContextPropertyKey<FooClient>()
+        private val barClientKey = ContextPropertyKey<BarClient>()
+    }
+
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionReceiverTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionReceiverTest.kt
@@ -1,0 +1,49 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.ContextPropertyKey
+import soil.query.core.ContextReceiver
+import soil.query.core.ContextReceiverBuilder
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SubscriptionReceiverTest : UnitTest() {
+
+    @Test
+    fun testBuilder() {
+        val foo = FooClient()
+        val bar = BarClient()
+        val actual = SubscriptionReceiver {
+            fooClient = foo
+            barClient = bar
+        }
+        assertEquals(foo, actual.fooClient)
+        assertEquals(bar, actual.barClient)
+    }
+
+    private class FooClient
+
+    private class BarClient
+
+    private val ContextReceiver.fooClient: FooClient?
+        get() = get(fooClientKey)
+
+    private val SubscriptionReceiver.barClient: BarClient?
+        get() = get(barClientKey)
+
+    private var ContextReceiverBuilder.fooClient: FooClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(fooClientKey, value)
+
+    private var SubscriptionReceiverBuilder.barClient: BarClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(barClientKey, value)
+
+    companion object {
+        private val fooClientKey = ContextPropertyKey<FooClient>()
+        private val barClientKey = ContextPropertyKey<BarClient>()
+    }
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/SwrCachePlusPolicyTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/SwrCachePlusPolicyTest.kt
@@ -1,0 +1,66 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.annotation.ExperimentalSoilQueryApi
+import soil.query.core.ContextPropertyKey
+import soil.query.core.ContextReceiver
+import soil.query.core.ContextReceiverBuilder
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalSoilQueryApi::class)
+class SwrCachePlusPolicyTest : UnitTest() {
+
+    @Test
+    fun testFactory() {
+        val actual = SwrCachePlusPolicy(SwrCacheScope())
+        assertEquals(null, actual.queryReceiver.fooClient)
+        assertEquals(null, actual.queryReceiver.barClient)
+        assertEquals(null, actual.mutationReceiver.fooClient)
+        assertEquals(null, actual.mutationReceiver.barClient)
+        assertEquals(null, actual.subscriptionReceiver.fooClient)
+        assertEquals(null, actual.subscriptionReceiver.barClient)
+    }
+
+    @Test
+    fun testFactory_withReceiver() {
+        val foo = FooClient()
+        val bar = BarClient()
+        val actual = SwrCachePlusPolicy(SwrCacheScope()) {
+            fooClient = foo
+            barClient = bar
+        }
+        assertEquals(foo, actual.queryReceiver.fooClient)
+        assertEquals(bar, actual.queryReceiver.barClient)
+        assertEquals(foo, actual.mutationReceiver.fooClient)
+        assertEquals(bar, actual.mutationReceiver.barClient)
+        assertEquals(foo, actual.subscriptionReceiver.fooClient)
+        assertEquals(bar, actual.subscriptionReceiver.barClient)
+    }
+
+    private class FooClient
+
+    private class BarClient
+
+    private val ContextReceiver.fooClient: FooClient?
+        get() = get(fooClientKey)
+
+    private val ContextReceiver.barClient: BarClient?
+        get() = get(barClientKey)
+
+    private var ContextReceiverBuilder.fooClient: FooClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(fooClientKey, value)
+
+    private var ContextReceiverBuilder.barClient: BarClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(barClientKey, value)
+
+    companion object {
+        private val fooClientKey = ContextPropertyKey<FooClient>()
+        private val barClientKey = ContextPropertyKey<BarClient>()
+    }
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/SwrCachePolicyTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/SwrCachePolicyTest.kt
@@ -1,0 +1,60 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.ContextPropertyKey
+import soil.query.core.ContextReceiver
+import soil.query.core.ContextReceiverBuilder
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SwrCachePolicyTest : UnitTest() {
+
+    @Test
+    fun testFactory() {
+        val actual = SwrCachePolicy(SwrCacheScope())
+        assertEquals(null, actual.queryReceiver.fooClient)
+        assertEquals(null, actual.queryReceiver.barClient)
+        assertEquals(null, actual.mutationReceiver.fooClient)
+        assertEquals(null, actual.mutationReceiver.barClient)
+    }
+
+    @Test
+    fun testFactory_withReceiver() {
+        val foo = FooClient()
+        val bar = BarClient()
+        val actual = SwrCachePolicy(SwrCacheScope()) {
+            fooClient = foo
+            barClient = bar
+        }
+        assertEquals(foo, actual.queryReceiver.fooClient)
+        assertEquals(bar, actual.queryReceiver.barClient)
+        assertEquals(foo, actual.mutationReceiver.fooClient)
+        assertEquals(bar, actual.mutationReceiver.barClient)
+    }
+
+    private class FooClient
+
+    private class BarClient
+
+    private val ContextReceiver.fooClient: FooClient?
+        get() = get(fooClientKey)
+
+    private val ContextReceiver.barClient: BarClient?
+        get() = get(barClientKey)
+
+    private var ContextReceiverBuilder.fooClient: FooClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(fooClientKey, value)
+
+    private var ContextReceiverBuilder.barClient: BarClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(barClientKey, value)
+
+    companion object {
+        private val fooClientKey = ContextPropertyKey<FooClient>()
+        private val barClientKey = ContextPropertyKey<BarClient>()
+    }
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/SwrReceiverPlusTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/SwrReceiverPlusTest.kt
@@ -1,0 +1,60 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.ContextPropertyKey
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SwrReceiverPlusTest : UnitTest() {
+
+    @Test
+    fun testBuilder() {
+        val foo = FooClient()
+        val bar = BarClient()
+        val baz = BazClient()
+        val actual = SwrReceiverBuilderPlusImpl().apply {
+            fooClient = foo
+            barClient = bar
+            bazClient = baz
+        }.build()
+        assertEquals(foo, actual.fooClient)
+        assertEquals(bar, actual.barClient)
+        assertEquals(baz, actual.bazClient)
+    }
+
+    private class FooClient
+
+    private class BarClient
+
+    private class BazClient
+
+    private val QueryReceiver.fooClient: FooClient?
+        get() = get(fooClientKey)
+
+    private val MutationReceiver.barClient: BarClient?
+        get() = get(barClientKey)
+
+    private val SubscriptionReceiver.bazClient: BazClient?
+        get() = get(bazClientKey)
+
+    private var QueryReceiverBuilder.fooClient: FooClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(fooClientKey, value)
+
+    private var MutationReceiverBuilder.barClient: BarClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(barClientKey, value)
+
+    private var SubscriptionReceiverBuilder.bazClient: BazClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(bazClientKey, value)
+
+    companion object {
+        private val fooClientKey = ContextPropertyKey<FooClient>()
+        private val barClientKey = ContextPropertyKey<BarClient>()
+        private val bazClientKey = ContextPropertyKey<BazClient>()
+    }
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/SwrReceiverTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/SwrReceiverTest.kt
@@ -1,0 +1,47 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.ContextPropertyKey
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SwrReceiverTest : UnitTest() {
+
+    @Test
+    fun testBuilder() {
+        val foo = FooClient()
+        val bar = BarClient()
+        val actual = SwrReceiverBuilderImpl().apply {
+            fooClient = foo
+            barClient = bar
+        }.build()
+        assertEquals(foo, actual.fooClient)
+        assertEquals(bar, actual.barClient)
+    }
+
+    private class FooClient
+
+    private class BarClient
+
+    private val QueryReceiver.fooClient: FooClient?
+        get() = get(fooClientKey)
+
+    private val MutationReceiver.barClient: BarClient?
+        get() = get(barClientKey)
+
+    private var QueryReceiverBuilder.fooClient: FooClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(fooClientKey, value)
+
+    private var MutationReceiverBuilder.barClient: BarClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(barClientKey, value)
+
+    companion object {
+        private val fooClientKey = ContextPropertyKey<FooClient>()
+        private val barClientKey = ContextPropertyKey<BarClient>()
+    }
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/core/ContextReceiverTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/core/ContextReceiverTest.kt
@@ -1,0 +1,66 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ContextReceiverTest : UnitTest() {
+
+    @Test
+    fun testBuilder() {
+        val foo = FooClient()
+        val bar = BarClient()
+        val actual = TestReceiverBuilder().apply {
+            fooClient = foo
+            barClient = bar
+        }.build()
+        assertEquals(foo, actual.fooClient)
+        assertEquals(bar, actual.barClient)
+    }
+
+    @Test
+    fun testBuilder_unsetBar() {
+        val foo = FooClient()
+        val actual = TestReceiverBuilder().apply {
+            fooClient = foo
+        }.build()
+        assertEquals(foo, actual.fooClient)
+        assertNull(actual.barClient)
+    }
+
+    private class TestReceiver(
+        context: Map<ContextPropertyKey<*>, Any>
+    ) : ContextReceiverBase(context)
+
+    private class TestReceiverBuilder(
+    ) : ContextReceiverBuilderBase() {
+        override fun build(): TestReceiver = TestReceiver(context)
+    }
+
+    private class FooClient
+
+    private class BarClient
+
+    private val ContextReceiver.fooClient: FooClient?
+        get() = get(fooClientKey)
+
+    private val ContextReceiver.barClient: BarClient?
+        get() = get(barClientKey)
+
+    private var ContextReceiverBuilder.fooClient: FooClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(fooClientKey, value)
+
+    private var ContextReceiverBuilder.barClient: BarClient
+        get() = error("You cannot retrieve a builder property directly.")
+        set(value) = set(barClientKey, value)
+
+    companion object {
+        private val fooClientKey = ContextPropertyKey<FooClient>()
+        private val barClientKey = ContextPropertyKey<BarClient>()
+    }
+}

--- a/soil-query-receivers/ktor/src/commonMain/kotlin/soil/query/receivers/ktor/builders.kt
+++ b/soil-query-receivers/ktor/src/commonMain/kotlin/soil/query/receivers/ktor/builders.kt
@@ -33,7 +33,7 @@ import soil.query.buildSubscriptionKey
  * ```
  *
  * **Note:**
- * [KtorReceiver] is required to use the builder functions designed for [KtorReceiver].
+ * [httpClient] is required to use the builder functions designed for [soil.query.core.ContextReceiver].
  *
  * @param id The identifier of the mutation key.
  * @param mutate The mutation function that sends a request to the server.
@@ -44,8 +44,8 @@ inline fun <T, S> buildKtorMutationKey(
 ): MutationKey<T, S> = buildMutationKey(
     id = id,
     mutate = {
-        check(this is KtorReceiver) { "KtorReceiver isn't available. Did you forget to set it up?" }
-        with(ktorClient) { mutate(it) }
+        val client = checkNotNull(httpClient) { "httpClient isn't available. Did you forget to set it up?" }
+        with(client) { mutate(it) }
     }
 )
 
@@ -62,7 +62,7 @@ inline fun <T, S> buildKtorMutationKey(
  * ```
  *
  * **Note:**
- * [KtorReceiver] is required to use the builder functions designed for [KtorReceiver].
+ * [httpClient] is required to use the builder functions designed for [soil.query.core.ContextReceiver].
  *
  * @param id The identifier of the query key.
  * @param fetch The query function that sends a request to the server.
@@ -73,8 +73,8 @@ inline fun <T> buildKtorQueryKey(
 ): QueryKey<T> = buildQueryKey(
     id = id,
     fetch = {
-        check(this is KtorReceiver) { "KtorReceiver isn't available. Did you forget to set it up?" }
-        with(ktorClient) { fetch() }
+        val client = checkNotNull(httpClient) { "httpClient isn't available. Did you forget to set it up?" }
+        with(client) { fetch() }
     }
 )
 
@@ -95,7 +95,7 @@ inline fun <T> buildKtorQueryKey(
  * ```
  *
  * **Note:**
- * [KtorReceiver] is required to use the builder functions designed for [KtorReceiver].
+ * [httpClient] is required to use the builder functions designed for [soil.query.core.ContextReceiver].
  *
  * @param id The identifier of the infinite query key.
  * @param fetch The query function that sends a request to the server.
@@ -108,8 +108,8 @@ inline fun <T, S> buildKtorInfiniteQueryKey(
 ): InfiniteQueryKey<T, S> = buildInfiniteQueryKey(
     id = id,
     fetch = { param ->
-        check(this is KtorReceiver) { "KtorReceiver isn't available. Did you forget to set it up?" }
-        with(ktorClient) { fetch(param) }
+        val client = checkNotNull(httpClient) { "httpClient isn't available. Did you forget to set it up?" }
+        with(client) { fetch(param) }
     },
     initialParam = initialParam,
     loadMoreParam = loadMoreParam
@@ -118,8 +118,17 @@ inline fun <T, S> buildKtorInfiniteQueryKey(
 /**
  * A delegation function to build a [SubscriptionKey] for Ktor.
  *
+ * ```kotlin
+ * class ExampleSubscriptionKey(auto: Namespace) : SubscriptionKey<String> by buildKtorSubscriptionKey(
+ *     id = SubscriptionId(auto.value),
+ *     subscribe = { // HttpClient.() -> Flow<String>
+ *         doSomethingFlow()
+ *     }
+ * )
+ * ```
+ *
  * **Note:**
- * [KtorReceiver] is required to use the builder functions designed for [KtorReceiver].
+ * [httpClient] is required to use the builder functions designed for [soil.query.core.ContextReceiver].
  *
  * @param id The identifier of the subscription key.
  * @param subscribe The subscription function for receiving data, such as from a server.
@@ -130,7 +139,7 @@ inline fun <T> buildKtorSubscriptionKey(
 ): SubscriptionKey<T> = buildSubscriptionKey(
     id = id,
     subscribe = {
-        check(this is KtorReceiver) { "KtorReceiver isn't available. Did you forget to set it up?" }
-        with(ktorClient) { subscribe() }
+        val client = checkNotNull(httpClient) { "httpClient isn't available. Did you forget to set it up?" }
+        with(client) { subscribe() }
     }
 )


### PR DESCRIPTION
Previously, we provided implementations via the Receiver interface as one option for referencing external clients within a Key. These included:

- MutationReceiver
- QueryReceiver
- SubscriptionReceiver

While the library offered these interface implementations for Ktor, the following issues were identified:

- When handling multiple external clients, it was always necessary to merge both interface definitions into a single implementation.
- If the library itself aggregated all the Receiver interfaces, it would inevitably enforce dependencies on all Receivers for library users.

To address these issues, we will discontinue the interface-based implementation and switch to a definition based on context maps and extension properties. With this change, users will be able to define property keys and extension properties for a type within the library or project, enabling seamless setting and retrieval for Receiver.

Example:

```kotlin
val ContextReceiver.httpClient: HttpClient?
    get() = get(httpClientKey)

var ContextReceiverBuilder.httpClient: HttpClient
    get() = error("You cannot retrieve a builder property directly")
    set(value) = set(httpClientKey, value)

internal val httpClientKey = ContextPropertyKey<HttpClient>()
```

When setting multiple external clients to a Receiver, you only need to declare different property keys and extension properties. (Much simpler! 😄 )

```kotlin
val ContextReceiver.dbClient: DbClient?
    get() = get(dbClientKey)

var ContextReceiverBuilder.dbClient: DbClient
    get() = error("You cannot retrieve a builder property directly")
    set(value) = set(dbClientKey, value)

internal val dbClientKey = ContextPropertyKey<DbClient>()
```

This idea was inspired by SemanticsPropertyReceiver.

Reference: [SemanticsProperties.kt](https://github.com/androidx/androidx/blob/androidx-main/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/semantics/SemanticsProperties.kt)
