### PR TITLE
Refactor Cache Internal Classes

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.StateFlow
 import soil.query.MutationClient
 import soil.query.MutationId
 import soil.query.MutationKey
-import soil.query.MutationOptions
 import soil.query.MutationRef
 import soil.query.MutationState
 import soil.query.core.Marker
@@ -29,8 +28,7 @@ import soil.query.core.getOrThrow
  */
 @Stable
 class MutationPreviewClient(
-    private val previewData: Map<UniqueId, MutationState<*>>,
-    override val defaultMutationOptions: MutationOptions = MutationOptions
+    private val previewData: Map<UniqueId, MutationState<*>>
 ) : MutationClient {
 
     @Suppress("UNCHECKED_CAST")

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
@@ -32,8 +32,7 @@ import soil.query.core.UniqueId
  */
 @Stable
 class QueryPreviewClient(
-    private val previewData: Map<UniqueId, QueryState<*>>,
-    override val defaultQueryOptions: QueryOptions = QueryOptions
+    private val previewData: Map<UniqueId, QueryState<*>>
 ) : QueryClient {
 
     @Suppress("UNCHECKED_CAST")

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SubscriptionPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SubscriptionPreviewClient.kt
@@ -29,8 +29,7 @@ import soil.query.core.UniqueId
  */
 @Stable
 class SubscriptionPreviewClient(
-    private val previewData: Map<UniqueId, SubscriptionState<*>>,
-    override val defaultSubscriptionOptions: SubscriptionOptions = SubscriptionOptions()
+    private val previewData: Map<UniqueId, SubscriptionState<*>>
 ) : SubscriptionClient {
 
     @ExperimentalSoilQueryApi

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationClient.kt
@@ -11,11 +11,6 @@ import soil.query.core.Marker
 interface MutationClient {
 
     /**
-     * The default mutation options.
-     */
-    val defaultMutationOptions: MutationOptions
-
-    /**
      * Gets the [MutationRef] by the specified [MutationKey].
      */
     fun <T, S> getMutation(

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
@@ -13,11 +13,6 @@ import soil.query.core.UniqueId
 interface QueryClient {
 
     /**
-     * The default query options.
-     */
-    val defaultQueryOptions: QueryOptions
-
-    /**
      * Gets the [QueryRef] by the specified [QueryKey].
      */
     fun <T> getQuery(

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionClient.kt
@@ -12,11 +12,6 @@ import soil.query.core.Marker
 interface SubscriptionClient {
 
     /**
-     * The default subscription options.
-     */
-    val defaultSubscriptionOptions: SubscriptionOptions
-
-    /**
      * Gets the [SubscriptionRef] by the specified [SubscriptionKey].
      */
     @ExperimentalSoilQueryApi

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCache.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCache.kt
@@ -3,43 +3,28 @@
 
 package soil.query
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.SendChannel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
-import soil.query.core.ActorBlockRunner
-import soil.query.core.ActorSequenceNumber
+import soil.query.annotation.InternalSoilQueryApi
 import soil.query.core.BatchScheduler
+import soil.query.core.BatchSchedulerFactory
 import soil.query.core.ErrorRecord
-import soil.query.core.Marker
+import soil.query.core.ErrorRelay
 import soil.query.core.MemoryPressure
 import soil.query.core.MemoryPressureLevel
 import soil.query.core.NetworkConnectivity
-import soil.query.core.NetworkConnectivityEvent
-import soil.query.core.Reply
-import soil.query.core.SurrogateKey
 import soil.query.core.TimeBasedCache
 import soil.query.core.UniqueId
 import soil.query.core.WindowVisibility
-import soil.query.core.WindowVisibilityEvent
-import soil.query.core.epoch
-import soil.query.core.getOrNull
-import soil.query.core.vvv
-import kotlin.coroutines.CoroutineContext
+import soil.query.core.observeOnMemoryPressure
+import soil.query.core.observeOnNetworkReconnect
+import soil.query.core.observeOnWindowFocus
+import kotlin.time.Duration
 
 /**
  * Implementation of the [SwrClient] interface.
@@ -59,35 +44,69 @@ import kotlin.coroutines.CoroutineContext
  * [Mutation] is managed similarly to Active state [Query], but it is not explicitly deleted like [removeQueries].
  * Typically, since the result of [Mutation] execution is not reused, it does not cache after going inactive.
  *
- * @param policy The policy for the [SwrCache].
  * @constructor Creates a new [SwrCache] instance.
  */
-open class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutableClient {
+@OptIn(InternalSoilQueryApi::class)
+class SwrCache internal constructor(
+    override val coroutineScope: CoroutineScope,
+    override val mainDispatcher: CoroutineDispatcher,
+    override val mutationOptions: MutationOptions,
+    override val mutationReceiver: MutationReceiver,
+    override val mutationStore: MutableMap<UniqueId, ManagedMutation<*>>,
+    override val queryOptions: QueryOptions,
+    override val queryReceiver: QueryReceiver,
+    override val queryStore: MutableMap<UniqueId, ManagedQuery<*>>,
+    override val queryCache: QueryCache,
+    override val errorRelaySource: ErrorRelay?,
+    private val memoryPressure: MemoryPressure,
+    private val networkConnectivity: NetworkConnectivity,
+    private val networkResumeAfterDelay: Duration,
+    private val networkResumeQueriesFilter: ResumeQueriesFilter,
+    private val windowVisibility: WindowVisibility,
+    private val windowResumeQueriesFilter: ResumeQueriesFilter,
+    batchSchedulerFactory: BatchSchedulerFactory
+) : SwrCacheInternal(), SwrCacheView, SwrClient {
 
     @Suppress("unused")
     constructor(coroutineScope: CoroutineScope) : this(SwrCachePolicy(coroutineScope))
 
-    private val mutationReceiver = policy.mutationReceiver
-    private val mutationStore: MutableMap<UniqueId, ManagedMutation<*>> = mutableMapOf()
-    private val queryReceiver = policy.queryReceiver
-    private val queryStore: MutableMap<UniqueId, ManagedQuery<*>> = mutableMapOf()
-    private val queryCache: QueryCache = policy.queryCache
-    private val coroutineScope: CoroutineScope = CoroutineScope(
-        context = newCoroutineContext(policy.coroutineScope)
+    constructor(policy: SwrCachePolicy) : this(
+        coroutineScope = policy.coroutineScope,
+        mainDispatcher = policy.mainDispatcher,
+        mutationOptions = policy.mutationOptions,
+        mutationReceiver = policy.mutationReceiver,
+        mutationStore = mutableMapOf(),
+        queryOptions = policy.queryOptions,
+        queryReceiver = policy.queryReceiver,
+        queryStore = mutableMapOf(),
+        queryCache = policy.queryCache,
+        errorRelaySource = policy.errorRelay,
+        memoryPressure = policy.memoryPressure,
+        networkConnectivity = policy.networkConnectivity,
+        networkResumeAfterDelay = policy.networkResumeAfterDelay,
+        networkResumeQueriesFilter = policy.networkResumeQueriesFilter,
+        windowVisibility = policy.windowVisibility,
+        windowResumeQueriesFilter = policy.windowResumeQueriesFilter,
+        batchSchedulerFactory = policy.batchSchedulerFactory
     )
-    private val batchScheduler: BatchScheduler = policy.batchSchedulerFactory.create(coroutineScope)
+
+    override val batchScheduler: BatchScheduler = batchSchedulerFactory.create(coroutineScope)
 
     private var mountedIds: Set<String> = emptySet()
     private var mountedScope: CoroutineScope? = null
 
+    // ----- SwrCacheView ----- //
+
+    override val mutationStoreView: Map<UniqueId, Mutation<*>>
+        get() = mutationStore
+
+    override val queryStoreView: Map<UniqueId, Query<*>>
+        get() = queryStore
 
     // ----- SwrClient ----- //
 
-    override val defaultMutationOptions: MutationOptions = policy.mutationOptions
-    override val defaultQueryOptions: QueryOptions = policy.queryOptions
-
     override val errorRelay: Flow<ErrorRecord>
-        get() = policy.errorRelay?.receiveAsFlow() ?: error("policy.errorRelay is not configured :(")
+        get() = errorRelaySource?.receiveAsFlow() ?: error("policy.errorRelay is not configured :(")
 
     override fun gc(level: MemoryPressureLevel) {
         when (level) {
@@ -97,27 +116,12 @@ open class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutabl
     }
 
     override fun purgeAll() {
-        purgeAllQueries()
-        purgeAllMutations()
-    }
-
-    private fun purgeAllQueries() {
-        val queryStoreCopy = queryStore.toMap()
-        queryStore.clear()
-        queryCache.clear()
-        queryStoreCopy.values.forEach { it.close() }
-    }
-
-    private fun purgeAllMutations() {
-        val mutationStoreCopy = mutationStore.toMap()
-        mutationStore.clear()
-        mutationStoreCopy.values.forEach { it.close() }
+        resetQueries()
+        resetMutations()
     }
 
     override fun perform(sideEffects: QueryEffect): Job {
-        return coroutineScope.launch {
-            with(this@SwrCache) { sideEffects() }
-        }
+        return launch(sideEffects)
     }
 
     override fun onMount(id: String) {
@@ -140,553 +144,37 @@ open class SwrCache(private val policy: SwrCachePolicy) : SwrClient, QueryMutabl
     }
 
     private suspend fun observeMemoryPressure() {
-        if (policy.memoryPressure == MemoryPressure.Unsupported) return
-        policy.memoryPressure.asFlow()
-            .collect { level ->
-                withContext(policy.mainDispatcher) {
-                    gc(level)
-                }
+        if (memoryPressure == MemoryPressure.Unsupported) return
+        observeOnMemoryPressure(memoryPressure) { level ->
+            withContext(mainDispatcher) {
+                gc(level)
             }
+        }
     }
 
     private suspend fun observeNetworkConnectivity() {
-        if (policy.networkConnectivity == NetworkConnectivity.Unsupported) return
-        policy.networkConnectivity.asFlow()
-            .distinctUntilChanged()
-            .scan(NetworkConnectivityEvent.Available to NetworkConnectivityEvent.Available) { acc, state -> state to acc.first }
-            .filter { it.first == NetworkConnectivityEvent.Available && it.second == NetworkConnectivityEvent.Lost }
-            .onEach { delay(policy.networkResumeAfterDelay) }
-            .collect {
-                perform {
-                    forEach(policy.networkResumeQueriesFilter) { id, _ ->
-                        queryStore[id]
-                            ?.takeIf { it.options.revalidateOnReconnect }
-                            ?.resume()
-                    }
+        if (networkConnectivity == NetworkConnectivity.Unsupported) return
+        observeOnNetworkReconnect(networkConnectivity, networkResumeAfterDelay) {
+            perform {
+                forEach(networkResumeQueriesFilter) { id, _ ->
+                    queryStore[id]
+                        ?.takeIf { it.options.revalidateOnReconnect }
+                        ?.resume()
                 }
             }
+        }
     }
 
     private suspend fun observeWindowVisibility() {
-        if (policy.windowVisibility == WindowVisibility.Unsupported) return
-        policy.windowVisibility.asFlow()
-            .distinctUntilChanged()
-            .scan(WindowVisibilityEvent.Foreground to WindowVisibilityEvent.Foreground) { acc, state -> state to acc.first }
-            .filter { it.first == WindowVisibilityEvent.Foreground && it.second == WindowVisibilityEvent.Background }
-            .collect {
-                perform {
-                    forEach(policy.windowResumeQueriesFilter) { id, _ ->
-                        queryStore[id]
-                            ?.takeIf { it.options.revalidateOnFocus }
-                            ?.resume()
-                    }
+        if (windowVisibility == WindowVisibility.Unsupported) return
+        observeOnWindowFocus(windowVisibility) {
+            perform {
+                forEach(windowResumeQueriesFilter) { id, _ ->
+                    queryStore[id]
+                        ?.takeIf { it.options.revalidateOnFocus }
+                        ?.resume()
                 }
             }
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    override fun <T, S> getMutation(
-        key: MutationKey<T, S>,
-        marker: Marker
-    ): MutationRef<T, S> {
-        val id = key.id
-        var mutation = mutationStore[id] as? ManagedMutation<T>
-        if (mutation == null) {
-            mutation = newMutation(
-                id = id,
-                options = key.onConfigureOptions()?.invoke(defaultMutationOptions) ?: defaultMutationOptions,
-                initialValue = MutationState<T>()
-            ).also { mutationStore[id] = it }
-        }
-        return MutationRef(
-            key = key,
-            marker = marker,
-            mutation = mutation
-        )
-    }
-
-    private fun <T> newMutation(
-        id: UniqueId,
-        options: MutationOptions,
-        initialValue: MutationState<T>
-    ): ManagedMutation<T> {
-        val scope = CoroutineScope(newCoroutineContext(coroutineScope))
-        val state = MutableStateFlow(initialValue)
-        val reducer = createMutationReducer<T>()
-        val dispatch: MutationDispatch<T> = { action ->
-            options.vvv(id) { "dispatching $action" }
-            state.value = reducer(state.value, action)
-        }
-        val notifier = MutationNotifier { effect -> perform(effect) }
-        val relay: MutationErrorRelay? = policy.errorRelay?.let { it::send }
-        val command = Channel<MutationCommand<T>>()
-        val actor = ActorBlockRunner(
-            scope = scope,
-            options = options,
-            onTimeout = { seq ->
-                scope.launch { batchScheduler.post { closeMutation<T>(id, seq) } }
-            }
-        ) {
-            for (c in command) {
-                options.vvv(id) { "next command $c" }
-                c.handle(
-                    ctx = ManagedMutationContext(
-                        receiver = mutationReceiver,
-                        options = options,
-                        state = state.value,
-                        dispatch = dispatch,
-                        notifier = notifier,
-                        relay = relay
-                    )
-                )
-            }
-        }
-        return ManagedMutation(
-            scope = scope,
-            id = id,
-            options = options,
-            state = state,
-            command = command,
-            actor = actor
-        )
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun <T> closeMutation(id: UniqueId, seq: ActorSequenceNumber) {
-        val mutation = mutationStore[id] as? ManagedMutation<T> ?: return
-        if (mutation.actor.seq == seq) {
-            mutationStore.remove(id)
-            mutation.close()
-        }
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    override fun <T> getQuery(
-        key: QueryKey<T>,
-        marker: Marker
-    ): QueryRef<T> {
-        val id = key.id
-        var query = queryStore[id] as? ManagedQuery<T>
-        if (query == null) {
-            query = newQuery(
-                id = id,
-                options = key.onConfigureOptions()?.invoke(defaultQueryOptions) ?: defaultQueryOptions,
-                initialValue = queryCache[key.id] as? QueryState<T> ?: newQueryState(key),
-                contentCacheable = key.contentCacheable
-            ).also { queryStore[id] = it }
-        }
-        return QueryRef(
-            key = key,
-            marker = marker,
-            query = query
-        )
-    }
-
-    private fun <T> newQuery(
-        id: UniqueId,
-        options: QueryOptions,
-        initialValue: QueryState<T>,
-        contentCacheable: QueryContentCacheable<T>?
-    ): ManagedQuery<T> {
-        val scope = CoroutineScope(newCoroutineContext(coroutineScope))
-        val event = MutableSharedFlow<QueryEvent>(
-            extraBufferCapacity = 1,
-            onBufferOverflow = BufferOverflow.DROP_OLDEST
-        )
-        val state = MutableStateFlow(initialValue)
-        val reducer = createQueryReducer<T>()
-        val dispatch: QueryDispatch<T> = { action ->
-            options.vvv(id) { "dispatching $action" }
-            state.value = reducer(state.value, action)
-        }
-        val relay: QueryErrorRelay? = policy.errorRelay?.let { it::send }
-        val command = Channel<QueryCommand<T>>()
-        val actor = ActorBlockRunner(
-            scope = scope,
-            options = options,
-            onTimeout = { seq ->
-                scope.launch { batchScheduler.post { closeQuery<T>(id, seq) } }
-            },
-        ) {
-            for (c in command) {
-                options.vvv(id) { "next command $c" }
-                c.handle(
-                    ctx = ManagedQueryContext(
-                        receiver = queryReceiver,
-                        options = options,
-                        state = state.value,
-                        dispatch = dispatch,
-                        relay = relay
-                    )
-                )
-            }
-        }
-        return ManagedQuery(
-            scope = scope,
-            id = id,
-            options = options,
-            event = event,
-            state = state,
-            command = command,
-            actor = actor,
-            dispatch = dispatch,
-            cacheable = contentCacheable
-        )
-    }
-
-    private fun <T> newQueryState(key: QueryKey<T>): QueryState<T> {
-        val onInitialData = key.onInitialData() ?: return QueryState()
-        val initialData = with(this) { onInitialData() } ?: return QueryState()
-        return QueryState.success(data = initialData, dataUpdatedAt = 0)
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun <T> closeQuery(id: UniqueId, seq: ActorSequenceNumber) {
-        val query = queryStore[id] as? ManagedQuery<T> ?: return
-        if (query.actor.seq == seq) {
-            queryStore.remove(id)
-            query.close()
-            saveToCache(query)
-        }
-    }
-
-    private fun <T> saveToCache(query: ManagedQuery<T>) {
-        val lastValue = query.state.value
-        val ttl = query.options.gcTime
-        val saveable = lastValue.isSuccess && ttl.isPositive()
-        if (saveable && query.isCacheable(lastValue.reply)) {
-            queryCache.set(query.id, lastValue, ttl)
-            query.options.vvv(query.id) { "cached(ttl=$ttl)" }
-        }
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    override fun <T, S> getInfiniteQuery(
-        key: InfiniteQueryKey<T, S>,
-        marker: Marker
-    ): InfiniteQueryRef<T, S> {
-        val id = key.id
-        var query = queryStore[id] as? ManagedQuery<QueryChunks<T, S>>
-        if (query == null) {
-            query = newInfiniteQuery(
-                id = id,
-                options = key.onConfigureOptions()?.invoke(defaultQueryOptions) ?: defaultQueryOptions,
-                initialValue = queryCache[id] as? QueryState<QueryChunks<T, S>> ?: QueryState(),
-                contentCacheable = key.contentCacheable
-            ).also { queryStore[id] = it }
-        }
-        return InfiniteQueryRef(
-            key = key,
-            marker = marker,
-            query = query
-        )
-    }
-
-    private fun <T, S> newInfiniteQuery(
-        id: UniqueId,
-        options: QueryOptions,
-        initialValue: QueryState<QueryChunks<T, S>>,
-        contentCacheable: QueryContentCacheable<QueryChunks<T, S>>?
-    ): ManagedQuery<QueryChunks<T, S>> {
-        return newQuery(
-            id = id,
-            options = options,
-            initialValue = initialValue,
-            contentCacheable = contentCacheable
-        )
-    }
-
-    override fun <T> prefetchQuery(
-        key: QueryKey<T>,
-        marker: Marker
-    ): Job {
-        val scope = CoroutineScope(policy.mainDispatcher)
-        val query = getQuery(key, marker).also { it.launchIn(scope) }
-        return coroutineScope.launch {
-            try {
-                val options = key.onConfigureOptions()?.invoke(defaultQueryOptions) ?: defaultQueryOptions
-                withTimeoutOrNull(options.prefetchWindowTime) {
-                    query.resume()
-                }
-            } finally {
-                scope.cancel()
-            }
-        }
-    }
-
-    override fun <T, S> prefetchInfiniteQuery(
-        key: InfiniteQueryKey<T, S>,
-        marker: Marker
-    ): Job {
-        val scope = CoroutineScope(policy.mainDispatcher)
-        val query = getInfiniteQuery(key, marker).also { it.launchIn(scope) }
-        return coroutineScope.launch {
-            try {
-                val options = key.onConfigureOptions()?.invoke(defaultQueryOptions) ?: defaultQueryOptions
-                withTimeoutOrNull(options.prefetchWindowTime) {
-                    query.resume()
-                }
-            } finally {
-                scope.cancel()
-            }
-        }
-    }
-
-    // ----- QueryMutableClient ----- //
-
-    @Suppress("UNCHECKED_CAST")
-    override fun <T> getQueryData(id: QueryId<T>): T? {
-        val query = queryStore[id] as? ManagedQuery<T>
-        if (query != null) {
-            return query.state.value.reply.getOrNull()
-        }
-        val state = queryCache[id] as? QueryState<T>
-        if (state != null) {
-            return state.reply.getOrNull()
-        }
-        return null
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    override fun <T, S> getInfiniteQueryData(id: InfiniteQueryId<T, S>): QueryChunks<T, S>? {
-        val query = queryStore[id] as? ManagedQuery<QueryChunks<T, S>>
-        if (query != null) {
-            return query.state.value.reply.getOrNull()
-        }
-        val state = queryCache[id] as? QueryState<QueryChunks<T, S>>
-        if (state != null) {
-            return state.reply.getOrNull()
-        }
-        return null
-    }
-
-    override fun <T> updateQueryData(
-        id: QueryId<T>,
-        edit: T.() -> T
-    ) {
-        val data = getQueryData(id)
-        if (data != null) {
-            setQueryData(id, data.edit())
-        }
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun <T> setQueryData(id: QueryId<T>, data: T) {
-        val query = queryStore[id] as? ManagedQuery<T>
-        query?.forceUpdate(data)
-        queryCache.swap(id) {
-            this as QueryState<T>
-            patch(data)
-        }
-    }
-
-    override fun <T, S> updateInfiniteQueryData(
-        id: InfiniteQueryId<T, S>,
-        edit: QueryChunks<T, S>.() -> QueryChunks<T, S>
-    ) {
-        val data = getInfiniteQueryData(id)
-        if (!data.isNullOrEmpty()) {
-            setInfiniteQueryData(id, data.edit())
-        }
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun <T, S> setInfiniteQueryData(id: InfiniteQueryId<T, S>, data: QueryChunks<T, S>) {
-        val query = queryStore[id] as? ManagedQuery<QueryChunks<T, S>>
-        query?.forceUpdate(data)
-        queryCache.swap(id) {
-            this as QueryState<QueryChunks<T, S>>
-            patch(data)
-        }
-    }
-
-    override fun invalidateQueries(filter: InvalidateQueriesFilter) {
-        forEach(filter, ::invalidate)
-    }
-
-    override fun <U : UniqueId> invalidateQueriesBy(vararg ids: U) {
-        require(ids.isNotEmpty())
-        ids.forEach { id ->
-            invalidate(id, QueryFilterType.Active)
-            invalidate(id, QueryFilterType.Inactive)
-        }
-    }
-
-    private fun invalidate(id: UniqueId, type: QueryFilterType) {
-        when (type) {
-            QueryFilterType.Active -> queryStore[id]?.invalidate()
-            QueryFilterType.Inactive -> queryCache.swap(id) { copy(isInvalidated = true) }
-        }
-    }
-
-    override fun removeQueries(filter: RemoveQueriesFilter) {
-        forEach(filter, ::remove)
-    }
-
-    override fun <U : UniqueId> removeQueriesBy(vararg ids: U) {
-        require(ids.isNotEmpty())
-        ids.forEach { id ->
-            remove(id, QueryFilterType.Active)
-            remove(id, QueryFilterType.Inactive)
-        }
-    }
-
-    private fun remove(id: UniqueId, type: QueryFilterType) {
-        when (type) {
-            QueryFilterType.Active -> queryStore.remove(id)?.close()
-            QueryFilterType.Inactive -> queryCache.delete(id)
-        }
-    }
-
-    override fun resumeQueries(filter: ResumeQueriesFilter) {
-        // NOTE: resume targets only active queries.
-        forEach(filter) { id, _ -> resume(id) }
-    }
-
-    override fun <U : UniqueId> resumeQueriesBy(vararg ids: U) {
-        require(ids.isNotEmpty())
-        ids.forEach { id -> resume(id) }
-    }
-
-    private fun resume(id: UniqueId) {
-        queryStore[id]?.resume()
-    }
-
-    private fun forEach(
-        filter: QueryFilter,
-        action: (UniqueId, QueryFilterType) -> Unit
-    ) {
-        if (filter.type == null || filter.type == QueryFilterType.Active) {
-            forEach(QueryFilterType.Active, filter.keys, filter.predicate) { id ->
-                action(id, QueryFilterType.Active)
-            }
-        }
-        if (filter.type == null || filter.type == QueryFilterType.Inactive) {
-            forEach(QueryFilterType.Inactive, filter.keys, filter.predicate) { id ->
-                action(id, QueryFilterType.Inactive)
-            }
-        }
-    }
-
-    private fun forEach(
-        type: QueryFilterType,
-        keys: Array<SurrogateKey>?,
-        predicate: ((QueryModel<*>) -> Boolean)?,
-        action: (UniqueId) -> Unit
-    ) {
-        val queryIds = when (type) {
-            QueryFilterType.Active -> queryStore.keys
-            QueryFilterType.Inactive -> queryCache.keys
-        }
-        queryIds.toSet()
-            .asSequence()
-            .filter { id ->
-                if (keys.isNullOrEmpty()) true
-                else keys.any { id.tags.contains(it) }
-            }
-            .filter { id ->
-                if (predicate == null) true
-                else isMatch(id, type, predicate)
-            }
-            .forEach(action)
-    }
-
-    private fun isMatch(
-        id: UniqueId,
-        type: QueryFilterType,
-        predicate: ((QueryModel<*>) -> Boolean)
-    ): Boolean {
-        val model = when (type) {
-            QueryFilterType.Active -> queryStore[id]?.state?.value
-            QueryFilterType.Inactive -> queryCache[id]
-        }
-        return model?.let(predicate) ?: false
-    }
-
-
-    internal class ManagedMutation<T>(
-        val scope: CoroutineScope,
-        val id: UniqueId,
-        val options: MutationOptions,
-        override val state: StateFlow<MutationState<T>>,
-        override val command: SendChannel<MutationCommand<T>>,
-        internal val actor: ActorBlockRunner,
-    ) : Mutation<T> {
-
-        override fun launchIn(scope: CoroutineScope): Job {
-            return actor.launchIn(scope)
-        }
-
-        fun close() {
-            scope.cancel()
-            command.close()
-        }
-    }
-
-    internal class ManagedMutationContext<T>(
-        override val receiver: MutationReceiver,
-        override val options: MutationOptions,
-        override val state: MutationState<T>,
-        override val dispatch: MutationDispatch<T>,
-        override val notifier: MutationNotifier,
-        override val relay: MutationErrorRelay?
-    ) : MutationCommand.Context<T>
-
-    internal class ManagedQuery<T>(
-        val scope: CoroutineScope,
-        val id: UniqueId,
-        val options: QueryOptions,
-        override val event: MutableSharedFlow<QueryEvent>,
-        override val state: StateFlow<QueryState<T>>,
-        override val command: SendChannel<QueryCommand<T>>,
-        internal val actor: ActorBlockRunner,
-        private val dispatch: QueryDispatch<T>,
-        private val cacheable: QueryContentCacheable<T>?,
-    ) : Query<T> {
-
-        override fun launchIn(scope: CoroutineScope): Job {
-            return actor.launchIn(scope)
-        }
-
-        fun close() {
-            scope.cancel()
-            command.close()
-        }
-
-        fun invalidate() {
-            dispatch(QueryAction.Invalidate)
-            event.tryEmit(QueryEvent.Invalidate)
-        }
-
-        fun resume() {
-            event.tryEmit(QueryEvent.Resume)
-        }
-
-        fun forceUpdate(data: T) {
-            dispatch(QueryAction.ForceUpdate(data = data, dataUpdatedAt = epoch()))
-        }
-
-        fun isCacheable(reply: Reply<T>): Boolean {
-            return when (reply) {
-                is Reply.None -> false
-                is Reply.Some<T> -> {
-                    cacheable?.invoke(reply.value) ?: true
-                }
-            }
-        }
-    }
-
-    internal class ManagedQueryContext<T>(
-        override val receiver: QueryReceiver,
-        override val options: QueryOptions,
-        override val state: QueryState<T>,
-        override val dispatch: QueryDispatch<T>,
-        override val relay: QueryErrorRelay?
-    ) : QueryCommand.Context<T>
-
-    companion object {
-        internal fun newCoroutineContext(parent: CoroutineScope): CoroutineContext {
-            return parent.coroutineContext + Job(parent.coroutineContext[Job])
         }
     }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCacheInternal.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCacheInternal.kt
@@ -1,0 +1,579 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import soil.query.annotation.InternalSoilQueryApi
+import soil.query.core.ActorBlockRunner
+import soil.query.core.ActorSequenceNumber
+import soil.query.core.BatchScheduler
+import soil.query.core.ErrorRelay
+import soil.query.core.HasActorSequence
+import soil.query.core.Marker
+import soil.query.core.Reply
+import soil.query.core.SurrogateKey
+import soil.query.core.UniqueId
+import soil.query.core.epoch
+import soil.query.core.getOrNull
+import soil.query.core.vvv
+import kotlin.coroutines.CoroutineContext
+
+@InternalSoilQueryApi
+abstract class SwrCacheInternal : MutationClient, QueryClient, QueryMutableClient {
+
+    protected abstract val coroutineScope: CoroutineScope
+    protected abstract val mainDispatcher: CoroutineDispatcher
+    protected abstract val mutationOptions: MutationOptions
+    protected abstract val mutationReceiver: MutationReceiver
+    protected abstract val mutationStore: MutableMap<UniqueId, ManagedMutation<*>>
+    protected abstract val queryOptions: QueryOptions
+    protected abstract val queryReceiver: QueryReceiver
+    protected abstract val queryStore: MutableMap<UniqueId, ManagedQuery<*>>
+    protected abstract val queryCache: QueryCache
+    protected abstract val batchScheduler: BatchScheduler
+    protected abstract val errorRelaySource: ErrorRelay?
+
+    protected fun launch(effectBlock: QueryEffect): Job {
+        return coroutineScope.launch {
+            with(this@SwrCacheInternal) { effectBlock() }
+        }
+    }
+
+    protected fun resetQueries() {
+        val queryStoreCopy = queryStore.toMap()
+        queryStore.clear()
+        queryCache.clear()
+        queryStoreCopy.values.forEach { it.close() }
+    }
+
+    protected fun resetMutations() {
+        val mutationStoreCopy = mutationStore.toMap()
+        mutationStore.clear()
+        mutationStoreCopy.values.forEach { it.close() }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T, S> getMutation(
+        key: MutationKey<T, S>,
+        marker: Marker
+    ): MutationRef<T, S> {
+        val id = key.id
+        var mutation = mutationStore[id] as? ManagedMutation<T>
+        if (mutation == null) {
+            mutation = newMutation(
+                id = id,
+                options = key.onConfigureOptions()?.invoke(mutationOptions) ?: mutationOptions,
+                initialValue = MutationState<T>()
+            ).also { mutationStore[id] = it }
+        }
+        return MutationRef(
+            key = key,
+            marker = marker,
+            mutation = mutation
+        )
+    }
+
+    private fun <T> newMutation(
+        id: UniqueId,
+        options: MutationOptions,
+        initialValue: MutationState<T>
+    ): ManagedMutation<T> {
+        val scope = CoroutineScope(newCoroutineContext(coroutineScope))
+        val state = MutableStateFlow(initialValue)
+        val reducer = createMutationReducer<T>()
+        val dispatch: MutationDispatch<T> = { action ->
+            options.vvv(id) { "dispatching $action" }
+            state.value = reducer(state.value, action)
+        }
+        val notifier = MutationNotifier { effect -> launch(effect) }
+        val relay: MutationErrorRelay? = errorRelaySource?.let { it::send }
+        val command = Channel<MutationCommand<T>>()
+        val actor = ActorBlockRunner(
+            scope = scope,
+            options = options,
+            onTimeout = { seq ->
+                scope.launch { batchScheduler.post { closeMutation<T>(id, seq) } }
+            }
+        ) {
+            for (c in command) {
+                options.vvv(id) { "next command $c" }
+                c.handle(
+                    ctx = ManagedMutationContext(
+                        receiver = mutationReceiver,
+                        options = options,
+                        state = state.value,
+                        dispatch = dispatch,
+                        notifier = notifier,
+                        relay = relay
+                    )
+                )
+            }
+        }
+        return ManagedMutation(
+            id = id,
+            options = options,
+            state = state,
+            command = command,
+            scope = scope,
+            actor = actor
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> closeMutation(id: UniqueId, seq: ActorSequenceNumber) {
+        val mutation = mutationStore[id] as? ManagedMutation<T> ?: return
+        if (mutation.seq == seq) {
+            mutationStore.remove(id)
+            mutation.close()
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getQuery(
+        key: QueryKey<T>,
+        marker: Marker
+    ): QueryRef<T> {
+        val id = key.id
+        var query = queryStore[id] as? ManagedQuery<T>
+        if (query == null) {
+            query = newQuery(
+                id = id,
+                options = key.onConfigureOptions()?.invoke(queryOptions) ?: queryOptions,
+                initialValue = queryCache[key.id] as? QueryState<T> ?: newQueryState(key),
+                contentCacheable = key.contentCacheable
+            ).also { queryStore[id] = it }
+        }
+        return QueryRef(
+            key = key,
+            marker = marker,
+            query = query
+        )
+    }
+
+    private fun <T> newQuery(
+        id: UniqueId,
+        options: QueryOptions,
+        initialValue: QueryState<T>,
+        contentCacheable: QueryContentCacheable<T>?
+    ): ManagedQuery<T> {
+        val scope = CoroutineScope(newCoroutineContext(coroutineScope))
+        val event = MutableSharedFlow<QueryEvent>(
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST
+        )
+        val state = MutableStateFlow(initialValue)
+        val reducer = createQueryReducer<T>()
+        val dispatch: QueryDispatch<T> = { action ->
+            options.vvv(id) { "dispatching $action" }
+            state.value = reducer(state.value, action)
+        }
+        val relay: QueryErrorRelay? = errorRelaySource?.let { it::send }
+        val command = Channel<QueryCommand<T>>()
+        val actor = ActorBlockRunner(
+            scope = scope,
+            options = options,
+            onTimeout = { seq ->
+                scope.launch { batchScheduler.post { closeQuery<T>(id, seq) } }
+            },
+        ) {
+            for (c in command) {
+                options.vvv(id) { "next command $c" }
+                c.handle(
+                    ctx = ManagedQueryContext(
+                        receiver = queryReceiver,
+                        options = options,
+                        state = state.value,
+                        dispatch = dispatch,
+                        relay = relay
+                    )
+                )
+            }
+        }
+        return ManagedQuery(
+            id = id,
+            options = options,
+            event = event,
+            state = state,
+            command = command,
+            scope = scope,
+            actor = actor,
+            dispatch = dispatch,
+            cacheable = contentCacheable
+        )
+    }
+
+    private fun <T> newQueryState(key: QueryKey<T>): QueryState<T> {
+        val onInitialData = key.onInitialData() ?: return QueryState()
+        val initialData = with(this) { onInitialData() } ?: return QueryState()
+        return QueryState.success(data = initialData, dataUpdatedAt = 0)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> closeQuery(id: UniqueId, seq: ActorSequenceNumber) {
+        val query = queryStore[id] as? ManagedQuery<T> ?: return
+        if (query.seq == seq) {
+            queryStore.remove(id)
+            query.close()
+            saveToCache(query)
+        }
+    }
+
+    private fun <T> saveToCache(query: ManagedQuery<T>) {
+        val lastValue = query.state.value
+        val ttl = query.options.gcTime
+        val saveable = lastValue.isSuccess && ttl.isPositive()
+        if (saveable && query.isCacheable(lastValue.reply)) {
+            queryCache.set(query.id, lastValue, ttl)
+            query.options.vvv(query.id) { "cached(ttl=$ttl)" }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T, S> getInfiniteQuery(
+        key: InfiniteQueryKey<T, S>,
+        marker: Marker
+    ): InfiniteQueryRef<T, S> {
+        val id = key.id
+        var query = queryStore[id] as? ManagedQuery<QueryChunks<T, S>>
+        if (query == null) {
+            query = newInfiniteQuery(
+                id = id,
+                options = key.onConfigureOptions()?.invoke(queryOptions) ?: queryOptions,
+                initialValue = queryCache[id] as? QueryState<QueryChunks<T, S>> ?: QueryState(),
+                contentCacheable = key.contentCacheable
+            ).also { queryStore[id] = it }
+        }
+        return InfiniteQueryRef(
+            key = key,
+            marker = marker,
+            query = query
+        )
+    }
+
+    private fun <T, S> newInfiniteQuery(
+        id: UniqueId,
+        options: QueryOptions,
+        initialValue: QueryState<QueryChunks<T, S>>,
+        contentCacheable: QueryContentCacheable<QueryChunks<T, S>>?
+    ): ManagedQuery<QueryChunks<T, S>> {
+        return newQuery(
+            id = id,
+            options = options,
+            initialValue = initialValue,
+            contentCacheable = contentCacheable
+        )
+    }
+
+    override fun <T> prefetchQuery(
+        key: QueryKey<T>,
+        marker: Marker
+    ): Job {
+        val scope = CoroutineScope(mainDispatcher)
+        val query = getQuery(key, marker).also { it.launchIn(scope) }
+        return coroutineScope.launch {
+            try {
+                val options = key.onConfigureOptions()?.invoke(queryOptions) ?: queryOptions
+                withTimeoutOrNull(options.prefetchWindowTime) {
+                    query.resume()
+                }
+            } finally {
+                scope.cancel()
+            }
+        }
+    }
+
+    override fun <T, S> prefetchInfiniteQuery(
+        key: InfiniteQueryKey<T, S>,
+        marker: Marker
+    ): Job {
+        val scope = CoroutineScope(mainDispatcher)
+        val query = getInfiniteQuery(key, marker).also { it.launchIn(scope) }
+        return coroutineScope.launch {
+            try {
+                val options = key.onConfigureOptions()?.invoke(queryOptions) ?: queryOptions
+                withTimeoutOrNull(options.prefetchWindowTime) {
+                    query.resume()
+                }
+            } finally {
+                scope.cancel()
+            }
+        }
+    }
+
+    // ----- QueryMutableClient ----- //
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getQueryData(id: QueryId<T>): T? {
+        val query = queryStore[id] as? ManagedQuery<T>
+        if (query != null) {
+            return query.state.value.reply.getOrNull()
+        }
+        val state = queryCache[id] as? QueryState<T>
+        if (state != null) {
+            return state.reply.getOrNull()
+        }
+        return null
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T, S> getInfiniteQueryData(id: InfiniteQueryId<T, S>): QueryChunks<T, S>? {
+        val query = queryStore[id] as? ManagedQuery<QueryChunks<T, S>>
+        if (query != null) {
+            return query.state.value.reply.getOrNull()
+        }
+        val state = queryCache[id] as? QueryState<QueryChunks<T, S>>
+        if (state != null) {
+            return state.reply.getOrNull()
+        }
+        return null
+    }
+
+    override fun <T> updateQueryData(
+        id: QueryId<T>,
+        edit: T.() -> T
+    ) {
+        val data = getQueryData(id)
+        if (data != null) {
+            setQueryData(id, data.edit())
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> setQueryData(id: QueryId<T>, data: T) {
+        val query = queryStore[id] as? ManagedQuery<T>
+        query?.forceUpdate(data)
+        queryCache.swap(id) {
+            this as QueryState<T>
+            patch(data)
+        }
+    }
+
+    override fun <T, S> updateInfiniteQueryData(
+        id: InfiniteQueryId<T, S>,
+        edit: QueryChunks<T, S>.() -> QueryChunks<T, S>
+    ) {
+        val data = getInfiniteQueryData(id)
+        if (!data.isNullOrEmpty()) {
+            setInfiniteQueryData(id, data.edit())
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T, S> setInfiniteQueryData(id: InfiniteQueryId<T, S>, data: QueryChunks<T, S>) {
+        val query = queryStore[id] as? ManagedQuery<QueryChunks<T, S>>
+        query?.forceUpdate(data)
+        queryCache.swap(id) {
+            this as QueryState<QueryChunks<T, S>>
+            patch(data)
+        }
+    }
+
+    override fun invalidateQueries(filter: InvalidateQueriesFilter) {
+        forEach(filter, ::invalidate)
+    }
+
+    override fun <U : UniqueId> invalidateQueriesBy(vararg ids: U) {
+        require(ids.isNotEmpty())
+        ids.forEach { id ->
+            invalidate(id, QueryFilterType.Active)
+            invalidate(id, QueryFilterType.Inactive)
+        }
+    }
+
+    private fun invalidate(id: UniqueId, type: QueryFilterType) {
+        when (type) {
+            QueryFilterType.Active -> queryStore[id]?.invalidate()
+            QueryFilterType.Inactive -> queryCache.swap(id) { copy(isInvalidated = true) }
+        }
+    }
+
+    override fun removeQueries(filter: RemoveQueriesFilter) {
+        forEach(filter, ::remove)
+    }
+
+    override fun <U : UniqueId> removeQueriesBy(vararg ids: U) {
+        require(ids.isNotEmpty())
+        ids.forEach { id ->
+            remove(id, QueryFilterType.Active)
+            remove(id, QueryFilterType.Inactive)
+        }
+    }
+
+    private fun remove(id: UniqueId, type: QueryFilterType) {
+        when (type) {
+            QueryFilterType.Active -> queryStore.remove(id)?.close()
+            QueryFilterType.Inactive -> queryCache.delete(id)
+        }
+    }
+
+    override fun resumeQueries(filter: ResumeQueriesFilter) {
+        // NOTE: resume targets only active queries.
+        forEach(filter) { id, _ -> resume(id) }
+    }
+
+    override fun <U : UniqueId> resumeQueriesBy(vararg ids: U) {
+        require(ids.isNotEmpty())
+        ids.forEach { id -> resume(id) }
+    }
+
+    private fun resume(id: UniqueId) {
+        queryStore[id]?.resume()
+    }
+
+    protected fun forEach(
+        filter: QueryFilter,
+        action: (UniqueId, QueryFilterType) -> Unit
+    ) {
+        if (filter.type == null || filter.type == QueryFilterType.Active) {
+            forEach(QueryFilterType.Active, filter.keys, filter.predicate) { id ->
+                action(id, QueryFilterType.Active)
+            }
+        }
+        if (filter.type == null || filter.type == QueryFilterType.Inactive) {
+            forEach(QueryFilterType.Inactive, filter.keys, filter.predicate) { id ->
+                action(id, QueryFilterType.Inactive)
+            }
+        }
+    }
+
+    private fun forEach(
+        type: QueryFilterType,
+        keys: Array<SurrogateKey>?,
+        predicate: ((QueryModel<*>) -> Boolean)?,
+        action: (UniqueId) -> Unit
+    ) {
+        val queryIds = when (type) {
+            QueryFilterType.Active -> queryStore.keys
+            QueryFilterType.Inactive -> queryCache.keys
+        }
+        queryIds.toSet()
+            .asSequence()
+            .filter { id ->
+                if (keys.isNullOrEmpty()) true
+                else keys.any { id.tags.contains(it) }
+            }
+            .filter { id ->
+                if (predicate == null) true
+                else isMatch(id, type, predicate)
+            }
+            .forEach(action)
+    }
+
+    private fun isMatch(
+        id: UniqueId,
+        type: QueryFilterType,
+        predicate: ((QueryModel<*>) -> Boolean)
+    ): Boolean {
+        val model = when (type) {
+            QueryFilterType.Active -> queryStore[id]?.state?.value
+            QueryFilterType.Inactive -> queryCache[id]
+        }
+        return model?.let(predicate) ?: false
+    }
+
+    @InternalSoilQueryApi
+    class ManagedMutation<T> internal constructor(
+        val id: UniqueId,
+        val options: MutationOptions,
+        override val state: StateFlow<MutationState<T>>,
+        override val command: SendChannel<MutationCommand<T>>,
+        private val scope: CoroutineScope,
+        private val actor: ActorBlockRunner,
+    ) : Mutation<T>, HasActorSequence {
+
+        override val seq: ActorSequenceNumber
+            get() = actor.seq
+
+        override fun launchIn(scope: CoroutineScope): Job {
+            return actor.launchIn(scope)
+        }
+
+        fun close() {
+            scope.cancel()
+            command.close()
+        }
+    }
+
+    internal class ManagedMutationContext<T>(
+        override val receiver: MutationReceiver,
+        override val options: MutationOptions,
+        override val state: MutationState<T>,
+        override val dispatch: MutationDispatch<T>,
+        override val notifier: MutationNotifier,
+        override val relay: MutationErrorRelay?
+    ) : MutationCommand.Context<T>
+
+    @InternalSoilQueryApi
+    class ManagedQuery<T> internal constructor(
+        val id: UniqueId,
+        val options: QueryOptions,
+        override val event: MutableSharedFlow<QueryEvent>,
+        override val state: StateFlow<QueryState<T>>,
+        override val command: SendChannel<QueryCommand<T>>,
+        private val scope: CoroutineScope,
+        private val actor: ActorBlockRunner,
+        private val dispatch: QueryDispatch<T>,
+        private val cacheable: QueryContentCacheable<T>?,
+    ) : Query<T>, HasActorSequence {
+
+        override val seq: ActorSequenceNumber
+            get() = actor.seq
+
+        override fun launchIn(scope: CoroutineScope): Job {
+            return actor.launchIn(scope)
+        }
+
+        fun close() {
+            scope.cancel()
+            command.close()
+        }
+
+        fun invalidate() {
+            dispatch(QueryAction.Invalidate)
+            event.tryEmit(QueryEvent.Invalidate)
+        }
+
+        fun resume() {
+            event.tryEmit(QueryEvent.Resume)
+        }
+
+        fun forceUpdate(data: T) {
+            dispatch(QueryAction.ForceUpdate(data = data, dataUpdatedAt = epoch()))
+        }
+
+        fun isCacheable(reply: Reply<T>): Boolean {
+            return when (reply) {
+                is Reply.None -> false
+                is Reply.Some<T> -> {
+                    cacheable?.invoke(reply.value) ?: true
+                }
+            }
+        }
+    }
+
+    internal class ManagedQueryContext<T>(
+        override val receiver: QueryReceiver,
+        override val options: QueryOptions,
+        override val state: QueryState<T>,
+        override val dispatch: QueryDispatch<T>,
+        override val relay: QueryErrorRelay?
+    ) : QueryCommand.Context<T>
+
+    companion object {
+        internal fun newCoroutineContext(parent: CoroutineScope): CoroutineContext {
+            return parent.coroutineContext + Job(parent.coroutineContext[Job])
+        }
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlus.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlus.kt
@@ -3,227 +3,181 @@
 
 package soil.query
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import soil.query.annotation.ExperimentalSoilQueryApi
-import soil.query.core.ActorBlockRunner
-import soil.query.core.ActorSequenceNumber
+import soil.query.annotation.InternalSoilQueryApi
 import soil.query.core.BatchScheduler
-import soil.query.core.Marker
+import soil.query.core.BatchSchedulerFactory
+import soil.query.core.ErrorRecord
+import soil.query.core.ErrorRelay
+import soil.query.core.MemoryPressure
 import soil.query.core.MemoryPressureLevel
-import soil.query.core.Reply
+import soil.query.core.NetworkConnectivity
 import soil.query.core.UniqueId
-import soil.query.core.WhileSubscribedAlt
-import soil.query.core.epoch
-import soil.query.core.retryWithExponentialBackoff
-import soil.query.core.toResultFlow
-import soil.query.core.vvv
+import soil.query.core.WindowVisibility
+import soil.query.core.observeOnMemoryPressure
+import soil.query.core.observeOnNetworkReconnect
+import soil.query.core.observeOnWindowFocus
+import kotlin.time.Duration
 
 /**
  * An enhanced version of [SwrCache] that integrates [SwrClientPlus] into SwrCache.
  */
 @ExperimentalSoilQueryApi
-class SwrCachePlus(private val policy: SwrCachePlusPolicy) : SwrCache(policy), SwrClientPlus {
+@OptIn(InternalSoilQueryApi::class)
+class SwrCachePlus internal constructor(
+    override val coroutineScope: CoroutineScope,
+    override val mainDispatcher: CoroutineDispatcher,
+    override val mutationOptions: MutationOptions,
+    override val mutationReceiver: MutationReceiver,
+    override val mutationStore: MutableMap<UniqueId, ManagedMutation<*>>,
+    override val queryOptions: QueryOptions,
+    override val queryReceiver: QueryReceiver,
+    override val queryStore: MutableMap<UniqueId, ManagedQuery<*>>,
+    override val queryCache: QueryCache,
+    override val subscriptionOptions: SubscriptionOptions,
+    override val subscriptionReceiver: SubscriptionReceiver,
+    override val subscriptionStore: MutableMap<UniqueId, ManagedSubscription<*>>,
+    override val subscriptionCache: SubscriptionCache,
+    override val errorRelaySource: ErrorRelay?,
+    private val memoryPressure: MemoryPressure,
+    private val networkConnectivity: NetworkConnectivity,
+    private val networkResumeAfterDelay: Duration,
+    private val networkResumeQueriesFilter: ResumeQueriesFilter,
+    private val windowVisibility: WindowVisibility,
+    private val windowResumeQueriesFilter: ResumeQueriesFilter,
+    batchSchedulerFactory: BatchSchedulerFactory
+) : SwrCachePlusInternal(), SwrCachePlusView, SwrClientPlus {
 
     @Suppress("unused")
     constructor(coroutineScope: CoroutineScope) : this(SwrCachePlusPolicy(coroutineScope))
 
-    private val subscriptionReceiver = policy.subscriptionReceiver
-    private val subscriptionStore: MutableMap<UniqueId, ManagedSubscription<*>> = mutableMapOf()
-    private val subscriptionCache = policy.subscriptionCache
-
-    private val coroutineScope: CoroutineScope = CoroutineScope(
-        context = newCoroutineContext(policy.coroutineScope)
+    constructor(policy: SwrCachePlusPolicy) : this(
+        coroutineScope = policy.coroutineScope,
+        mainDispatcher = policy.mainDispatcher,
+        mutationOptions = policy.mutationOptions,
+        mutationReceiver = policy.mutationReceiver,
+        mutationStore = mutableMapOf(),
+        queryOptions = policy.queryOptions,
+        queryReceiver = policy.queryReceiver,
+        queryStore = mutableMapOf(),
+        queryCache = policy.queryCache,
+        subscriptionOptions = policy.subscriptionOptions,
+        subscriptionReceiver = policy.subscriptionReceiver,
+        subscriptionStore = mutableMapOf(),
+        subscriptionCache = policy.subscriptionCache,
+        errorRelaySource = policy.errorRelay,
+        memoryPressure = policy.memoryPressure,
+        networkConnectivity = policy.networkConnectivity,
+        networkResumeAfterDelay = policy.networkResumeAfterDelay,
+        networkResumeQueriesFilter = policy.networkResumeQueriesFilter,
+        windowVisibility = policy.windowVisibility,
+        windowResumeQueriesFilter = policy.windowResumeQueriesFilter,
+        batchSchedulerFactory = policy.batchSchedulerFactory
     )
-    private val batchScheduler: BatchScheduler = policy.batchSchedulerFactory.create(coroutineScope)
 
+    override val batchScheduler: BatchScheduler = batchSchedulerFactory.create(coroutineScope)
+
+    private var mountedIds: Set<String> = emptySet()
+    private var mountedScope: CoroutineScope? = null
+
+    // ----- SwrCacheView ----- //
+
+    override val mutationStoreView: Map<UniqueId, Mutation<*>>
+        get() = mutationStore
+
+    override val queryStoreView: Map<UniqueId, Query<*>>
+        get() = queryStore
+
+    override val subscriptionStoreView: Map<UniqueId, Subscription<*>>
+        get() = subscriptionStore
 
     // ----- SwrClientPlus ----- //
 
-    override val defaultSubscriptionOptions: SubscriptionOptions = policy.subscriptionOptions
+    override val errorRelay: Flow<ErrorRecord>
+        get() = errorRelaySource?.receiveAsFlow() ?: error("policy.errorRelay is not configured :(")
 
     override fun gc(level: MemoryPressureLevel) {
-        super.gc(level)
         when (level) {
-            MemoryPressureLevel.Low -> subscriptionCache.evict()
-            MemoryPressureLevel.High -> subscriptionCache.clear()
+            MemoryPressureLevel.Low -> {
+                queryCache.evict()
+                subscriptionCache.evict()
+            }
+
+            MemoryPressureLevel.High -> {
+                queryCache.clear()
+                subscriptionCache.clear()
+            }
         }
     }
 
     override fun purgeAll() {
-        super.purgeAll()
-        purgeAllSubscriptions()
+        resetQueries()
+        resetMutations()
+        resetSubscriptions()
     }
 
-    private fun purgeAllSubscriptions() {
-        val subscriptionStoreCopy = subscriptionStore.toMap()
-        subscriptionStore.clear()
-        subscriptionCache.clear()
-        subscriptionStoreCopy.values.forEach { it.close() }
+    override fun perform(sideEffects: QueryEffect): Job {
+        return launch(sideEffects)
     }
 
-    @Suppress("UNCHECKED_CAST")
-    override fun <T> getSubscription(
-        key: SubscriptionKey<T>,
-        marker: Marker
-    ): SubscriptionRef<T> {
-        val id = key.id
-        var subscription = subscriptionStore[id] as? ManagedSubscription<T>
-        if (subscription == null) {
-            subscription = newSubscription(
-                id = id,
-                options = key.onConfigureOptions()?.invoke(defaultSubscriptionOptions) ?: defaultSubscriptionOptions,
-                initialValue = subscriptionCache[key.id] as? SubscriptionState<T> ?: SubscriptionState(),
-                subscribe = key.subscribe,
-                contentCacheable = key.contentCacheable
-            ).also { subscriptionStore[id] = it }
+    override fun onMount(id: String) {
+        if (mountedIds.isEmpty()) {
+            val scope = CoroutineScope(context = newCoroutineContext(coroutineScope))
+            scope.launch { observeMemoryPressure() }
+            scope.launch { observeNetworkConnectivity() }
+            scope.launch { observeWindowVisibility() }
+            mountedScope = scope
         }
-        return SubscriptionRef(
-            key = key,
-            marker = marker,
-            subscription = subscription
-        )
+        mountedIds += id
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private fun <T> newSubscription(
-        id: UniqueId,
-        options: SubscriptionOptions,
-        initialValue: SubscriptionState<T>,
-        subscribe: SubscriptionReceiver.() -> Flow<T>,
-        contentCacheable: SubscriptionContentCacheable<T>?
-    ): ManagedSubscription<T> {
-        val scope = CoroutineScope(newCoroutineContext(coroutineScope))
-        val state = MutableStateFlow(initialValue)
-        val reducer = createSubscriptionReducer<T>()
-        val dispatch: SubscriptionDispatch<T> = { action ->
-            options.vvv(id) { "dispatching $action" }
-            state.value = reducer(state.value, action)
+    override fun onUnmount(id: String) {
+        mountedIds -= id
+        if (mountedIds.isEmpty()) {
+            mountedScope?.cancel()
+            mountedScope = null
         }
-        val refresh = MutableStateFlow(epoch())
-        val restart: SubscriptionRestart = {
-            scope.launch { refresh.emit(epoch()) }
-        }
-        val relay: SubscriptionErrorRelay? = policy.errorRelay?.let { it::send }
-        val command = Channel<SubscriptionCommand<T>>()
-        val actor = ActorBlockRunner(
-            scope = scope,
-            options = options,
-            onTimeout = { seq ->
-                scope.launch { batchScheduler.post { closeSubscription<T>(id, seq) } }
-            }
-        ) {
-            for (c in command) {
-                options.vvv(id) { "next command $c" }
-                c.handle(
-                    ctx = ManagedSubscriptionContext(
-                        options = options,
-                        state = state.value,
-                        dispatch = dispatch,
-                        restart = restart,
-                        relay = relay
-                    )
-                )
+    }
+
+    private suspend fun observeMemoryPressure() {
+        if (memoryPressure == MemoryPressure.Unsupported) return
+        observeOnMemoryPressure(memoryPressure) { level ->
+            withContext(mainDispatcher) {
+                gc(level)
             }
         }
-
-        val subscribeFlow = subscriptionReceiver.subscribe()
-        val source = refresh
-            .flatMapLatest {
-                subscribeFlow
-                    .retryWithExponentialBackoff(options) { err, count, nextBackOff ->
-                        options.vvv(id) { "retry(count=$count next=$nextBackOff error=${err.message})" }
-                    }
-                    .toResultFlow()
-            }
-            .shareIn(
-                scope = scope,
-                started = SharingStarted.WhileSubscribedAlt(
-                    stopTimeout = options.keepAliveTime,
-                    onSubscriptionCount = { subscribers ->
-                        options.vvv(id) { "subscription count: $subscribers" }
-                    }
-                )
-            )
-        return ManagedSubscription(
-            scope = scope,
-            id = id,
-            options = options,
-            source = source,
-            state = state,
-            command = command,
-            actor = actor,
-            cacheable = contentCacheable
-        )
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun <T> closeSubscription(id: UniqueId, seq: ActorSequenceNumber) {
-        val subscription = subscriptionStore[id] as? ManagedSubscription<T> ?: return
-        if (subscription.actor.seq == seq) {
-            subscriptionStore.remove(id)
-            subscription.close()
-            saveToCache(subscription)
-        }
-    }
-
-    private fun <T> saveToCache(subscription: ManagedSubscription<T>) {
-        val lastValue = subscription.state.value
-        val ttl = subscription.options.gcTime
-        val saveable = lastValue.isSuccess && ttl.isPositive()
-        if (saveable && subscription.isCacheable(lastValue.reply)) {
-            subscriptionCache.set(subscription.id, lastValue, ttl)
-            subscription.options.vvv(subscription.id) { "cached(ttl=$ttl)" }
-        }
-    }
-
-    internal class ManagedSubscription<T>(
-        val scope: CoroutineScope,
-        val id: UniqueId,
-        val options: SubscriptionOptions,
-        override val source: SharedFlow<Result<T>>,
-        override val state: StateFlow<SubscriptionState<T>>,
-        override val command: SendChannel<SubscriptionCommand<T>>,
-        internal val actor: ActorBlockRunner,
-        private val cacheable: SubscriptionContentCacheable<T>?
-    ) : Subscription<T> {
-
-        override fun launchIn(scope: CoroutineScope): Job {
-            return actor.launchIn(scope)
-        }
-
-        fun close() {
-            scope.cancel()
-            command.close()
-        }
-
-        fun isCacheable(reply: Reply<T>): Boolean {
-            return when (reply) {
-                is Reply.None -> false
-                is Reply.Some<T> -> {
-                    cacheable?.invoke(reply.value) ?: true
+    private suspend fun observeNetworkConnectivity() {
+        if (networkConnectivity == NetworkConnectivity.Unsupported) return
+        observeOnNetworkReconnect(networkConnectivity, networkResumeAfterDelay) {
+            perform {
+                forEach(networkResumeQueriesFilter) { id, _ ->
+                    queryStore[id]
+                        ?.takeIf { it.options.revalidateOnReconnect }
+                        ?.resume()
                 }
             }
         }
     }
 
-    internal class ManagedSubscriptionContext<T>(
-        override val options: SubscriptionOptions,
-        override val state: SubscriptionState<T>,
-        override val dispatch: SubscriptionDispatch<T>,
-        override val restart: SubscriptionRestart,
-        override val relay: SubscriptionErrorRelay?
-    ) : SubscriptionCommand.Context<T>
+    private suspend fun observeWindowVisibility() {
+        if (windowVisibility == WindowVisibility.Unsupported) return
+        observeOnWindowFocus(windowVisibility) {
+            perform {
+                forEach(windowResumeQueriesFilter) { id, _ ->
+                    queryStore[id]
+                        ?.takeIf { it.options.revalidateOnFocus }
+                        ?.resume()
+                }
+            }
+        }
+    }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlusInternal.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlusInternal.kt
@@ -1,0 +1,206 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.launch
+import soil.query.annotation.ExperimentalSoilQueryApi
+import soil.query.annotation.InternalSoilQueryApi
+import soil.query.core.ActorBlockRunner
+import soil.query.core.ActorSequenceNumber
+import soil.query.core.HasActorSequence
+import soil.query.core.Marker
+import soil.query.core.Reply
+import soil.query.core.UniqueId
+import soil.query.core.WhileSubscribedAlt
+import soil.query.core.epoch
+import soil.query.core.retryWithExponentialBackoff
+import soil.query.core.toResultFlow
+import soil.query.core.vvv
+
+@ExperimentalSoilQueryApi
+@InternalSoilQueryApi
+abstract class SwrCachePlusInternal : SwrCacheInternal(), SubscriptionClient {
+
+    protected abstract val subscriptionOptions: SubscriptionOptions
+    protected abstract val subscriptionReceiver: SubscriptionReceiver
+    protected abstract val subscriptionStore: MutableMap<UniqueId, ManagedSubscription<*>>
+    protected abstract val subscriptionCache: SubscriptionCache
+
+    protected fun resetSubscriptions() {
+        val subscriptionStoreCopy = subscriptionStore.toMap()
+        subscriptionStore.clear()
+        subscriptionCache.clear()
+        subscriptionStoreCopy.values.forEach { it.close() }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getSubscription(
+        key: SubscriptionKey<T>,
+        marker: Marker
+    ): SubscriptionRef<T> {
+        val id = key.id
+        var subscription = subscriptionStore[id] as? ManagedSubscription<T>
+        if (subscription == null) {
+            subscription = newSubscription(
+                id = id,
+                options = key.onConfigureOptions()?.invoke(subscriptionOptions) ?: subscriptionOptions,
+                initialValue = subscriptionCache[key.id] as? SubscriptionState<T> ?: SubscriptionState(),
+                subscribe = key.subscribe,
+                contentCacheable = key.contentCacheable
+            ).also { subscriptionStore[id] = it }
+        }
+        return SubscriptionRef(
+            key = key,
+            marker = marker,
+            subscription = subscription
+        )
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun <T> newSubscription(
+        id: UniqueId,
+        options: SubscriptionOptions,
+        initialValue: SubscriptionState<T>,
+        subscribe: SubscriptionReceiver.() -> Flow<T>,
+        contentCacheable: SubscriptionContentCacheable<T>?
+    ): ManagedSubscription<T> {
+        val scope = CoroutineScope(newCoroutineContext(coroutineScope))
+        val state = MutableStateFlow(initialValue)
+        val reducer = createSubscriptionReducer<T>()
+        val dispatch: SubscriptionDispatch<T> = { action ->
+            options.vvv(id) { "dispatching $action" }
+            state.value = reducer(state.value, action)
+        }
+        val refresh = MutableStateFlow(epoch())
+        val restart: SubscriptionRestart = {
+            scope.launch { refresh.emit(epoch()) }
+        }
+        val relay: SubscriptionErrorRelay? = errorRelaySource?.let { it::send }
+        val command = Channel<SubscriptionCommand<T>>()
+        val actor = ActorBlockRunner(
+            scope = scope,
+            options = options,
+            onTimeout = { seq ->
+                scope.launch { batchScheduler.post { closeSubscription<T>(id, seq) } }
+            }
+        ) {
+            for (c in command) {
+                options.vvv(id) { "next command $c" }
+                c.handle(
+                    ctx = ManagedSubscriptionContext(
+                        options = options,
+                        state = state.value,
+                        dispatch = dispatch,
+                        restart = restart,
+                        relay = relay
+                    )
+                )
+            }
+        }
+
+        val subscribeFlow = subscriptionReceiver.subscribe()
+        val source = refresh
+            .flatMapLatest {
+                subscribeFlow
+                    .retryWithExponentialBackoff(options) { err, count, nextBackOff ->
+                        options.vvv(id) { "retry(count=$count next=$nextBackOff error=${err.message})" }
+                    }
+                    .toResultFlow()
+            }
+            .shareIn(
+                scope = scope,
+                started = SharingStarted.WhileSubscribedAlt(
+                    stopTimeout = options.keepAliveTime,
+                    onSubscriptionCount = { subscribers ->
+                        options.vvv(id) { "subscription count: $subscribers" }
+                    }
+                )
+            )
+        return ManagedSubscription(
+            scope = scope,
+            id = id,
+            options = options,
+            source = source,
+            state = state,
+            command = command,
+            actor = actor,
+            cacheable = contentCacheable
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> closeSubscription(id: UniqueId, seq: ActorSequenceNumber) {
+        val subscription = subscriptionStore[id] as? ManagedSubscription<T> ?: return
+        if (subscription.seq == seq) {
+            subscriptionStore.remove(id)
+            subscription.close()
+            saveToCache(subscription)
+        }
+    }
+
+    private fun <T> saveToCache(subscription: ManagedSubscription<T>) {
+        val lastValue = subscription.state.value
+        val ttl = subscription.options.gcTime
+        val saveable = lastValue.isSuccess && ttl.isPositive()
+        if (saveable && subscription.isCacheable(lastValue.reply)) {
+            subscriptionCache.set(subscription.id, lastValue, ttl)
+            subscription.options.vvv(subscription.id) { "cached(ttl=$ttl)" }
+        }
+    }
+
+    @InternalSoilQueryApi
+    class ManagedSubscription<T> internal constructor(
+        val id: UniqueId,
+        val options: SubscriptionOptions,
+        override val source: SharedFlow<Result<T>>,
+        override val state: StateFlow<SubscriptionState<T>>,
+        override val command: SendChannel<SubscriptionCommand<T>>,
+        private val scope: CoroutineScope,
+        private val actor: ActorBlockRunner,
+        private val cacheable: SubscriptionContentCacheable<T>?
+    ) : Subscription<T>, HasActorSequence {
+
+        override val seq: ActorSequenceNumber
+            get() = actor.seq
+
+        override fun launchIn(scope: CoroutineScope): Job {
+            return actor.launchIn(scope)
+        }
+
+        fun close() {
+            scope.cancel()
+            command.close()
+        }
+
+        fun isCacheable(reply: Reply<T>): Boolean {
+            return when (reply) {
+                is Reply.None -> false
+                is Reply.Some<T> -> {
+                    cacheable?.invoke(reply.value) ?: true
+                }
+            }
+        }
+    }
+
+    internal class ManagedSubscriptionContext<T>(
+        override val options: SubscriptionOptions,
+        override val state: SubscriptionState<T>,
+        override val dispatch: SubscriptionDispatch<T>,
+        override val restart: SubscriptionRestart,
+        override val relay: SubscriptionErrorRelay?
+    ) : SubscriptionCommand.Context<T>
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCacheView.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCacheView.kt
@@ -1,0 +1,18 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.annotation.InternalSoilQueryApi
+import soil.query.core.UniqueId
+
+@InternalSoilQueryApi
+interface SwrCacheView {
+    val mutationStoreView: Map<UniqueId, Mutation<*>>
+    val queryStoreView: Map<UniqueId, Query<*>>
+}
+
+@InternalSoilQueryApi
+interface SwrCachePlusView : SwrCacheView {
+    val subscriptionStoreView: Map<UniqueId, Subscription<*>>
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/annotation/InternalSoilQueryApi.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/annotation/InternalSoilQueryApi.kt
@@ -1,0 +1,15 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.annotation
+
+@RequiresOptIn(message = "This API is internal to Soil Query and should not be used from outside the library.")
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.TYPEALIAS,
+    AnnotationTarget.CONSTRUCTOR
+)
+annotation class InternalSoilQueryApi

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/Actor.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/Actor.kt
@@ -31,7 +31,11 @@ interface Actor {
     fun launchIn(scope: CoroutineScope): Job
 }
 
-internal typealias ActorSequenceNumber = String
+typealias ActorSequenceNumber = String
+
+interface HasActorSequence {
+    val seq: ActorSequenceNumber
+}
 
 internal class ActorBlockRunner(
     private val id: String = uuid(),
@@ -39,9 +43,9 @@ internal class ActorBlockRunner(
     private val options: ActorOptions,
     private val onTimeout: (ActorSequenceNumber) -> Unit,
     private val block: suspend () -> Unit
-) : Actor {
+) : Actor, HasActorSequence {
 
-    val seq: ActorSequenceNumber
+    override val seq: ActorSequenceNumber
         get() = "$id#$versionCounter"
 
     private var versionCounter: Int = 0

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/MemoryPressure.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/MemoryPressure.kt
@@ -5,6 +5,7 @@ package soil.query.core
 
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.callbackFlow
 
 /**
@@ -70,4 +71,12 @@ enum class MemoryPressureLevel {
      * Indicates moderate memory pressure.
      */
     High
+}
+
+internal suspend fun observeOnMemoryPressure(
+    memoryPressure: MemoryPressure,
+    collector: FlowCollector<MemoryPressureLevel>
+) {
+    memoryPressure.asFlow()
+        .collect(collector::emit)
 }


### PR DESCRIPTION
In #89, we introduced the Subscription API and split the Client I/F and Cache implementation into two:

* SwrClient - SwrCache
* SwrClientPlus - SwrCachePlus

Previously, SwrCache and SwrCachePlus had a direct inheritance relationship. This refactor extracts the internal logic and removes the inheritance.

With this change, the soil-query-testing library can now define the same extension functions for both:

```
val testClient1 = SwrCache(..).test()
val testClient2 = SwrCachePlus(..).test()
```