### PR TITLE
Rename recomposition optimizer

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryConfig.kt
@@ -44,7 +44,7 @@ data class InfiniteQueryConfig internal constructor(
     companion object {
         val Default = InfiniteQueryConfig(
             mapper = InfiniteQueryObjectMapper.Default,
-            optimizer = InfiniteQueryRecompositionOptimizer.Default,
+            optimizer = InfiniteQueryRecompositionOptimizer.Enabled,
             strategy = InfiniteQueryStrategy.Default,
             marker = Marker.None
         )

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizer.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizer.kt
@@ -26,10 +26,10 @@ interface InfiniteQueryRecompositionOptimizer {
 /**
  * Optimizer implementation for [InfiniteQueryStrategy.Companion.Default].
  */
-val InfiniteQueryRecompositionOptimizer.Companion.Default: InfiniteQueryRecompositionOptimizer
-    get() = DefaultInfiniteQueryRecompositionOptimizer
+val InfiniteQueryRecompositionOptimizer.Companion.Enabled: InfiniteQueryRecompositionOptimizer
+    get() = InfiniteQueryRecompositionOptimizerEnabled
 
-private object DefaultInfiniteQueryRecompositionOptimizer : InfiniteQueryRecompositionOptimizer {
+private object InfiniteQueryRecompositionOptimizerEnabled : InfiniteQueryRecompositionOptimizer {
     override fun <T, S> omit(state: QueryState<QueryChunks<T, S>>): QueryState<QueryChunks<T, S>> {
         val keys = buildSet {
             add(QueryState.OmitKey.replyUpdatedAt)

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationConfig.kt
@@ -44,7 +44,7 @@ data class MutationConfig internal constructor(
     companion object {
         val Default = MutationConfig(
             mapper = MutationObjectMapper.Default,
-            optimizer = MutationRecompositionOptimizer.Default,
+            optimizer = MutationRecompositionOptimizer.Enabled,
             strategy = MutationStrategy.Default,
             marker = Marker.None
         )

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationRecompositionOptimizer.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/MutationRecompositionOptimizer.kt
@@ -25,10 +25,10 @@ interface MutationRecompositionOptimizer {
 /**
  * Optimizer implementation for [MutationStrategy.Companion.Default].
  */
-val MutationRecompositionOptimizer.Companion.Default: MutationRecompositionOptimizer
-    get() = DefaultMutationRecompositionOptimizer
+val MutationRecompositionOptimizer.Companion.Enabled: MutationRecompositionOptimizer
+    get() = MutationRecompositionOptimizerEnabled
 
-private object DefaultMutationRecompositionOptimizer : MutationRecompositionOptimizer {
+private object MutationRecompositionOptimizerEnabled : MutationRecompositionOptimizer {
     override fun <T> omit(state: MutationState<T>): MutationState<T> {
         val keys = buildSet {
             add(MutationState.OmitKey.replyUpdatedAt)

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryConfig.kt
@@ -44,7 +44,7 @@ data class QueryConfig internal constructor(
     companion object {
         val Default = QueryConfig(
             mapper = QueryObjectMapper.Default,
-            optimizer = QueryRecompositionOptimizer.Default,
+            optimizer = QueryRecompositionOptimizer.Enabled,
             strategy = QueryStrategy.Default,
             marker = Marker.None
         )

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryRecompositionOptimizer.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryRecompositionOptimizer.kt
@@ -25,10 +25,10 @@ interface QueryRecompositionOptimizer {
 /**
  * Optimizer implementation for [QueryStrategy.Companion.Default].
  */
-val QueryRecompositionOptimizer.Companion.Default: QueryRecompositionOptimizer
-    get() = DefaultQueryRecompositionOptimizer
+val QueryRecompositionOptimizer.Companion.Enabled: QueryRecompositionOptimizer
+    get() = QueryRecompositionOptimizerEnabled
 
-private object DefaultQueryRecompositionOptimizer : QueryRecompositionOptimizer {
+private object QueryRecompositionOptimizerEnabled : QueryRecompositionOptimizer {
     override fun <T> omit(state: QueryState<T>): QueryState<T> {
         val keys = buildSet {
             add(QueryState.OmitKey.replyUpdatedAt)

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionConfig.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionConfig.kt
@@ -44,7 +44,7 @@ data class SubscriptionConfig internal constructor(
     companion object {
         val Default = SubscriptionConfig(
             mapper = SubscriptionObjectMapper.Default,
-            optimizer = SubscriptionRecompositionOptimizer.Default,
+            optimizer = SubscriptionRecompositionOptimizer.Enabled,
             strategy = SubscriptionStrategy.Default,
             marker = Marker.None
         )

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionRecompositionOptimizer.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionRecompositionOptimizer.kt
@@ -25,10 +25,10 @@ interface SubscriptionRecompositionOptimizer {
 /**
  * Optimizer implementation for [SubscriptionStrategy.Companion.Default].
  */
-val SubscriptionRecompositionOptimizer.Companion.Default: SubscriptionRecompositionOptimizer
-    get() = DefaultSubscriptionRecompositionOptimizer
+val SubscriptionRecompositionOptimizer.Companion.Enabled: SubscriptionRecompositionOptimizer
+    get() = SubscriptionRecompositionOptimizerEnabled
 
-private object DefaultSubscriptionRecompositionOptimizer : SubscriptionRecompositionOptimizer {
+private object SubscriptionRecompositionOptimizerEnabled : SubscriptionRecompositionOptimizer {
     override fun <T> omit(state: SubscriptionState<T>): SubscriptionState<T> {
         val keys = buildSet {
             add(SubscriptionState.OmitKey.replyUpdatedAt)

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryComposableTest.kt
@@ -51,7 +51,7 @@ class InfiniteQueryComposableTest : UnitTest() {
             SwrClientProvider(client) {
                 val query = rememberInfiniteQuery(key, config = InfiniteQueryConfig {
                     mapper = InfiniteQueryObjectMapper.Default
-                    optimizer = InfiniteQueryRecompositionOptimizer.Default
+                    optimizer = InfiniteQueryRecompositionOptimizer.Enabled
                     strategy = InfiniteQueryStrategy.Default
                     marker = Marker.None
                 })

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizerTest.kt
@@ -110,7 +110,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             fetchStatus = QueryFetchStatus.Fetching,
             isInvalidated = false
         )
-        val actual = InfiniteQueryRecompositionOptimizer.Default.omit(state)
+        val actual = InfiniteQueryRecompositionOptimizer.Enabled.omit(state)
         val expected = QueryState.test<QueryChunks<Int, Int>>(
             reply = Reply.None,
             replyUpdatedAt = 0,
@@ -134,7 +134,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             fetchStatus = QueryFetchStatus.Fetching,
             isInvalidated = false
         )
-        val actual = InfiniteQueryRecompositionOptimizer.Default.omit(state)
+        val actual = InfiniteQueryRecompositionOptimizer.Enabled.omit(state)
         val expected = QueryState.test<QueryChunks<Int, Int>>(
             reply = Reply.some(emptyChunks()),
             replyUpdatedAt = 0,
@@ -158,7 +158,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             fetchStatus = QueryFetchStatus.Fetching,
             isInvalidated = true
         )
-        val actual = InfiniteQueryRecompositionOptimizer.Default.omit(state)
+        val actual = InfiniteQueryRecompositionOptimizer.Enabled.omit(state)
         val expected = QueryState.test<QueryChunks<Int, Int>>(
             reply = Reply.some(emptyChunks()),
             replyUpdatedAt = 0,
@@ -184,7 +184,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             fetchStatus = QueryFetchStatus.Fetching,
             isInvalidated = false
         )
-        val actual = InfiniteQueryRecompositionOptimizer.Default.omit(state)
+        val actual = InfiniteQueryRecompositionOptimizer.Enabled.omit(state)
         val expected = QueryState.test<QueryChunks<Int, Int>>(
             reply = Reply.some(emptyChunks()),
             replyUpdatedAt = 0,
@@ -211,7 +211,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             fetchStatus = QueryFetchStatus.Fetching,
             isInvalidated = true
         )
-        val actual = InfiniteQueryRecompositionOptimizer.Default.omit(state)
+        val actual = InfiniteQueryRecompositionOptimizer.Enabled.omit(state)
         val expected = QueryState.test<QueryChunks<Int, Int>>(
             reply = Reply.some(emptyChunks()),
             replyUpdatedAt = 0,

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationComposableTest.kt
@@ -46,7 +46,7 @@ class MutationComposableTest : UnitTest() {
             SwrClientProvider(client) {
                 val mutation = rememberMutation(key, config = MutationConfig {
                     mapper = MutationObjectMapper.Default
-                    optimizer = MutationRecompositionOptimizer.Default
+                    optimizer = MutationRecompositionOptimizer.Enabled
                     strategy = MutationStrategy.Default
                     marker = Marker.None
                 })

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationRecompositionOptimizerTest.kt
@@ -22,7 +22,7 @@ class MutationRecompositionOptimizerTest : UnitTest() {
             status = MutationStatus.Idle,
             mutatedCount = 1
         )
-        val actual = MutationRecompositionOptimizer.Default.omit(state)
+        val actual = MutationRecompositionOptimizer.Enabled.omit(state)
         val expected = MutationState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,
@@ -44,7 +44,7 @@ class MutationRecompositionOptimizerTest : UnitTest() {
             status = MutationStatus.Pending,
             mutatedCount = 1
         )
-        val actual = MutationRecompositionOptimizer.Default.omit(state)
+        val actual = MutationRecompositionOptimizer.Enabled.omit(state)
         val expected = MutationState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,
@@ -66,7 +66,7 @@ class MutationRecompositionOptimizerTest : UnitTest() {
             status = MutationStatus.Success,
             mutatedCount = 1
         )
-        val actual = MutationRecompositionOptimizer.Default.omit(state)
+        val actual = MutationRecompositionOptimizer.Enabled.omit(state)
         val expected = MutationState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,
@@ -89,7 +89,7 @@ class MutationRecompositionOptimizerTest : UnitTest() {
             status = MutationStatus.Failure,
             mutatedCount = 1
         )
-        val actual = MutationRecompositionOptimizer.Default.omit(state)
+        val actual = MutationRecompositionOptimizer.Enabled.omit(state)
         val expected = MutationState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryComposableTest.kt
@@ -45,7 +45,7 @@ class QueryComposableTest : UnitTest() {
             SwrClientProvider(client) {
                 val query = rememberQuery(key, config = QueryConfig {
                     mapper = QueryObjectMapper.Default
-                    optimizer = QueryRecompositionOptimizer.Default
+                    optimizer = QueryRecompositionOptimizer.Enabled
                     strategy = QueryStrategy.Default
                     marker = Marker.None
                 })

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryRecompositionOptimizerTest.kt
@@ -87,7 +87,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             fetchStatus = QueryFetchStatus.Fetching,
             isInvalidated = false
         )
-        val actual = QueryRecompositionOptimizer.Default.omit(state)
+        val actual = QueryRecompositionOptimizer.Enabled.omit(state)
         val expected = QueryState.test(
             reply = Reply.None,
             replyUpdatedAt = 0,
@@ -111,7 +111,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             fetchStatus = QueryFetchStatus.Fetching,
             isInvalidated = false
         )
-        val actual = QueryRecompositionOptimizer.Default.omit(state)
+        val actual = QueryRecompositionOptimizer.Enabled.omit(state)
         val expected = QueryState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,
@@ -135,7 +135,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             fetchStatus = QueryFetchStatus.Fetching,
             isInvalidated = true
         )
-        val actual = QueryRecompositionOptimizer.Default.omit(state)
+        val actual = QueryRecompositionOptimizer.Enabled.omit(state)
         val expected = QueryState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,
@@ -161,7 +161,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             fetchStatus = QueryFetchStatus.Fetching,
             isInvalidated = false
         )
-        val actual = QueryRecompositionOptimizer.Default.omit(state)
+        val actual = QueryRecompositionOptimizer.Enabled.omit(state)
         val expected = QueryState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,
@@ -188,7 +188,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             fetchStatus = QueryFetchStatus.Fetching,
             isInvalidated = true
         )
-        val actual = QueryRecompositionOptimizer.Default.omit(state)
+        val actual = QueryRecompositionOptimizer.Enabled.omit(state)
         val expected = QueryState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionComposableTest.kt
@@ -48,7 +48,7 @@ class SubscriptionComposableTest : UnitTest() {
             SwrClientProvider(client) {
                 val subscription = rememberSubscription(key, config = SubscriptionConfig {
                     mapper = SubscriptionObjectMapper.Default
-                    optimizer = SubscriptionRecompositionOptimizer.Default
+                    optimizer = SubscriptionRecompositionOptimizer.Enabled
                     strategy = SubscriptionStrategy.Default
                     marker = Marker.None
                 })

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionRecompositionOptimizerTest.kt
@@ -27,7 +27,7 @@ class SubscriptionRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             status = SubscriptionStatus.Pending
         )
-        val actual = SubscriptionRecompositionOptimizer.Default.omit(state)
+        val actual = SubscriptionRecompositionOptimizer.Enabled.omit(state)
         val expected = SubscriptionState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,
@@ -45,7 +45,7 @@ class SubscriptionRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             status = SubscriptionStatus.Success
         )
-        val actual = SubscriptionRecompositionOptimizer.Default.omit(state)
+        val actual = SubscriptionRecompositionOptimizer.Enabled.omit(state)
         val expected = SubscriptionState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,
@@ -65,7 +65,7 @@ class SubscriptionRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             status = SubscriptionStatus.Failure
         )
-        val actual = SubscriptionRecompositionOptimizer.Default.omit(state)
+        val actual = SubscriptionRecompositionOptimizer.Enabled.omit(state)
         val expected = SubscriptionState.test(
             reply = Reply.some(1),
             replyUpdatedAt = 0,


### PR DESCRIPTION
We decided to rename `Default` to `Enabled` because we had a use case where we wanted the Default value to be Disabled.