### PR TITLE
Determining key equivalence

### DIFF
--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberExampleSubscription.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberExampleSubscription.kt
@@ -1,7 +1,6 @@
 package soil.playground.query.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import soil.playground.query.key.ExampleSubscriptionKey
 import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.compose.SubscriptionObject
@@ -12,7 +11,7 @@ import soil.query.core.Namespace
 @OptIn(ExperimentalSoilQueryApi::class)
 @Composable
 fun rememberExampleSubscription(): SubscriptionObject<String> {
-    val auto = Namespace.auto()
-    val key = remember { ExampleSubscriptionKey(auto) }
-    return rememberSubscription(key)
+    return rememberSubscription(
+        key = ExampleSubscriptionKey(Namespace.auto())
+    )
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetPostQuery.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetPostQuery.kt
@@ -1,7 +1,6 @@
 package soil.playground.query.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import soil.playground.query.data.Post
 import soil.playground.query.key.posts.GetPostKey
 import soil.query.compose.QueryConfig
@@ -15,6 +14,8 @@ fun rememberGetPostQuery(
     postId: Int,
     builderBlock: QueryConfig.Builder.() -> Unit = {}
 ): GetPostQueryObject {
-    val key = remember(postId) { GetPostKey(postId) }
-    return rememberQuery(key, QueryConfig(builderBlock))
+    return rememberQuery(
+        key = GetPostKey(postId),
+        config = QueryConfig(builderBlock)
+    )
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetPostsQuery.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetPostsQuery.kt
@@ -1,7 +1,6 @@
 package soil.playground.query.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import soil.playground.query.data.PageParam
 import soil.playground.query.data.Posts
 import soil.playground.query.key.posts.GetPostsKey
@@ -17,6 +16,9 @@ fun rememberGetPostsQuery(
     userId: Int? = null,
     builderBlock: InfiniteQueryConfig.Builder.() -> Unit = {}
 ): GetPostsQueryObject {
-    val key = remember(userId) { GetPostsKey(userId) }
-    return rememberInfiniteQuery(key, select = { it.chunkedData }, config = InfiniteQueryConfig(builderBlock))
+    return rememberInfiniteQuery(
+        key = GetPostsKey(userId),
+        select = { it.chunkedData },
+        config = InfiniteQueryConfig(builderBlock)
+    )
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetUserPostsQuery.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetUserPostsQuery.kt
@@ -1,7 +1,6 @@
 package soil.playground.query.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import soil.playground.query.data.PageParam
 import soil.playground.query.data.Posts
 import soil.playground.query.key.users.GetUserPostsKey
@@ -17,6 +16,9 @@ fun rememberGetUserPostsQuery(
     userId: Int,
     builderBlock: InfiniteQueryConfig.Builder.() -> Unit = {}
 ): GetUserPostsQueryObject {
-    val key = remember(userId) { GetUserPostsKey(userId) }
-    return rememberInfiniteQuery(key = key, select = { it.chunkedData }, config = InfiniteQueryConfig(builderBlock))
+    return rememberInfiniteQuery(
+        key = GetUserPostsKey(userId),
+        select = { it.chunkedData },
+        config = InfiniteQueryConfig(builderBlock)
+    )
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetUserQuery.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/compose/RememberGetUserQuery.kt
@@ -1,7 +1,6 @@
 package soil.playground.query.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import soil.playground.query.data.User
 import soil.playground.query.key.users.GetUserKey
 import soil.query.compose.QueryConfig
@@ -15,6 +14,8 @@ fun rememberGetUserQuery(
     userId: Int,
     builderBlock: QueryConfig.Builder.() -> Unit = {}
 ): GetUserQueryObject {
-    val key = remember(userId) { GetUserKey(userId) }
-    return rememberQuery(key, config = QueryConfig(builderBlock))
+    return rememberQuery(
+        key = GetUserKey(userId),
+        config = QueryConfig(builderBlock)
+    )
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/ExampleSubscriptionKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/ExampleSubscriptionKey.kt
@@ -1,13 +1,16 @@
 package soil.playground.query.key
 
+import androidx.compose.runtime.Stable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 import soil.query.SubscriptionId
 import soil.query.SubscriptionKey
 import soil.query.buildSubscriptionKey
+import soil.query.core.KeyEquals
 import soil.query.core.Namespace
 
-class ExampleSubscriptionKey(auto: Namespace) : SubscriptionKey<String> by buildSubscriptionKey(
+@Stable
+class ExampleSubscriptionKey(auto: Namespace) : KeyEquals(), SubscriptionKey<String> by buildSubscriptionKey(
     id = SubscriptionId(auto.value),
     subscribe = {
         flow {

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/albums/GetAlbumPhotosKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/albums/GetAlbumPhotosKey.kt
@@ -1,5 +1,6 @@
 package soil.playground.query.key.albums
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -7,9 +8,11 @@ import soil.playground.query.data.PageParam
 import soil.playground.query.data.Photos
 import soil.query.InfiniteQueryId
 import soil.query.InfiniteQueryKey
+import soil.query.core.KeyEquals
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
-class GetAlbumPhotosKey(albumId: Int) : InfiniteQueryKey<Photos, PageParam> by buildKtorInfiniteQueryKey(
+@Stable
+class GetAlbumPhotosKey(albumId: Int) : KeyEquals(), InfiniteQueryKey<Photos, PageParam> by buildKtorInfiniteQueryKey(
     id = InfiniteQueryId.forGetAlbumPhotos(albumId),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/albums/$albumId/photos") {

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/albums/GetAlbumsKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/albums/GetAlbumsKey.kt
@@ -1,5 +1,6 @@
 package soil.playground.query.key.albums
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -7,9 +8,11 @@ import soil.playground.query.data.Albums
 import soil.playground.query.data.PageParam
 import soil.query.InfiniteQueryId
 import soil.query.InfiniteQueryKey
+import soil.query.core.KeyEquals
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
-class GetAlbumsKey : InfiniteQueryKey<Albums, PageParam> by buildKtorInfiniteQueryKey(
+@Stable
+class GetAlbumsKey : KeyEquals(), InfiniteQueryKey<Albums, PageParam> by buildKtorInfiniteQueryKey(
     id = InfiniteQueryId.forGetAlbums(),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/albums") {

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/CreatePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/CreatePostKey.kt
@@ -1,5 +1,6 @@
 package soil.playground.query.key.posts
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -8,10 +9,12 @@ import soil.query.InfiniteQueryId
 import soil.query.MutationId
 import soil.query.MutationKey
 import soil.query.QueryEffect
+import soil.query.core.KeyEquals
 import soil.query.core.Namespace
 import soil.query.receivers.ktor.buildKtorMutationKey
 
-class CreatePostKey(auto: Namespace) : MutationKey<Post, PostForm> by buildKtorMutationKey(
+@Stable
+class CreatePostKey(auto: Namespace) : KeyEquals(), MutationKey<Post, PostForm> by buildKtorMutationKey(
     id = MutationId(auto.value),
     mutate = { body ->
         post("https://jsonplaceholder.typicode.com/posts") {

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/DeletePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/DeletePostKey.kt
@@ -1,15 +1,18 @@
 package soil.playground.query.key.posts
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.request.delete
 import soil.query.InfiniteQueryId
 import soil.query.MutationId
 import soil.query.MutationKey
 import soil.query.QueryEffect
 import soil.query.QueryId
+import soil.query.core.KeyEquals
 import soil.query.core.Namespace
 import soil.query.receivers.ktor.buildKtorMutationKey
 
-class DeletePostKey(auto: Namespace) : MutationKey<Unit, Int> by buildKtorMutationKey(
+@Stable
+class DeletePostKey(auto: Namespace) : KeyEquals(), MutationKey<Unit, Int> by buildKtorMutationKey(
     id = MutationId(auto.value),
     mutate = { postId ->
         delete("https://jsonplaceholder.typicode.com/posts/$postId")

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostCommentsKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostCommentsKey.kt
@@ -1,5 +1,6 @@
 package soil.playground.query.key.posts
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -7,9 +8,13 @@ import soil.playground.query.data.Comments
 import soil.playground.query.data.PageParam
 import soil.query.InfiniteQueryId
 import soil.query.InfiniteQueryKey
+import soil.query.core.KeyEquals
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
-class GetPostCommentsKey(private val postId: Int) : InfiniteQueryKey<Comments, PageParam> by buildKtorInfiniteQueryKey(
+@Stable
+class GetPostCommentsKey(
+    private val postId: Int
+) : KeyEquals(), InfiniteQueryKey<Comments, PageParam> by buildKtorInfiniteQueryKey(
     id = InfiniteQueryId.forGetPostComments(postId),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/posts/$postId/comments") {

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostKey.kt
@@ -1,5 +1,6 @@
 package soil.playground.query.key.posts
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import soil.playground.query.data.Post
@@ -8,9 +9,11 @@ import soil.query.QueryId
 import soil.query.QueryInitialData
 import soil.query.QueryKey
 import soil.query.chunkedData
+import soil.query.core.KeyEquals
 import soil.query.receivers.ktor.buildKtorQueryKey
 
-class GetPostKey(private val postId: Int) : QueryKey<Post> by buildKtorQueryKey(
+@Stable
+class GetPostKey(private val postId: Int) : KeyEquals(), QueryKey<Post> by buildKtorQueryKey(
     id = QueryId.forGetPost(postId),
     fetch = {
         get("https://jsonplaceholder.typicode.com/posts/$postId").body()

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostsKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/GetPostsKey.kt
@@ -1,5 +1,6 @@
 package soil.playground.query.key.posts
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -7,12 +8,16 @@ import soil.playground.query.data.PageParam
 import soil.playground.query.data.Posts
 import soil.query.InfiniteQueryId
 import soil.query.InfiniteQueryKey
+import soil.query.core.KeyEquals
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
 // NOTE: userId
 // Filtering resources
 // ref. https://jsonplaceholder.typicode.com/guide/
-class GetPostsKey(val userId: Int? = null) : InfiniteQueryKey<Posts, PageParam> by buildKtorInfiniteQueryKey(
+@Stable
+class GetPostsKey(
+    val userId: Int? = null
+) : KeyEquals(), InfiniteQueryKey<Posts, PageParam> by buildKtorInfiniteQueryKey(
     id = InfiniteQueryId.forGetPosts(userId),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/posts") {

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/UpdatePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/UpdatePostKey.kt
@@ -1,5 +1,6 @@
 package soil.playground.query.key.posts
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.call.body
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
@@ -9,11 +10,13 @@ import soil.query.MutationId
 import soil.query.MutationKey
 import soil.query.QueryEffect
 import soil.query.QueryId
+import soil.query.core.KeyEquals
 import soil.query.core.Namespace
 import soil.query.modifyData
 import soil.query.receivers.ktor.buildKtorMutationKey
 
-class UpdatePostKey(auto: Namespace) : MutationKey<Post, Post> by buildKtorMutationKey(
+@Stable
+class UpdatePostKey(auto: Namespace) : KeyEquals(), MutationKey<Post, Post> by buildKtorMutationKey(
     id = MutationId(auto.value),
     mutate = { body ->
         put("https://jsonplaceholder.typicode.com/posts/${body.id}") {

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserAlbumsKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserAlbumsKey.kt
@@ -1,5 +1,6 @@
 package soil.playground.query.key.users
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -7,9 +8,11 @@ import soil.playground.query.data.Albums
 import soil.playground.query.data.PageParam
 import soil.query.InfiniteQueryId
 import soil.query.InfiniteQueryKey
+import soil.query.core.KeyEquals
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
-class GetUserAlbumsKey(userId: Int) : InfiniteQueryKey<Albums, PageParam> by buildKtorInfiniteQueryKey(
+@Stable
+class GetUserAlbumsKey(userId: Int) : KeyEquals(), InfiniteQueryKey<Albums, PageParam> by buildKtorInfiniteQueryKey(
     id = InfiniteQueryId.forGetUserAlbums(userId),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/users/$userId/albums") {

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserKey.kt
@@ -1,5 +1,6 @@
 package soil.playground.query.key.users
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import soil.playground.query.data.User
@@ -8,9 +9,11 @@ import soil.query.QueryId
 import soil.query.QueryInitialData
 import soil.query.QueryKey
 import soil.query.chunkedData
+import soil.query.core.KeyEquals
 import soil.query.receivers.ktor.buildKtorQueryKey
 
-class GetUserKey(private val userId: Int) : QueryKey<User> by buildKtorQueryKey(
+@Stable
+class GetUserKey(private val userId: Int) : KeyEquals(), QueryKey<User> by buildKtorQueryKey(
     id = QueryId.forGetUser(userId),
     fetch = {
         get("https://jsonplaceholder.typicode.com/users/$userId").body()

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserPostsKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserPostsKey.kt
@@ -1,5 +1,6 @@
 package soil.playground.query.key.users
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -7,9 +8,11 @@ import soil.playground.query.data.PageParam
 import soil.playground.query.data.Posts
 import soil.query.InfiniteQueryId
 import soil.query.InfiniteQueryKey
+import soil.query.core.KeyEquals
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
-class GetUserPostsKey(userId: Int) : InfiniteQueryKey<Posts, PageParam> by buildKtorInfiniteQueryKey(
+@Stable
+class GetUserPostsKey(userId: Int) : KeyEquals(), InfiniteQueryKey<Posts, PageParam> by buildKtorInfiniteQueryKey(
     id = InfiniteQueryId.forGetUserPosts(userId),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/users/$userId/posts") {

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserTodosKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUserTodosKey.kt
@@ -1,5 +1,6 @@
 package soil.playground.query.key.users
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -7,9 +8,11 @@ import soil.playground.query.data.PageParam
 import soil.playground.query.data.Todos
 import soil.query.InfiniteQueryId
 import soil.query.InfiniteQueryKey
+import soil.query.core.KeyEquals
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
-class GetUserTodosKey(userId: Int) : InfiniteQueryKey<Todos, PageParam> by buildKtorInfiniteQueryKey(
+@Stable
+class GetUserTodosKey(userId: Int) : KeyEquals(), InfiniteQueryKey<Todos, PageParam> by buildKtorInfiniteQueryKey(
     id = InfiniteQueryId.forGetUserTodos(userId),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/users/$userId/todos") {

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUsersKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/users/GetUsersKey.kt
@@ -1,5 +1,6 @@
 package soil.playground.query.key.users
 
+import androidx.compose.runtime.Stable
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -7,9 +8,11 @@ import soil.playground.query.data.PageParam
 import soil.playground.query.data.Users
 import soil.query.InfiniteQueryId
 import soil.query.InfiniteQueryKey
+import soil.query.core.KeyEquals
 import soil.query.receivers.ktor.buildKtorInfiniteQueryKey
 
-class GetUsersKey : InfiniteQueryKey<Users, PageParam> by buildKtorInfiniteQueryKey(
+@Stable
+class GetUsersKey : KeyEquals(), InfiniteQueryKey<Users, PageParam> by buildKtorInfiniteQueryKey(
     id = InfiniteQueryId.forGetUsers(),
     fetch = { param ->
         get("https://jsonplaceholder.typicode.com/users") {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/KeyEquals.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/KeyEquals.kt
@@ -1,0 +1,35 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+/**
+ * An optional base class for determining key equivalence.
+ *
+ * Usage:
+ * ```
+ * private class TestQueryKey : KeyEquals(), QueryKey<String> by buildQueryKey(
+ *   id = ..
+ * )
+ * ```
+ *
+ * **Note:**
+ * When using this on Compose with StrongSkippingMode enabled, you can generate the key without wrapping it in the `remember` function if the key can be marked as stable.
+ * For details on marking objects as stable, refer to the official documentation:
+ * https://developer.android.com/develop/ui/compose/performance/stability
+ */
+abstract class KeyEquals {
+    abstract val id: UniqueId
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as KeyEquals
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/core/KeyEqualsTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/core/KeyEqualsTest.kt
@@ -1,0 +1,38 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+import soil.query.QueryId
+import soil.query.QueryKey
+import soil.query.buildQueryKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class KeyEqualsTest {
+
+    @Test
+    fun test() {
+        val key1 = TestKey1()
+        val key2 = TestKey1()
+        assertEquals(key1, key2)
+    }
+
+    @Test
+    fun testWithoutKeyEquals() {
+        val key1 = TestKey2()
+        val key2 = TestKey2()
+        assertNotEquals(key1, key2)
+    }
+
+    private class TestKey1 : KeyEquals(), QueryKey<String> by buildQueryKey(
+        id = QueryId("test"),
+        fetch = { "test" }
+    )
+
+    private class TestKey2 : QueryKey<String> by buildQueryKey(
+        id = QueryId("test"),
+        fetch = { "test" }
+    )
+}


### PR DESCRIPTION
When using this on Compose with StrongSkippingMode enabled, you can generate the key without wrapping it in the `remember` function if the key can be marked as stable.

```
private class TestQueryKey : KeyEquals(), QueryKey<String> by buildQueryKey(
  id = ..
)
```
