### PR TITLE
Remove Manual Subscription Management

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionConfig.kt
@@ -48,13 +48,6 @@ data class SubscriptionConfig internal constructor(
             strategy = SubscriptionStrategy.Default,
             marker = Marker.None
         )
-
-        val Lazy = SubscriptionConfig(
-            mapper = SubscriptionObjectMapper.Default,
-            optimizer = SubscriptionRecompositionOptimizer.Lazy,
-            strategy = SubscriptionStrategy.Lazy,
-            marker = Marker.None
-        )
     }
 }
 

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionObject.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionObject.kt
@@ -5,7 +5,6 @@ package soil.query.compose
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
-import soil.query.SubscriberStatus
 import soil.query.SubscriptionModel
 import soil.query.SubscriptionStatus
 import soil.query.core.Reply
@@ -26,42 +25,9 @@ sealed interface SubscriptionObject<out T> : SubscriptionModel<T> {
     val data: T?
 
     /**
-     * Starts the subscription if not already subscribed.
-     */
-    val subscribe: suspend () -> Unit
-
-    /**
-     * Cancels the subscription if currently subscribed.
-     */
-    val unsubscribe: () -> Unit
-
-    /**
      * Resets the subscribed data and re-executes the subscription process.
      */
     val reset: suspend () -> Unit
-}
-
-/**
- * A SubscriptionIdleObject represents the initial idle state of the [SubscriptionObject].
- *
- * This means that no data has been received and there are no subscribers.
- * This is the initial state when subscription processing has not been performed automatically.
- *
- * @param T Type of data to receive.
- */
-@Immutable
-data class SubscriptionIdleObject<T>(
-    override val reply: Reply<T>,
-    override val replyUpdatedAt: Long,
-    override val error: Throwable?,
-    override val errorUpdatedAt: Long,
-    override val subscribe: suspend () -> Unit,
-    override val unsubscribe: () -> Unit,
-    override val reset: suspend () -> Unit
-) : SubscriptionObject<T> {
-    override val status: SubscriptionStatus = SubscriptionStatus.Pending
-    override val subscriberStatus: SubscriberStatus = SubscriberStatus.NoSubscribers
-    override val data: T? get() = reply.getOrNull()
 }
 
 /**
@@ -77,12 +43,9 @@ data class SubscriptionLoadingObject<T>(
     override val replyUpdatedAt: Long,
     override val error: Throwable?,
     override val errorUpdatedAt: Long,
-    override val subscribe: suspend () -> Unit,
-    override val unsubscribe: () -> Unit,
     override val reset: suspend () -> Unit
 ) : SubscriptionObject<T> {
     override val status: SubscriptionStatus = SubscriptionStatus.Pending
-    override val subscriberStatus: SubscriberStatus = SubscriberStatus.Active
     override val data: T? get() = reply.getOrNull()
 }
 
@@ -100,9 +63,6 @@ data class SubscriptionErrorObject<T>(
     override val replyUpdatedAt: Long,
     override val error: Throwable,
     override val errorUpdatedAt: Long,
-    override val subscriberStatus: SubscriberStatus,
-    override val subscribe: suspend () -> Unit,
-    override val unsubscribe: () -> Unit,
     override val reset: suspend () -> Unit
 ) : SubscriptionObject<T> {
     override val status: SubscriptionStatus = SubscriptionStatus.Failure
@@ -120,9 +80,6 @@ data class SubscriptionSuccessObject<T>(
     override val replyUpdatedAt: Long,
     override val error: Throwable?,
     override val errorUpdatedAt: Long,
-    override val subscriberStatus: SubscriberStatus,
-    override val subscribe: suspend () -> Unit,
-    override val unsubscribe: () -> Unit,
     override val reset: suspend () -> Unit
 ) : SubscriptionObject<T> {
     override val status: SubscriptionStatus = SubscriptionStatus.Success

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionObjectMapper.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionObjectMapper.kt
@@ -3,7 +3,6 @@
 
 package soil.query.compose
 
-import soil.query.SubscriberStatus
 import soil.query.SubscriptionRef
 import soil.query.SubscriptionState
 import soil.query.SubscriptionStatus
@@ -40,36 +39,19 @@ private object DefaultSubscriptionObjectMapper : SubscriptionObjectMapper {
         subscription: SubscriptionRef<T>,
         select: (T) -> U
     ): SubscriptionObject<U> = when (status) {
-        SubscriptionStatus.Pending -> if (subscriberStatus == SubscriberStatus.NoSubscribers) {
-            SubscriptionIdleObject(
-                reply = reply.map(select),
-                replyUpdatedAt = replyUpdatedAt,
-                error = error,
-                errorUpdatedAt = errorUpdatedAt,
-                subscribe = subscription::resume,
-                unsubscribe = subscription::cancel,
-                reset = subscription::reset
-            )
-        } else {
-            SubscriptionLoadingObject(
-                reply = reply.map(select),
-                replyUpdatedAt = replyUpdatedAt,
-                error = error,
-                errorUpdatedAt = errorUpdatedAt,
-                subscribe = subscription::resume,
-                unsubscribe = subscription::cancel,
-                reset = subscription::reset
-            )
-        }
+        SubscriptionStatus.Pending -> SubscriptionLoadingObject(
+            reply = reply.map(select),
+            replyUpdatedAt = replyUpdatedAt,
+            error = error,
+            errorUpdatedAt = errorUpdatedAt,
+            reset = subscription::reset
+        )
 
         SubscriptionStatus.Success -> SubscriptionSuccessObject(
             reply = reply.map(select),
             replyUpdatedAt = replyUpdatedAt,
             error = error,
             errorUpdatedAt = errorUpdatedAt,
-            subscriberStatus = subscriberStatus,
-            subscribe = subscription::resume,
-            unsubscribe = subscription::cancel,
             reset = subscription::reset
         )
 
@@ -78,9 +60,6 @@ private object DefaultSubscriptionObjectMapper : SubscriptionObjectMapper {
             replyUpdatedAt = replyUpdatedAt,
             error = checkNotNull(error),
             errorUpdatedAt = errorUpdatedAt,
-            subscriberStatus = subscriberStatus,
-            subscribe = subscription::resume,
-            unsubscribe = subscription::cancel,
             reset = subscription::reset
         )
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionRecompositionOptimizer.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionRecompositionOptimizer.kt
@@ -3,7 +3,6 @@
 
 package soil.query.compose
 
-import soil.query.SubscriberStatus
 import soil.query.SubscriptionState
 import soil.query.SubscriptionStatus
 
@@ -29,27 +28,10 @@ interface SubscriptionRecompositionOptimizer {
 val SubscriptionRecompositionOptimizer.Companion.Default: SubscriptionRecompositionOptimizer
     get() = DefaultSubscriptionRecompositionOptimizer
 
-private object DefaultSubscriptionRecompositionOptimizer :
-    AbstractSubscriptionRecompositionOptimizer(SubscriberStatus.Active)
-
-/**
- * Optimizer implementation for [SubscriptionStrategy.Companion.Lazy].
- */
-val SubscriptionRecompositionOptimizer.Companion.Lazy: SubscriptionRecompositionOptimizer
-    get() = LazySubscriptionRecompositionOptimizer
-
-private object LazySubscriptionRecompositionOptimizer :
-    AbstractSubscriptionRecompositionOptimizer()
-
-private abstract class AbstractSubscriptionRecompositionOptimizer(
-    private val subscriberStatus: SubscriberStatus? = null
-) : SubscriptionRecompositionOptimizer {
+private object DefaultSubscriptionRecompositionOptimizer : SubscriptionRecompositionOptimizer {
     override fun <T> omit(state: SubscriptionState<T>): SubscriptionState<T> {
         val keys = buildSet {
             add(SubscriptionState.OmitKey.replyUpdatedAt)
-            if (subscriberStatus != null) {
-                add(SubscriptionState.OmitKey.subscriberStatus)
-            }
             when (state.status) {
                 SubscriptionStatus.Pending -> {
                     add(SubscriptionState.OmitKey.errorUpdatedAt)
@@ -62,7 +44,7 @@ private abstract class AbstractSubscriptionRecompositionOptimizer(
                 SubscriptionStatus.Failure -> Unit
             }
         }
-        return state.omit(keys, subscriberStatus ?: SubscriberStatus.NoSubscribers)
+        return state.omit(keys)
     }
 }
 

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionStrategy.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionStrategy.kt
@@ -43,19 +43,6 @@ private object DefaultSubscriptionStrategy : SubscriptionStrategy {
     }
 }
 
-/**
- * Strategy for manually starting the Subscription without automatic subscription.
- */
-val SubscriptionStrategy.Companion.Lazy: SubscriptionStrategy
-    get() = LazySubscriptionStrategy
-
-private object LazySubscriptionStrategy : SubscriptionStrategy {
-    @Composable
-    override fun <T> collectAsState(subscription: SubscriptionRef<T>): SubscriptionState<T> {
-        return subscription.state.collectAsState().value
-    }
-}
-
 // FIXME: CompositionLocal LocalLifecycleOwner not present
 //  Android, it works only with Compose UI 1.7.0-alpha05 or above.
 //  Therefore, we will postpone adding this code until a future release.

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/Subscription.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/Subscription.kt
@@ -47,8 +47,6 @@ private class Subscription<T>(
 
     override suspend fun resume() = subscription.resume()
 
-    override fun cancel() = subscription.cancel()
-
     override fun launchIn(scope: CoroutineScope): Job {
         return scope.launch {
             subscription.state.collect { _state.value = optimize(it) }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SubscriptionPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SubscriptionPreviewClient.kt
@@ -50,7 +50,6 @@ class SubscriptionPreviewClient(
         override fun launchIn(scope: CoroutineScope): Job = Job()
         override suspend fun reset() = Unit
         override suspend fun resume() = Unit
-        override fun cancel() = Unit
     }
 
     /**

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionComposableTest.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
-import soil.query.SubscriberStatus
 import soil.query.SubscriptionId
 import soil.query.SubscriptionKey
 import soil.query.SubscriptionState
@@ -108,32 +107,11 @@ class SubscriptionComposableTest : UnitTest() {
     }
 
     @Test
-    fun testRememberSubscription_idlePreview() = runComposeUiTest {
-        val key = TestSubscriptionKey()
-        val client = SwrPreviewClient(
-            subscription = SubscriptionPreviewClient {
-                on(key.id) { SubscriptionState.initial(subscriberStatus = SubscriberStatus.NoSubscribers) }
-            }
-        )
-        setContent {
-            SwrClientProvider(client) {
-                when (rememberSubscription(key, config = SubscriptionConfig.Lazy)) {
-                    is SubscriptionIdleObject -> Text("idle", modifier = Modifier.testTag("subscription"))
-                    else -> Unit
-                }
-            }
-        }
-
-        waitForIdle()
-        onNodeWithTag("subscription").assertTextEquals("idle")
-    }
-
-    @Test
     fun testRememberSubscription_loadingPreview() = runComposeUiTest {
         val key = TestSubscriptionKey()
         val client = SwrPreviewClient(
             subscription = SubscriptionPreviewClient {
-                on(key.id) { SubscriptionState.initial(subscriberStatus = SubscriberStatus.Active) }
+                on(key.id) { SubscriptionState.initial() }
             }
         )
         setContent {
@@ -156,8 +134,7 @@ class SubscriptionComposableTest : UnitTest() {
             subscription = SubscriptionPreviewClient {
                 on(key.id) {
                     SubscriptionState.success(
-                        data = "Hello, Subscription!",
-                        subscriberStatus = SubscriberStatus.Active
+                        data = "Hello, Subscription!"
                     )
                 }
             }
@@ -182,8 +159,7 @@ class SubscriptionComposableTest : UnitTest() {
             subscription = SubscriptionPreviewClient {
                 on(key.id) {
                     SubscriptionState.failure(
-                        error = RuntimeException("Error"),
-                        subscriberStatus = SubscriberStatus.Active
+                        error = RuntimeException("Error")
                     )
                 }
             }

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionObjectMapperTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionObjectMapperTest.kt
@@ -4,7 +4,6 @@
 package soil.query.compose
 
 import kotlinx.coroutines.flow.MutableStateFlow
-import soil.query.SubscriberStatus
 import soil.query.SubscriptionId
 import soil.query.SubscriptionKey
 import soil.query.SubscriptionState
@@ -26,36 +25,11 @@ import kotlin.test.assertTrue
 class SubscriptionObjectMapperTest : UnitTest() {
 
     @Test
-    fun testToObject_idle() {
-        val key = TestSubscriptionKey()
-        val client = SwrPreviewClient(
-            subscription = SubscriptionPreviewClient {
-                on(key.id) { SubscriptionState.initial() }
-            }
-        )
-        val subscription = client.getSubscription(key)
-        val actual = with(SubscriptionObjectMapper.Default) {
-            subscription.state.value.toObject(subscription = subscription, select = { it })
-        }
-        assertTrue(actual is SubscriptionIdleObject)
-        assertTrue(actual.reply.isNone)
-        assertEquals(0, actual.replyUpdatedAt)
-        assertNull(actual.error)
-        assertEquals(0, actual.errorUpdatedAt)
-        assertEquals(subscription::resume, actual.subscribe)
-        assertEquals(subscription::cancel, actual.unsubscribe)
-        assertEquals(subscription::reset, actual.reset)
-        assertEquals(SubscriptionStatus.Pending, actual.status)
-        assertEquals(SubscriberStatus.NoSubscribers, actual.subscriberStatus)
-        assertNull(actual.data)
-    }
-
-    @Test
     fun testToObject_loading() {
         val key = TestSubscriptionKey()
         val client = SwrPreviewClient(
             subscription = SubscriptionPreviewClient {
-                on(key.id) { SubscriptionState.initial(subscriberStatus = SubscriberStatus.Active) }
+                on(key.id) { SubscriptionState.initial() }
             }
         )
         val subscription = client.getSubscription(key)
@@ -67,11 +41,8 @@ class SubscriptionObjectMapperTest : UnitTest() {
         assertEquals(0, actual.replyUpdatedAt)
         assertNull(actual.error)
         assertEquals(0, actual.errorUpdatedAt)
-        assertEquals(subscription::resume, actual.subscribe)
-        assertEquals(subscription::cancel, actual.unsubscribe)
         assertEquals(subscription::reset, actual.reset)
         assertEquals(SubscriptionStatus.Pending, actual.status)
-        assertEquals(SubscriberStatus.Active, actual.subscriberStatus)
         assertNull(actual.data)
     }
 
@@ -83,8 +54,7 @@ class SubscriptionObjectMapperTest : UnitTest() {
                 on(key.id) {
                     SubscriptionState.success(
                         data = "Hello, Subscription!",
-                        dataUpdatedAt = 400,
-                        subscriberStatus = SubscriberStatus.Active
+                        dataUpdatedAt = 400
                     )
                 }
             }
@@ -98,11 +68,8 @@ class SubscriptionObjectMapperTest : UnitTest() {
         assertEquals(400, actual.replyUpdatedAt)
         assertNull(actual.error)
         assertEquals(0, actual.errorUpdatedAt)
-        assertEquals(subscription::resume, actual.subscribe)
-        assertEquals(subscription::cancel, actual.unsubscribe)
         assertEquals(subscription::reset, actual.reset)
         assertEquals(SubscriptionStatus.Success, actual.status)
-        assertEquals(SubscriberStatus.Active, actual.subscriberStatus)
         assertNotNull(actual.data)
     }
 
@@ -114,8 +81,7 @@ class SubscriptionObjectMapperTest : UnitTest() {
                 on(key.id) {
                     SubscriptionState.failure(
                         error = RuntimeException("Error"),
-                        errorUpdatedAt = 500,
-                        subscriberStatus = SubscriberStatus.Active
+                        errorUpdatedAt = 500
                     )
                 }
             }
@@ -129,11 +95,8 @@ class SubscriptionObjectMapperTest : UnitTest() {
         assertEquals(0, actual.replyUpdatedAt)
         assertNotNull(actual.error)
         assertEquals(500, actual.errorUpdatedAt)
-        assertEquals(subscription::resume, actual.subscribe)
-        assertEquals(subscription::cancel, actual.unsubscribe)
         assertEquals(subscription::reset, actual.reset)
         assertEquals(SubscriptionStatus.Failure, actual.status)
-        assertEquals(SubscriberStatus.Active, actual.subscriberStatus)
         assertNull(actual.data)
     }
 
@@ -147,8 +110,7 @@ class SubscriptionObjectMapperTest : UnitTest() {
                         error = RuntimeException("Error"),
                         errorUpdatedAt = 500,
                         data = "Hello, Subscription!",
-                        dataUpdatedAt = 400,
-                        subscriberStatus = SubscriberStatus.Active
+                        dataUpdatedAt = 400
                     )
                 }
             }
@@ -162,11 +124,8 @@ class SubscriptionObjectMapperTest : UnitTest() {
         assertEquals(400, actual.replyUpdatedAt)
         assertNotNull(actual.error)
         assertEquals(500, actual.errorUpdatedAt)
-        assertEquals(subscription::resume, actual.subscribe)
-        assertEquals(subscription::cancel, actual.unsubscribe)
         assertEquals(subscription::reset, actual.reset)
         assertEquals(SubscriptionStatus.Failure, actual.status)
-        assertEquals(SubscriberStatus.Active, actual.subscriberStatus)
         assertNotNull(actual.data)
     }
 

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionRecompositionOptimizerTest.kt
@@ -3,24 +3,12 @@
 
 package soil.query.compose
 
-import androidx.compose.material.Text
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.test.waitUntilExactlyOneExists
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
-import soil.query.SubscriberStatus
 import soil.query.SubscriptionId
 import soil.query.SubscriptionKey
 import soil.query.SubscriptionState
 import soil.query.SubscriptionStatus
-import soil.query.SwrCachePlus
-import soil.query.SwrCacheScope
-import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.buildSubscriptionKey
 import soil.query.core.Reply
 import soil.testing.UnitTest
@@ -29,54 +17,7 @@ import kotlin.test.assertEquals
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
-@OptIn(ExperimentalTestApi::class, ExperimentalSoilQueryApi::class)
 class SubscriptionRecompositionOptimizerTest : UnitTest() {
-
-    @Test
-    fun testRecomposition_default() = runComposeUiTest {
-        val key = TestSubscriptionKey()
-        val client = SwrCachePlus(coroutineScope = SwrCacheScope())
-        var recompositionCount = 0
-        setContent {
-            SwrClientProvider(client) {
-                val subscription = rememberSubscription(key)
-                SideEffect { recompositionCount++ }
-                when (val reply = subscription.reply) {
-                    is Reply.Some -> Text(reply.value, modifier = Modifier.testTag("subscription"))
-                    is Reply.None -> Unit
-                }
-            }
-        }
-
-        waitUntilExactlyOneExists(hasTestTag("subscription"))
-
-        // pending(active) -> success
-        assertEquals(2, recompositionCount)
-    }
-
-    @Test
-    fun testRecomposition_disabled() = runComposeUiTest {
-        val key = TestSubscriptionKey()
-        val client = SwrCachePlus(coroutineScope = SwrCacheScope())
-        var recompositionCount = 0
-        setContent {
-            SwrClientProvider(client) {
-                val subscription = rememberSubscription(key, config = SubscriptionConfig {
-                    optimizer = SubscriptionRecompositionOptimizer.Disabled
-                })
-                SideEffect { recompositionCount++ }
-                when (val reply = subscription.reply) {
-                    is Reply.Some -> Text(reply.value, modifier = Modifier.testTag("subscription"))
-                    is Reply.None -> Unit
-                }
-            }
-        }
-
-        waitUntilExactlyOneExists(hasTestTag("subscription"))
-
-        // pending(no-subscribers) -> pending(active) -> success
-        assertEquals(3, recompositionCount)
-    }
 
     @Test
     fun testOmit_default_pending() {
@@ -84,16 +25,14 @@ class SubscriptionRecompositionOptimizerTest : UnitTest() {
             reply = Reply.some(1),
             replyUpdatedAt = 300,
             errorUpdatedAt = 200,
-            status = SubscriptionStatus.Pending,
-            subscriberStatus = SubscriberStatus.NoSubscribers
+            status = SubscriptionStatus.Pending
         )
         val actual = SubscriptionRecompositionOptimizer.Default.omit(state)
         val expected = SubscriptionState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,
             errorUpdatedAt = 0,
-            status = SubscriptionStatus.Pending,
-            subscriberStatus = SubscriberStatus.Active
+            status = SubscriptionStatus.Pending
         )
         assertEquals(expected, actual)
     }
@@ -104,16 +43,14 @@ class SubscriptionRecompositionOptimizerTest : UnitTest() {
             reply = Reply.some(1),
             replyUpdatedAt = 300,
             errorUpdatedAt = 200,
-            status = SubscriptionStatus.Success,
-            subscriberStatus = SubscriberStatus.NoSubscribers
+            status = SubscriptionStatus.Success
         )
         val actual = SubscriptionRecompositionOptimizer.Default.omit(state)
         val expected = SubscriptionState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,
             errorUpdatedAt = 0,
-            status = SubscriptionStatus.Success,
-            subscriberStatus = SubscriberStatus.Active
+            status = SubscriptionStatus.Success
         )
         assertEquals(expected, actual)
     }
@@ -126,8 +63,7 @@ class SubscriptionRecompositionOptimizerTest : UnitTest() {
             replyUpdatedAt = 300,
             error = error,
             errorUpdatedAt = 200,
-            status = SubscriptionStatus.Failure,
-            subscriberStatus = SubscriberStatus.NoSubscribers
+            status = SubscriptionStatus.Failure
         )
         val actual = SubscriptionRecompositionOptimizer.Default.omit(state)
         val expected = SubscriptionState.test(
@@ -135,71 +71,7 @@ class SubscriptionRecompositionOptimizerTest : UnitTest() {
             replyUpdatedAt = 0,
             error = error,
             errorUpdatedAt = 200,
-            status = SubscriptionStatus.Failure,
-            subscriberStatus = SubscriberStatus.Active
-        )
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun testOmit_lazy_pending() {
-        val state = SubscriptionState.test(
-            reply = Reply.some(1),
-            replyUpdatedAt = 300,
-            errorUpdatedAt = 200,
-            status = SubscriptionStatus.Pending,
-            subscriberStatus = SubscriberStatus.NoSubscribers
-        )
-        val actual = SubscriptionRecompositionOptimizer.Lazy.omit(state)
-        val expected = SubscriptionState.test(
-            reply = Reply.some(1),
-            replyUpdatedAt = 0,
-            errorUpdatedAt = 0,
-            status = SubscriptionStatus.Pending,
-            subscriberStatus = SubscriberStatus.NoSubscribers
-        )
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun testOmit_lazy_success() {
-        val state = SubscriptionState.test(
-            reply = Reply.some(1),
-            replyUpdatedAt = 300,
-            errorUpdatedAt = 200,
-            status = SubscriptionStatus.Success,
-            subscriberStatus = SubscriberStatus.NoSubscribers
-        )
-        val actual = SubscriptionRecompositionOptimizer.Lazy.omit(state)
-        val expected = SubscriptionState.test(
-            reply = Reply.some(1),
-            replyUpdatedAt = 0,
-            errorUpdatedAt = 0,
-            status = SubscriptionStatus.Success,
-            subscriberStatus = SubscriberStatus.NoSubscribers
-        )
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun testOmit_lazy_failure() {
-        val error = RuntimeException("error")
-        val state = SubscriptionState.test(
-            reply = Reply.some(1),
-            replyUpdatedAt = 300,
-            error = error,
-            errorUpdatedAt = 200,
-            status = SubscriptionStatus.Failure,
-            subscriberStatus = SubscriberStatus.NoSubscribers
-        )
-        val actual = SubscriptionRecompositionOptimizer.Lazy.omit(state)
-        val expected = SubscriptionState.test(
-            reply = Reply.some(1),
-            replyUpdatedAt = 0,
-            error = error,
-            errorUpdatedAt = 200,
-            status = SubscriptionStatus.Failure,
-            subscriberStatus = SubscriberStatus.NoSubscribers
+            status = SubscriptionStatus.Failure
         )
         assertEquals(expected, actual)
     }
@@ -210,8 +82,7 @@ class SubscriptionRecompositionOptimizerTest : UnitTest() {
             reply = Reply.some(1),
             replyUpdatedAt = 300,
             errorUpdatedAt = 200,
-            status = SubscriptionStatus.Pending,
-            subscriberStatus = SubscriberStatus.NoSubscribers
+            status = SubscriptionStatus.Pending
         )
         val actual = SubscriptionRecompositionOptimizer.Disabled.omit(expected)
         assertEquals(expected, actual)
@@ -223,8 +94,7 @@ class SubscriptionRecompositionOptimizerTest : UnitTest() {
             reply = Reply.some(1),
             replyUpdatedAt = 300,
             errorUpdatedAt = 200,
-            status = SubscriptionStatus.Success,
-            subscriberStatus = SubscriberStatus.NoSubscribers
+            status = SubscriptionStatus.Success
         )
         val actual = SubscriptionRecompositionOptimizer.Disabled.omit(expected)
         assertEquals(expected, actual)
@@ -238,8 +108,7 @@ class SubscriptionRecompositionOptimizerTest : UnitTest() {
             replyUpdatedAt = 300,
             error = error,
             errorUpdatedAt = 200,
-            status = SubscriptionStatus.Failure,
-            subscriberStatus = SubscriberStatus.NoSubscribers
+            status = SubscriptionStatus.Failure
         )
         val actual = SubscriptionRecompositionOptimizer.Disabled.omit(expected)
         assertEquals(expected, actual)

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionAction.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionAction.kt
@@ -38,15 +38,6 @@ sealed interface SubscriptionAction<out T> {
         val error: Throwable,
         val errorUpdatedAt: Long
     ) : SubscriptionAction<Nothing>
-
-    /**
-     * Updates the subscriber status.
-     *
-     * @param subscriberStatus The subscriber status to be updated.
-     */
-    data class UpdateSubscriberStatus(
-        val subscriberStatus: SubscriberStatus
-    ) : SubscriptionAction<Nothing>
 }
 
 typealias SubscriptionReducer<T> = (SubscriptionState<T>, SubscriptionAction<T>) -> SubscriptionState<T>
@@ -82,12 +73,6 @@ fun <T> createSubscriptionReducer(): SubscriptionReducer<T> = { state, action ->
                 status = SubscriptionStatus.Failure,
                 error = action.error,
                 errorUpdatedAt = action.errorUpdatedAt
-            )
-        }
-
-        is SubscriptionAction.UpdateSubscriberStatus -> {
-            state.copy(
-                subscriberStatus = action.subscriberStatus
             )
         }
     }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionCommands.kt
@@ -51,21 +51,4 @@ object SubscriptionCommands {
             ctx.restart()
         }
     }
-
-    /**
-     * Handles changes in the number of subscribers.
-     *
-     * @param subscribers The number of subscribers.
-     */
-    class Count<T>(
-        private val subscribers: Int
-    ) : SubscriptionCommand<T> {
-        override suspend fun handle(ctx: SubscriptionCommand.Context<T>) {
-            val currentStatus = if (subscribers > 0) SubscriberStatus.Active else SubscriberStatus.NoSubscribers
-            if (ctx.state.subscriberStatus == currentStatus) {
-                return
-            }
-            ctx.dispatch(SubscriptionAction.UpdateSubscriberStatus(currentStatus))
-        }
-    }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionModel.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionModel.kt
@@ -20,11 +20,6 @@ interface SubscriptionModel<out T> : DataModel<T> {
     val status: SubscriptionStatus
 
     /**
-     * The subscriber status of the subscription.
-     */
-    val subscriberStatus: SubscriberStatus
-
-    /**
      * The revision of the currently snapshot.
      */
     val revision: String get() = "d-$replyUpdatedAt/e-$errorUpdatedAt"
@@ -45,17 +40,12 @@ interface SubscriptionModel<out T> : DataModel<T> {
     val isFailure: Boolean get() = status == SubscriptionStatus.Failure
 
     /**
-     * Returns `true` if the subscription has subscribers, `false` otherwise.
-     */
-    val hasSubscribers: Boolean get() = subscriberStatus == SubscriberStatus.Active
-
-    /**
      * Returns true if the [SubscriptionModel] is awaited.
      *
      * @see DataModel.isAwaited
      */
     override fun isAwaited(): Boolean {
-        return isPending && hasSubscribers
+        return isPending
     }
 }
 
@@ -66,12 +56,4 @@ enum class SubscriptionStatus {
     Pending,
     Success,
     Failure
-}
-
-/**
- * The subscriber status of the subscription.
- */
-enum class SubscriberStatus {
-    NoSubscribers,
-    Active,
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionState.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionState.kt
@@ -15,8 +15,7 @@ data class SubscriptionState<T> internal constructor(
     override val replyUpdatedAt: Long = 0,
     override val error: Throwable? = null,
     override val errorUpdatedAt: Long = 0,
-    override val status: SubscriptionStatus = SubscriptionStatus.Pending,
-    override val subscriberStatus: SubscriberStatus = SubscriberStatus.NoSubscribers
+    override val status: SubscriptionStatus = SubscriptionStatus.Pending
 ) : SubscriptionModel<T> {
 
     /**
@@ -25,14 +24,12 @@ data class SubscriptionState<T> internal constructor(
      * NOTE: This function is provided to optimize recomposition for Compose APIs.
      */
     fun omit(
-        keys: Set<OmitKey>,
-        defaultSubscriberStatus: SubscriberStatus = SubscriberStatus.NoSubscribers
+        keys: Set<OmitKey>
     ): SubscriptionState<T> {
         if (keys.isEmpty()) return this
         return copy(
             replyUpdatedAt = if (keys.contains(OmitKey.replyUpdatedAt)) 0 else replyUpdatedAt,
-            errorUpdatedAt = if (keys.contains(OmitKey.errorUpdatedAt)) 0 else errorUpdatedAt,
-            subscriberStatus = if (keys.contains(OmitKey.subscriberStatus)) defaultSubscriberStatus else subscriberStatus
+            errorUpdatedAt = if (keys.contains(OmitKey.errorUpdatedAt)) 0 else errorUpdatedAt
         )
     }
 
@@ -41,7 +38,6 @@ data class SubscriptionState<T> internal constructor(
         companion object {
             val replyUpdatedAt = OmitKey("replyUpdatedAt")
             val errorUpdatedAt = OmitKey("errorUpdatedAt")
-            val subscriberStatus = OmitKey("subscriberStatus")
         }
     }
 
@@ -49,15 +45,9 @@ data class SubscriptionState<T> internal constructor(
 
         /**
          * Creates a new [SubscriptionState] with the [SubscriptionStatus.Pending] status.
-         *
-         * @param subscriberStatus The status of the subscriber.
          */
-        fun <T> initial(
-            subscriberStatus: SubscriberStatus = SubscriberStatus.NoSubscribers
-        ): SubscriptionState<T> {
-            return SubscriptionState(
-                subscriberStatus = subscriberStatus
-            )
+        fun <T> initial(): SubscriptionState<T> {
+            return SubscriptionState()
         }
 
         /**
@@ -65,18 +55,15 @@ data class SubscriptionState<T> internal constructor(
          *
          * @param data The data to be stored in the state.
          * @param dataUpdatedAt The timestamp when the data was updated. Default is the current epoch.
-         * @param subscriberStatus The status of the subscriber.
          */
         fun <T> success(
             data: T,
-            dataUpdatedAt: Long = epoch(),
-            subscriberStatus: SubscriberStatus = SubscriberStatus.NoSubscribers
+            dataUpdatedAt: Long = epoch()
         ): SubscriptionState<T> {
             return SubscriptionState(
                 reply = Reply(data),
                 replyUpdatedAt = dataUpdatedAt,
-                status = SubscriptionStatus.Success,
-                subscriberStatus = subscriberStatus
+                status = SubscriptionStatus.Success
             )
         }
 
@@ -85,18 +72,15 @@ data class SubscriptionState<T> internal constructor(
          *
          * @param error The error to be stored in the state.
          * @param errorUpdatedAt The timestamp when the error was updated. Default is the current epoch.
-         * @param subscriberStatus The status of the subscriber.
          */
         fun <T> failure(
             error: Throwable,
-            errorUpdatedAt: Long = epoch(),
-            subscriberStatus: SubscriberStatus = SubscriberStatus.NoSubscribers
+            errorUpdatedAt: Long = epoch()
         ): SubscriptionState<T> {
             return SubscriptionState(
                 error = error,
                 errorUpdatedAt = errorUpdatedAt,
-                status = SubscriptionStatus.Failure,
-                subscriberStatus = subscriberStatus
+                status = SubscriptionStatus.Failure
             )
         }
 
@@ -107,22 +91,19 @@ data class SubscriptionState<T> internal constructor(
          * @param errorUpdatedAt The timestamp when the error was updated. Default is the current epoch.
          * @param data The data to be stored in the state.
          * @param dataUpdatedAt The timestamp when the data was updated. Default is the current epoch.
-         * @param subscriberStatus The status of the subscriber.
          */
         fun <T> failure(
             error: Throwable,
             errorUpdatedAt: Long = epoch(),
             data: T,
-            dataUpdatedAt: Long = epoch(),
-            subscriberStatus: SubscriberStatus = SubscriberStatus.NoSubscribers
+            dataUpdatedAt: Long = epoch()
         ): SubscriptionState<T> {
             return SubscriptionState(
                 reply = Reply(data),
                 replyUpdatedAt = dataUpdatedAt,
                 error = error,
                 errorUpdatedAt = errorUpdatedAt,
-                status = SubscriptionStatus.Failure,
-                subscriberStatus = subscriberStatus
+                status = SubscriptionStatus.Failure
             )
         }
 
@@ -136,16 +117,14 @@ data class SubscriptionState<T> internal constructor(
             replyUpdatedAt: Long = 0,
             error: Throwable? = null,
             errorUpdatedAt: Long = 0,
-            status: SubscriptionStatus = SubscriptionStatus.Pending,
-            subscriberStatus: SubscriberStatus = SubscriberStatus.NoSubscribers
+            status: SubscriptionStatus = SubscriptionStatus.Pending
         ): SubscriptionState<T> {
             return SubscriptionState(
                 reply = reply,
                 replyUpdatedAt = replyUpdatedAt,
                 error = error,
                 errorUpdatedAt = errorUpdatedAt,
-                status = status,
-                subscriberStatus = subscriberStatus
+                status = status
             )
         }
     }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlus.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlus.kt
@@ -154,7 +154,6 @@ class SwrCachePlus(private val policy: SwrCachePlusPolicy) : SwrCache(policy), S
                     stopTimeout = options.keepAliveTime,
                     onSubscriptionCount = { subscribers ->
                         options.vvv(id) { "subscription count: $subscribers" }
-                        scope.launch { command.send(SubscriptionCommands.Count(subscribers)) }
                     }
                 )
             )

--- a/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionStateTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionStateTest.kt
@@ -17,14 +17,12 @@ class SubscriptionStateTest : UnitTest() {
             replyUpdatedAt = 300,
             error = null,
             errorUpdatedAt = 400,
-            status = SubscriptionStatus.Success,
-            subscriberStatus = SubscriberStatus.Active
+            status = SubscriptionStatus.Success
         )
         val actual = state.omit(
             keys = setOf(
                 SubscriptionState.OmitKey.replyUpdatedAt,
-                SubscriptionState.OmitKey.errorUpdatedAt,
-                SubscriptionState.OmitKey.subscriberStatus
+                SubscriptionState.OmitKey.errorUpdatedAt
             )
         )
         val expected = SubscriptionState(
@@ -32,8 +30,7 @@ class SubscriptionStateTest : UnitTest() {
             replyUpdatedAt = 0,
             error = null,
             errorUpdatedAt = 0,
-            status = SubscriptionStatus.Success,
-            subscriberStatus = SubscriberStatus.NoSubscribers
+            status = SubscriptionStatus.Success
         )
         assertEquals(expected, actual)
     }
@@ -45,24 +42,20 @@ class SubscriptionStateTest : UnitTest() {
             replyUpdatedAt = 300,
             error = null,
             errorUpdatedAt = 400,
-            status = SubscriptionStatus.Success,
-            subscriberStatus = SubscriberStatus.NoSubscribers
+            status = SubscriptionStatus.Success
         )
         val actual = state.omit(
             keys = setOf(
                 SubscriptionState.OmitKey.replyUpdatedAt,
-                SubscriptionState.OmitKey.errorUpdatedAt,
-                SubscriptionState.OmitKey.subscriberStatus
-            ),
-            defaultSubscriberStatus = SubscriberStatus.Active
+                SubscriptionState.OmitKey.errorUpdatedAt
+            )
         )
         val expected = SubscriptionState(
             reply = Reply(1),
             replyUpdatedAt = 0,
             error = null,
             errorUpdatedAt = 0,
-            status = SubscriptionStatus.Success,
-            subscriberStatus = SubscriberStatus.Active
+            status = SubscriptionStatus.Success
         )
         assertEquals(expected, actual)
     }
@@ -73,5 +66,4 @@ class SubscriptionStateTest : UnitTest() {
         val actual = expected.omit(emptySet())
         assertEquals(expected, actual)
     }
-
 }

--- a/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientPlusTest.kt
+++ b/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientPlusTest.kt
@@ -42,11 +42,11 @@ class TestSwrClientPlusTest : UnitTest() {
         }
         val key = ExampleSubscriptionKey()
         val subscription = testClient.getSubscription(key).also { it.launchIn(backgroundScope) }
-        launch { subscription.resume() }
+        val job = launch { subscription.resume() }
         launch { subscription.state.filter { it.isSuccess }.first() }
         runCurrent()
         assertEquals("Hello, World!", subscription.state.value.reply.getOrThrow())
-        subscription.cancel()
+        job.cancel()
     }
 }
 


### PR DESCRIPTION
The Optional Subscription API was introduced in #95. This API should now cover the use cases we aimed to address with manual subscription management. As a result, we have decided to remove the features that were provided for manual subscription management.
