### PR TITLE
Simplify the Internal Lifecycle of Actor

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryComposable.kt
@@ -4,9 +4,11 @@
 package soil.query.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import soil.query.InfiniteQueryKey
+import soil.query.InfiniteQueryRef
 import soil.query.QueryChunks
 import soil.query.QueryClient
 import soil.query.compose.internal.newInfiniteQuery
@@ -29,6 +31,7 @@ fun <T, S> rememberInfiniteQuery(
 ): InfiniteQueryObject<QueryChunks<T, S>, S> {
     val scope = rememberCoroutineScope()
     val query = remember(key.id) { newInfiniteQuery(key, config, client, scope) }
+    query.Effect()
     return with(config.mapper) {
         config.strategy.collectAsState(query).toObject(query = query, select = { it })
     }
@@ -54,7 +57,19 @@ fun <T, S, U> rememberInfiniteQuery(
 ): InfiniteQueryObject<U, S> {
     val scope = rememberCoroutineScope()
     val query = remember(key.id) { newInfiniteQuery(key, config, client, scope) }
+    query.Effect()
     return with(config.mapper) {
         config.strategy.collectAsState(query).toObject(query = query, select = select)
+    }
+}
+
+@Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
+@Composable
+private inline fun InfiniteQueryRef<*, *>.Effect() {
+    // TODO: Switch to LifecycleResumeEffect
+    //  Android, it works only with Compose UI 1.7.0-alpha05 or above.
+    //  Therefore, we will postpone adding this code until a future release.
+    LaunchedEffect(id) {
+        join()
     }
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryComposable.kt
@@ -4,10 +4,12 @@
 package soil.query.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import soil.query.QueryClient
 import soil.query.QueryKey
+import soil.query.QueryRef
 import soil.query.compose.internal.newCombinedQuery
 import soil.query.compose.internal.newQuery
 
@@ -28,6 +30,7 @@ fun <T> rememberQuery(
 ): QueryObject<T> {
     val scope = rememberCoroutineScope()
     val query = remember(key.id) { newQuery(key, config, client, scope) }
+    query.Effect()
     return with(config.mapper) {
         config.strategy.collectAsState(query).toObject(query = query, select = { it })
     }
@@ -53,6 +56,7 @@ fun <T, U> rememberQuery(
 ): QueryObject<U> {
     val scope = rememberCoroutineScope()
     val query = remember(key.id) { newQuery(key, config, client, scope) }
+    query.Effect()
     return with(config.mapper) {
         config.strategy.collectAsState(query).toObject(query = query, select = select)
     }
@@ -83,6 +87,7 @@ fun <T1, T2, R> rememberQuery(
     val query = remember(key1.id, key2.id) {
         newCombinedQuery(key1, key2, transform, config, client, scope)
     }
+    query.Effect()
     return with(config.mapper) {
         config.strategy.collectAsState(query).toObject(query = query, select = { it })
     }
@@ -116,6 +121,7 @@ fun <T1, T2, T3, R> rememberQuery(
     val query = remember(key1.id, key2.id, key3.id) {
         newCombinedQuery(key1, key2, key3, transform, config, client, scope)
     }
+    query.Effect()
     return with(config.mapper) {
         config.strategy.collectAsState(query).toObject(query = query, select = { it })
     }
@@ -143,7 +149,19 @@ fun <T, R> rememberQuery(
     val query = remember(*keys.map { it.id }.toTypedArray()) {
         newCombinedQuery(keys, transform, config, client, scope)
     }
+    query.Effect()
     return with(config.mapper) {
         config.strategy.collectAsState(query).toObject(query = query, select = { it })
+    }
+}
+
+@Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
+@Composable
+private inline fun QueryRef<*>.Effect() {
+    // TODO: Switch to LifecycleResumeEffect
+    //  Android, it works only with Compose UI 1.7.0-alpha05 or above.
+    //  Therefore, we will postpone adding this code until a future release.
+    LaunchedEffect(id) {
+        join()
     }
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/CombinedQuery3.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/CombinedQuery3.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import soil.query.QueryClient
 import soil.query.QueryId
@@ -56,6 +57,12 @@ private class CombinedQuery3<T1, T2, T3, R>(
     )
     override val state: StateFlow<QueryState<R>> = _state
 
+    override fun close() {
+        query1.close()
+        query2.close()
+        query3.close()
+    }
+
     override suspend fun resume() {
         coroutineScope {
             val deferred1 = async { query1.resume() }
@@ -74,9 +81,12 @@ private class CombinedQuery3<T1, T2, T3, R>(
         }
     }
 
-    override fun launchIn(scope: CoroutineScope): Job {
-        return scope.launch {
-            combine(query1.state, query2.state, query3.state, ::merge).collect { _state.value = it }
+    override suspend fun join() {
+        coroutineScope {
+            val job1 = launch { query1.join() }
+            val job2 = launch { query2.join() }
+            val job3 = launch { query3.join() }
+            joinAll(job1, job2, job3)
         }
     }
 
@@ -85,27 +95,23 @@ private class CombinedQuery3<T1, T2, T3, R>(
     }
 
     // ----- RememberObserver -----//
-    private var jobs: List<Job>? = null
+    private var job: Job? = null
 
     override fun onAbandoned() = stop()
 
     override fun onForgotten() = stop()
 
-    override fun onRemembered() {
-        stop()
-        start()
-    }
+    override fun onRemembered() = start()
 
     private fun start() {
-        val job1 = query1.launchIn(scope)
-        val job2 = query2.launchIn(scope)
-        val job3 = query3.launchIn(scope)
-        val job4 = launchIn(scope)
-        jobs = listOf(job1, job2, job3, job4)
+        job = scope.launch {
+            combine(query1.state, query2.state, query3.state, ::merge).collect { _state.value = it }
+        }
     }
 
     private fun stop() {
-        jobs?.forEach { it.cancel() }
-        jobs = null
+        job?.cancel()
+        job = null
+        close()
     }
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
@@ -4,8 +4,6 @@
 package soil.query.compose.tooling
 
 import androidx.compose.runtime.Stable
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import soil.query.MutationClient
@@ -44,7 +42,7 @@ class MutationPreviewClient(
         override val id: MutationId<T, S>,
         override val state: StateFlow<MutationState<T>>
     ) : MutationRef<T, S> {
-        override fun launchIn(scope: CoroutineScope): Job = Job()
+        override fun close() = Unit
         override suspend fun reset() = Unit
         override suspend fun mutate(variable: S): T = state.value.reply.getOrThrow()
         override suspend fun mutateAsync(variable: S) = Unit

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
@@ -4,7 +4,6 @@
 package soil.query.compose.tooling
 
 import androidx.compose.runtime.Stable
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,7 +14,6 @@ import soil.query.QueryChunks
 import soil.query.QueryClient
 import soil.query.QueryId
 import soil.query.QueryKey
-import soil.query.QueryOptions
 import soil.query.QueryRef
 import soil.query.QueryState
 import soil.query.core.Marker
@@ -67,9 +65,10 @@ class QueryPreviewClient(
         override val id: QueryId<T>,
         override val state: StateFlow<QueryState<T>>
     ) : QueryRef<T> {
-        override fun launchIn(scope: CoroutineScope): Job = Job()
+        override fun close() = Unit
         override suspend fun resume() = Unit
         override suspend fun invalidate() = Unit
+        override suspend fun join() = Unit
     }
 
     private class SnapshotInfiniteQuery<T, S>(
@@ -77,11 +76,12 @@ class QueryPreviewClient(
         override val state: StateFlow<QueryState<QueryChunks<T, S>>>
     ) : InfiniteQueryRef<T, S> {
         override val id: InfiniteQueryId<T, S> = key.id
-        override fun launchIn(scope: CoroutineScope): Job = Job()
+        override fun close() = Unit
         override fun nextParam(data: QueryChunks<T, S>): S? = key.loadMoreParam(data)
         override suspend fun resume() = Unit
         override suspend fun loadMore(param: S) = Unit
         override suspend fun invalidate() = Unit
+        override suspend fun join() = Unit
     }
 
     /**

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SubscriptionPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SubscriptionPreviewClient.kt
@@ -4,14 +4,11 @@
 package soil.query.compose.tooling
 
 import androidx.compose.runtime.Stable
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import soil.query.SubscriptionClient
 import soil.query.SubscriptionId
 import soil.query.SubscriptionKey
-import soil.query.SubscriptionOptions
 import soil.query.SubscriptionRef
 import soil.query.SubscriptionState
 import soil.query.annotation.ExperimentalSoilQueryApi
@@ -46,7 +43,7 @@ class SubscriptionPreviewClient(
         override val id: SubscriptionId<T>,
         override val state: StateFlow<SubscriptionState<T>>
     ) : SubscriptionRef<T> {
-        override fun launchIn(scope: CoroutineScope): Job = Job()
+        override fun close() = Unit
         override suspend fun reset() = Unit
         override suspend fun resume() = Unit
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/util/KeepAlive.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/util/KeepAlive.kt
@@ -29,8 +29,7 @@ fun KeepAlive(
     key: QueryKey<*>,
     client: QueryClient = LocalQueryClient.current
 ) {
-    val scope = rememberCoroutineScope()
-    remember(key) { client.getQuery(key).also { it.launchIn(scope) } }
+    @Suppress("UNUSED_VARIABLE") val q = remember(key) { client.getQuery(key) }
 }
 
 /**
@@ -46,8 +45,7 @@ fun KeepAlive(
     key: InfiniteQueryKey<*, *>,
     client: QueryClient = LocalQueryClient.current
 ) {
-    val scope = rememberCoroutineScope()
-    remember(key) { client.getInfiniteQuery(key).also { it.launchIn(scope) } }
+    @Suppress("UNUSED_VARIABLE") val q = remember(key) { client.getInfiniteQuery(key) }
 }
 
 /**
@@ -63,6 +61,5 @@ fun KeepAlive(
     key: MutationKey<*, *>,
     client: MutationClient = LocalMutationClient.current
 ) {
-    val scope = rememberCoroutineScope()
-    remember(key) { client.getMutation(key).also { it.launchIn(scope) } }
+    @Suppress("UNUSED_VARIABLE") val q = remember(key) { client.getMutation(key) }
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/util/MutatedEffect.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/util/MutatedEffect.kt
@@ -66,6 +66,7 @@ fun <T, U : Any> MutatedEffect(
  * @param T Type of the return value from the mutation.
  * @param mutation The MutationObject whose result will be observed.
  */
+@Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
 @Composable
 inline fun <T> MutatedEffect(
     mutation: MutationObject<T, *>,

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryComposableTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryComposableTest.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import kotlinx.coroutines.launch
 import soil.query.InfiniteQueryId
 import soil.query.InfiniteQueryKey
@@ -259,7 +258,7 @@ class InfiniteQueryComposableTest : UnitTest() {
     @Test
     fun testRememberInfiniteQueryIf() = runComposeUiTest {
         val key = TestInfiniteQueryKey()
-        val client = SwrCache(coroutineScope = SwrCacheScope())
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test()
         setContent {
             SwrClientProvider(client) {
                 var enabled by remember { mutableStateOf(false) }
@@ -289,14 +288,14 @@ class InfiniteQueryComposableTest : UnitTest() {
         onNodeWithTag("toggle").performClick()
 
         waitForIdle()
-        waitUntilAtLeastOneExists(hasTestTag("query"))
+        waitUntil { client.isIdleNow() }
         onNodeWithTag("query").assertTextEquals("Size: 10 - Page: 0")
     }
 
     @Test
     fun testRememberInfiniteQueryIf_select() = runComposeUiTest {
         val key = TestInfiniteQueryKey()
-        val client = SwrCache(coroutineScope = SwrCacheScope())
+        val client = SwrCache(coroutineScope = SwrCacheScope()).test()
         setContent {
             SwrClientProvider(client) {
                 var enabled by remember { mutableStateOf(false) }
@@ -326,7 +325,7 @@ class InfiniteQueryComposableTest : UnitTest() {
         onNodeWithTag("toggle").performClick()
 
         waitForIdle()
-        waitUntilAtLeastOneExists(hasTestTag("query"))
+        waitUntil { client.isIdleNow() }
         onAllNodes(hasTestTag("query")).assertCountEquals(10)
     }
 

--- a/soil-query-core/src/jvmTest/kotlin/soil/query/KeepAliveTest.kt
+++ b/soil-query-core/src/jvmTest/kotlin/soil/query/KeepAliveTest.kt
@@ -72,13 +72,14 @@ class KeepAliveTest : UnitTest() {
             )
             repeat(times) {
                 val scope = CoroutineScope(Dispatchers.Main + Job())
-                val query = swrClient.getQuery(GetTestQueryKey()).also { it.launchIn(scope) }
-                yield()
-                scope.launch {
-                    query.resume()
-                }.join()
-                scope.cancel()
-                delay(callerDelay)
+                swrClient.getQuery(GetTestQueryKey()).use { query ->
+                    yield()
+                    scope.launch {
+                        query.resume()
+                    }.join()
+                    scope.cancel()
+                    delay(callerDelay)
+                }
             }
         }
     }

--- a/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientPlusTest.kt
+++ b/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientPlusTest.kt
@@ -34,12 +34,13 @@ class TestSwrClientPlusTest : UnitTest() {
             on(ExampleSubscriptionKey.Id) { MutableStateFlow("Hello, World!") }
         }
         val key = ExampleSubscriptionKey()
-        val subscription = testClient.getSubscription(key).also { it.launchIn(backgroundScope) }
+        val subscription = testClient.getSubscription(key)
         // Use backgroundScope for auto cancel
         backgroundScope.launch { subscription.resume() }
 
         testClient.awaitIdle(testDispatcher)
         assertEquals("Hello, World!", subscription.state.value.reply.getOrThrow())
+        subscription.close()
     }
 }
 

--- a/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientTest.kt
+++ b/soil-query-test/src/commonTest/kotlin/soil/query/test/TestSwrClientTest.kt
@@ -39,11 +39,12 @@ class TestSwrClientTest : UnitTest() {
             }
         }
         val key = ExampleMutationKey()
-        val mutation = testClient.getMutation(key).also { it.launchIn(backgroundScope) }
+        val mutation = testClient.getMutation(key)
         launch { mutation.mutate(0) }
 
         testClient.awaitIdle(testDispatcher)
         assertEquals("Hello, World!", mutation.state.value.reply.getOrThrow())
+        mutation.close()
     }
 
     @Test
@@ -59,11 +60,12 @@ class TestSwrClientTest : UnitTest() {
             on(ExampleQueryKey.Id) { "Hello, World!" }
         }
         val key = ExampleQueryKey()
-        val query = testClient.getQuery(key).also { it.launchIn(backgroundScope) }
+        val query = testClient.getQuery(key)
         launch { query.resume() }
 
         testClient.awaitIdle(testDispatcher)
         assertEquals("Hello, World!", query.state.value.reply.getOrThrow())
+        query.close()
     }
 
     @Test
@@ -79,11 +81,12 @@ class TestSwrClientTest : UnitTest() {
             on(ExampleInfiniteQueryKey.Id) { "Hello, World!" }
         }
         val key = ExampleInfiniteQueryKey()
-        val query = testClient.getInfiniteQuery(key).also { it.launchIn(backgroundScope) }
+        val query = testClient.getInfiniteQuery(key)
         launch { query.resume() }
 
         testClient.awaitIdle(testDispatcher)
         assertEquals("Hello, World!", query.state.value.reply.getOrThrow().first().data)
+        query.close()
     }
 }
 


### PR DESCRIPTION
This PR simplifies the mechanism for tracking reference counts in the Actor introduced in #44. Previously, the reference count was managed by invoking the `launchIn(scope)` function via `XxxRef` interface, controlling the increment and decrement of references based on the lifecycle of the CoroutineScope.

However, this approach proved inconvenient for short-lived scopes, such as those used with the prefetch function.

In this change, a UUID is assigned to each `XxxRef` instance, and a simpler attach/detach mechanism is introduced. Naturally, XxxRef instances must guarantee these calls. To enforce this, the [AutoCloseable](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-auto-closeable.html) interface is implemented, making it clear that the close function must be invoked once the instance is no longer needed.

For short-lived use cases like prefetch, the use extension function can be employed to ensure proper cleanup reliably.

```
getQuery(key, marker).use { query -> ... }
```