### PR TITLE
Fix the Subscription Reset Process

### DIFF
--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlus.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlus.kt
@@ -138,13 +138,16 @@ class SwrCachePlus(private val policy: SwrCachePlusPolicy) : SwrCache(policy), S
                 )
             }
         }
+
         val subscribeFlow = subscriptionReceiver.subscribe()
         val source = refresh
-            .flatMapLatest { subscribeFlow }
-            .retryWithExponentialBackoff(options) { err, count, nextBackOff ->
-                options.vvv(id) { "retry(count=$count next=$nextBackOff error=${err.message})" }
+            .flatMapLatest {
+                subscribeFlow
+                    .retryWithExponentialBackoff(options) { err, count, nextBackOff ->
+                        options.vvv(id) { "retry(count=$count next=$nextBackOff error=${err.message})" }
+                    }
+                    .toResultFlow()
             }
-            .toResultFlow()
             .shareIn(
                 scope = scope,
                 started = SharingStarted.WhileSubscribedAlt(


### PR DESCRIPTION
The reset process in the experimental Subscription API introduced in #89 was not functioning correctly. 

Flattening the Flow into a sequential structure caused the Completed state to propagate to the parent Flow after an error occurred, preventing any emit operations even when Reset was called. 

This PR addresses the issue by nesting certain Flows to ensure the reset process functions as intended.