### PR TITLE
Introduce idling functions for testing

### DIFF
--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizerTest.kt
@@ -24,6 +24,7 @@ import soil.query.SwrCacheScope
 import soil.query.buildInfiniteQueryKey
 import soil.query.core.Reply
 import soil.query.emptyChunks
+import soil.query.test.test
 import soil.testing.UnitTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -36,7 +37,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
     @Test
     fun testRecompositionCount_default() = runComposeUiTest {
         val key = TestInfiniteQueryKey()
-        val client = SwrCache(coroutineScope = SwrCacheScope())
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test()
         var recompositionCount = 0
         setContent {
             SwrClientProvider(client) {
@@ -68,7 +69,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
     @Test
     fun testRecompositionCount_disabled() = runComposeUiTest {
         val key = TestInfiniteQueryKey()
-        val client = SwrCache(coroutineScope = SwrCacheScope())
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test()
         var recompositionCount = 0
         setContent {
             SwrClientProvider(client) {

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/MutationComposableTest.kt
@@ -15,11 +15,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.test.waitUntilExactlyOneExists
 import kotlinx.coroutines.launch
 import soil.query.MutationKey
 import soil.query.MutationState
@@ -41,7 +39,7 @@ class MutationComposableTest : UnitTest() {
     @Test
     fun testRememberMutation() = runComposeUiTest {
         val key = TestMutationKey()
-        val client = SwrCache(coroutineScope = SwrCacheScope())
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test()
         setContent {
             SwrClientProvider(client) {
                 val mutation = rememberMutation(key, config = MutationConfig {
@@ -72,7 +70,8 @@ class MutationComposableTest : UnitTest() {
         onNodeWithTag("result").assertDoesNotExist()
         onNodeWithTag("mutation").performClick()
 
-        waitUntilExactlyOneExists(hasTestTag("result"))
+        waitForIdle()
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("result").assertTextEquals("Soil - 1")
     }
 
@@ -111,7 +110,8 @@ class MutationComposableTest : UnitTest() {
         }
 
         onNodeWithTag("mutation").performClick()
-        waitUntilExactlyOneExists(hasTestTag("result"))
+
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("result").assertTextEquals("error")
     }
 
@@ -146,7 +146,9 @@ class MutationComposableTest : UnitTest() {
         }
 
         onNodeWithTag("mutation").performClick()
-        waitUntilExactlyOneExists(hasTestTag("result"))
+
+        waitForIdle()
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("result").assertTextEquals("error")
     }
 
@@ -237,7 +239,7 @@ class MutationComposableTest : UnitTest() {
     @Test
     fun testRememberMutationIf() = runComposeUiTest {
         val key = TestMutationKey()
-        val client = SwrCache(coroutineScope = SwrCacheScope())
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test()
         setContent {
             SwrClientProvider(client) {
                 var enabled by remember { mutableStateOf(false) }
@@ -275,7 +277,8 @@ class MutationComposableTest : UnitTest() {
         onNodeWithTag("result").assertDoesNotExist()
         onNodeWithTag("mutation").performClick()
 
-        waitUntilExactlyOneExists(hasTestTag("result"))
+        waitForIdle()
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("result").assertTextEquals("Soil - 1")
     }
 

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryComposableTest.kt
@@ -14,11 +14,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.test.waitUntilExactlyOneExists
 import soil.query.QueryId
 import soil.query.QueryKey
 import soil.query.QueryState
@@ -40,7 +38,7 @@ class QueryComposableTest : UnitTest() {
     @Test
     fun testRememberQuery() = runComposeUiTest {
         val key = TestQueryKey()
-        val client = SwrCache(coroutineScope = SwrCacheScope())
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test()
         setContent {
             SwrClientProvider(client) {
                 val query = rememberQuery(key, config = QueryConfig {
@@ -56,7 +54,7 @@ class QueryComposableTest : UnitTest() {
             }
         }
 
-        waitUntilExactlyOneExists(hasTestTag("query"))
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("query").assertTextEquals("Hello, Soil!")
     }
 
@@ -76,7 +74,7 @@ class QueryComposableTest : UnitTest() {
             }
         }
 
-        waitUntilExactlyOneExists(hasTestTag("query"))
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("query").assertTextEquals("HELLO, COMPOSE!")
     }
 
@@ -99,7 +97,7 @@ class QueryComposableTest : UnitTest() {
             }
         }
 
-        waitUntilExactlyOneExists(hasTestTag("query"))
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("query").assertTextEquals("error")
     }
 
@@ -121,7 +119,7 @@ class QueryComposableTest : UnitTest() {
             }
         }
 
-        waitUntilExactlyOneExists(hasTestTag("query"))
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("query").assertTextEquals("Hello, Compose!Hello, Soil!")
     }
 
@@ -145,7 +143,7 @@ class QueryComposableTest : UnitTest() {
             }
         }
 
-        waitUntilExactlyOneExists(hasTestTag("query"))
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("query").assertTextEquals("Hello, Compose!Hello, Soil!Hello, Kotlin!")
     }
 
@@ -169,7 +167,7 @@ class QueryComposableTest : UnitTest() {
             }
         }
 
-        waitUntilExactlyOneExists(hasTestTag("query"))
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("query").assertTextEquals("Hello, Compose!|Hello, Soil!|Hello, Kotlin!")
     }
 
@@ -260,7 +258,7 @@ class QueryComposableTest : UnitTest() {
     @Test
     fun testRememberQueryIf() = runComposeUiTest {
         val key = TestQueryKey()
-        val client = SwrCache(coroutineScope = SwrCacheScope())
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test()
         setContent {
             SwrClientProvider(client) {
                 var enabled by remember { mutableStateOf(false) }
@@ -281,7 +279,8 @@ class QueryComposableTest : UnitTest() {
         onNodeWithTag("query").assertDoesNotExist()
         onNodeWithTag("toggle").performClick()
 
-        waitUntilExactlyOneExists(hasTestTag("query"))
+        waitForIdle()
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("query").assertTextEquals("Hello, Soil!")
     }
 
@@ -315,7 +314,8 @@ class QueryComposableTest : UnitTest() {
         onNodeWithTag("query").assertDoesNotExist()
         onNodeWithTag("toggle").performClick()
 
-        waitUntilExactlyOneExists(hasTestTag("query"))
+        waitForIdle()
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("query").assertTextEquals("HELLO, COMPOSE!")
     }
 
@@ -350,7 +350,8 @@ class QueryComposableTest : UnitTest() {
         onNodeWithTag("query").assertDoesNotExist()
         onNodeWithTag("toggle").performClick()
 
-        waitUntilExactlyOneExists(hasTestTag("query"))
+        waitForIdle()
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("query").assertTextEquals("Hello, Compose!Hello, Soil!")
     }
 
@@ -387,7 +388,8 @@ class QueryComposableTest : UnitTest() {
         onNodeWithTag("query").assertDoesNotExist()
         onNodeWithTag("toggle").performClick()
 
-        waitUntilExactlyOneExists(hasTestTag("query"))
+        waitForIdle()
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("query").assertTextEquals("Hello, Compose!Hello, Soil!Hello, Kotlin!")
     }
 
@@ -424,7 +426,8 @@ class QueryComposableTest : UnitTest() {
         onNodeWithTag("query").assertDoesNotExist()
         onNodeWithTag("toggle").performClick()
 
-        waitUntilExactlyOneExists(hasTestTag("query"))
+        waitForIdle()
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("query").assertTextEquals("Hello, Compose!|Hello, Soil!|Hello, Kotlin!")
     }
 

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryRecompositionOptimizerTest.kt
@@ -21,6 +21,7 @@ import soil.query.SwrCache
 import soil.query.SwrCacheScope
 import soil.query.buildQueryKey
 import soil.query.core.Reply
+import soil.query.test.test
 import soil.testing.UnitTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -33,7 +34,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
     @Test
     fun testRecompositionCount_default() = runComposeUiTest {
         val key = TestQueryKey()
-        val client = SwrCache(coroutineScope = SwrCacheScope())
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test()
         var recompositionCount = 0
         setContent {
             SwrClientProvider(client) {
@@ -55,7 +56,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
     @Test
     fun testRecompositionCount_disabled() = runComposeUiTest {
         val key = TestQueryKey()
-        val client = SwrCache(coroutineScope = SwrCacheScope())
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test()
         var recompositionCount = 0
         setContent {
             SwrClientProvider(client) {

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/SubscriptionRecompositionOptimizerTest.kt
@@ -3,19 +3,12 @@
 
 package soil.query.compose
 
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.flow
-import soil.query.SubscriptionId
-import soil.query.SubscriptionKey
 import soil.query.SubscriptionState
 import soil.query.SubscriptionStatus
-import soil.query.buildSubscriptionKey
 import soil.query.core.Reply
 import soil.testing.UnitTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 
 class SubscriptionRecompositionOptimizerTest : UnitTest() {
 
@@ -113,16 +106,4 @@ class SubscriptionRecompositionOptimizerTest : UnitTest() {
         val actual = SubscriptionRecompositionOptimizer.Disabled.omit(expected)
         assertEquals(expected, actual)
     }
-
-    private class TestSubscriptionKey(
-        private val delayTime: Duration = 100.milliseconds
-    ) : SubscriptionKey<String> by buildSubscriptionKey(
-        id = SubscriptionId("test/subscription"),
-        subscribe = {
-            flow {
-                delay(delayTime)
-                emit("Hello, Soil!")
-            }
-        }
-    )
 }

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/util/MutatedEffectTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/util/MutatedEffectTest.kt
@@ -15,13 +15,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.test.waitUntilExactlyOneExists
 import kotlinx.coroutines.launch
 import soil.query.MutationId
 import soil.query.MutationKey
@@ -30,6 +27,7 @@ import soil.query.SwrCacheScope
 import soil.query.buildMutationKey
 import soil.query.compose.SwrClientProvider
 import soil.query.compose.rememberMutation
+import soil.query.test.test
 import soil.testing.UnitTest
 import kotlin.test.Test
 
@@ -39,7 +37,7 @@ class MutatedEffectTest : UnitTest() {
     @Test
     fun testMutatedEffect() = runComposeUiTest {
         val key = TestMutationKey()
-        val client = SwrCache(coroutineScope = SwrCacheScope())
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test()
         setContent {
             SwrClientProvider(client) {
                 val mutation = rememberMutation(key)
@@ -73,13 +71,13 @@ class MutatedEffectTest : UnitTest() {
         onNodeWithTag("result").assertDoesNotExist()
         onNodeWithTag("mutation").performClick()
 
-        waitUntilExactlyOneExists(hasTestTag("result1"))
+        waitUntil { client.isIdleNow() }
         onNodeWithText("Mutated: 1").assertExists()
         onNodeWithTag("count").assertTextEquals("1")
 
         onNodeWithTag("mutation").performClick()
 
-        waitUntilExactlyOneExists(hasTestTag("result2"))
+        waitUntil { client.isIdleNow() }
         onNodeWithText("Mutated: 2").assertExists()
         onNodeWithTag("count").assertTextEquals("2")
     }
@@ -87,7 +85,7 @@ class MutatedEffectTest : UnitTest() {
     @Test
     fun testMutatedEffect_withKeySelector() = runComposeUiTest {
         val key = TestMutationKey()
-        val client = SwrCache(coroutineScope = SwrCacheScope())
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test()
         setContent {
             SwrClientProvider(client) {
                 val mutation = rememberMutation(key)
@@ -124,13 +122,13 @@ class MutatedEffectTest : UnitTest() {
         onNodeWithTag("result").assertDoesNotExist()
         onNodeWithTag("mutation").performClick()
 
-        waitUntilExactlyOneExists(hasTestTag("result1"))
+        waitUntil { client.isIdleNow() }
         onNodeWithText("Mutated: 1").assertExists()
         onNodeWithTag("count").assertTextEquals("1")
 
         onNodeWithTag("mutation").performClick()
 
-        waitUntilExactlyOneExists(hasTestTag("count") and hasText("2"))
+        waitUntil { client.isIdleNow() }
         // The key is the same as the first mutation result, so the MutatedEffect is not called.
         onNodeWithText("Mutated: 2").assertDoesNotExist()
         onNodeWithTag("count").assertTextEquals("2")


### PR DESCRIPTION
Implemented `isIdleNow` function, which can be used with `IdlingResource` or `waitUntil`,and `awaitIdle` suspend function for Compose UI testing, using the `SwrCacheView` introduced in #135.

Previously, it was not possible to determine whether there were ongoing operations within the cache. With these new functions, it is now possible to synchronize with Compose test functions for proper coordination during testing.