### PR TITLE
Introduce Subscription Filters

### DIFF
--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/CreatePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/CreatePostKey.kt
@@ -8,9 +8,10 @@ import soil.playground.query.data.Post
 import soil.query.InfiniteQueryId
 import soil.query.MutationId
 import soil.query.MutationKey
-import soil.query.QueryEffect
+import soil.query.core.Effect
 import soil.query.core.KeyEquals
 import soil.query.core.Namespace
+import soil.query.queryClient
 import soil.query.receivers.ktor.buildKtorMutationKey
 
 @Stable
@@ -22,8 +23,9 @@ class CreatePostKey(auto: Namespace) : KeyEquals(), MutationKey<Post, PostForm> 
         }.body()
     }
 ) {
-    override fun onQueryUpdate(variable: PostForm, data: Post): QueryEffect = {
-        invalidateQueriesBy(InfiniteQueryId.forGetPosts())
+
+    override fun onMutateEffect(variable: PostForm, data: Post): Effect = {
+        queryClient.invalidateQueriesBy(InfiniteQueryId.forGetPosts())
     }
 }
 

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/DeletePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/DeletePostKey.kt
@@ -5,11 +5,12 @@ import io.ktor.client.request.delete
 import soil.query.InfiniteQueryId
 import soil.query.MutationId
 import soil.query.MutationKey
-import soil.query.QueryEffect
 import soil.query.QueryId
+import soil.query.core.Effect
 import soil.query.core.KeyEquals
 import soil.query.core.Namespace
 import soil.query.receivers.ktor.buildKtorMutationKey
+import soil.query.withQuery
 
 @Stable
 class DeletePostKey(auto: Namespace) : KeyEquals(), MutationKey<Unit, Int> by buildKtorMutationKey(
@@ -18,8 +19,10 @@ class DeletePostKey(auto: Namespace) : KeyEquals(), MutationKey<Unit, Int> by bu
         delete("https://jsonplaceholder.typicode.com/posts/$postId")
     }
 ) {
-    override fun onQueryUpdate(variable: Int, data: Unit): QueryEffect = {
-        removeQueriesBy(QueryId.forGetPost(variable))
-        invalidateQueriesBy(InfiniteQueryId.forGetPosts())
+    override fun onMutateEffect(variable: Int, data: Unit): Effect = {
+        withQuery {
+            removeQueriesBy(QueryId.forGetPost(variable))
+            invalidateQueriesBy(InfiniteQueryId.forGetPosts())
+        }
     }
 }

--- a/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/UpdatePostKey.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/query/key/posts/UpdatePostKey.kt
@@ -8,12 +8,13 @@ import soil.playground.query.data.Post
 import soil.query.InfiniteQueryId
 import soil.query.MutationId
 import soil.query.MutationKey
-import soil.query.QueryEffect
 import soil.query.QueryId
+import soil.query.core.Effect
 import soil.query.core.KeyEquals
 import soil.query.core.Namespace
 import soil.query.modifyData
 import soil.query.receivers.ktor.buildKtorMutationKey
+import soil.query.withQuery
 
 @Stable
 class UpdatePostKey(auto: Namespace) : KeyEquals(), MutationKey<Post, Post> by buildKtorMutationKey(
@@ -24,8 +25,11 @@ class UpdatePostKey(auto: Namespace) : KeyEquals(), MutationKey<Post, Post> by b
         }.body()
     }
 ) {
-    override fun onQueryUpdate(variable: Post, data: Post): QueryEffect = {
-        updateQueryData(QueryId.forGetPost(data.id)) { data }
-        updateInfiniteQueryData(InfiniteQueryId.forGetPosts()) { modifyData({ it.id == data.id }) { data } }
+
+    override fun onMutateEffect(variable: Post, data: Post): Effect = {
+        withQuery {
+            updateQueryData(QueryId.forGetPost(data.id)) { data }
+            updateInfiniteQueryData(InfiniteQueryId.forGetPosts()) { modifyData({ it.id == data.id }) { data } }
+        }
     }
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionComposable.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionComposable.kt
@@ -4,10 +4,12 @@
 package soil.query.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import soil.query.SubscriptionClient
 import soil.query.SubscriptionKey
+import soil.query.SubscriptionRef
 import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.compose.internal.newSubscription
 
@@ -29,6 +31,7 @@ fun <T> rememberSubscription(
 ): SubscriptionObject<T> {
     val scope = rememberCoroutineScope()
     val subscription = remember(key.id) { newSubscription(key, config, client, scope) }
+    subscription.Effect()
     return with(config.mapper) {
         config.strategy.collectAsState(subscription).toObject(subscription = subscription, select = { it })
     }
@@ -55,7 +58,19 @@ fun <T, U> rememberSubscription(
 ): SubscriptionObject<U> {
     val scope = rememberCoroutineScope()
     val subscription = remember(key.id) { newSubscription(key, config, client, scope) }
+    subscription.Effect()
     return with(config.mapper) {
         config.strategy.collectAsState(subscription).toObject(subscription = subscription, select = select)
+    }
+}
+
+@Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
+@Composable
+private inline fun SubscriptionRef<*>.Effect() {
+    // TODO: Switch to LifecycleResumeEffect
+    //  Android, it works only with Compose UI 1.7.0-alpha05 or above.
+    //  Therefore, we will postpone adding this code until a future release.
+    LaunchedEffect(id) {
+        join()
     }
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionObject.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionObject.kt
@@ -43,6 +43,7 @@ data class SubscriptionLoadingObject<T>(
     override val replyUpdatedAt: Long,
     override val error: Throwable?,
     override val errorUpdatedAt: Long,
+    override val restartedAt: Long,
     override val reset: suspend () -> Unit
 ) : SubscriptionObject<T> {
     override val status: SubscriptionStatus = SubscriptionStatus.Pending
@@ -63,6 +64,7 @@ data class SubscriptionErrorObject<T>(
     override val replyUpdatedAt: Long,
     override val error: Throwable,
     override val errorUpdatedAt: Long,
+    override val restartedAt: Long,
     override val reset: suspend () -> Unit
 ) : SubscriptionObject<T> {
     override val status: SubscriptionStatus = SubscriptionStatus.Failure
@@ -80,6 +82,7 @@ data class SubscriptionSuccessObject<T>(
     override val replyUpdatedAt: Long,
     override val error: Throwable?,
     override val errorUpdatedAt: Long,
+    override val restartedAt: Long,
     override val reset: suspend () -> Unit
 ) : SubscriptionObject<T> {
     override val status: SubscriptionStatus = SubscriptionStatus.Success

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionObjectMapper.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionObjectMapper.kt
@@ -44,6 +44,7 @@ private object DefaultSubscriptionObjectMapper : SubscriptionObjectMapper {
             replyUpdatedAt = replyUpdatedAt,
             error = error,
             errorUpdatedAt = errorUpdatedAt,
+            restartedAt = restartedAt,
             reset = subscription::reset
         )
 
@@ -52,6 +53,7 @@ private object DefaultSubscriptionObjectMapper : SubscriptionObjectMapper {
             replyUpdatedAt = replyUpdatedAt,
             error = error,
             errorUpdatedAt = errorUpdatedAt,
+            restartedAt = restartedAt,
             reset = subscription::reset
         )
 
@@ -60,6 +62,7 @@ private object DefaultSubscriptionObjectMapper : SubscriptionObjectMapper {
             replyUpdatedAt = replyUpdatedAt,
             error = checkNotNull(error),
             errorUpdatedAt = errorUpdatedAt,
+            restartedAt = restartedAt,
             reset = subscription::reset
         )
     }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionRecompositionOptimizer.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/SubscriptionRecompositionOptimizer.kt
@@ -32,6 +32,7 @@ private object SubscriptionRecompositionOptimizerEnabled : SubscriptionRecomposi
     override fun <T> omit(state: SubscriptionState<T>): SubscriptionState<T> {
         val keys = buildSet {
             add(SubscriptionState.OmitKey.replyUpdatedAt)
+            add(SubscriptionState.OmitKey.restartedAt)
             when (state.status) {
                 SubscriptionStatus.Pending -> {
                     add(SubscriptionState.OmitKey.errorUpdatedAt)

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/Subscription.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/internal/Subscription.kt
@@ -49,6 +49,8 @@ private class Subscription<T>(
 
     override suspend fun resume() = subscription.resume()
 
+    override suspend fun join() = subscription.join()
+
     // ----- RememberObserver -----//
     private var job: Job? = null
 

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SubscriptionPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SubscriptionPreviewClient.kt
@@ -46,6 +46,7 @@ class SubscriptionPreviewClient(
         override fun close() = Unit
         override suspend fun reset() = Unit
         override suspend fun resume() = Unit
+        override suspend fun join() = Unit
     }
 
     /**

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SwrPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SwrPreviewClient.kt
@@ -13,6 +13,7 @@ import soil.query.QueryEffect
 import soil.query.SubscriptionClient
 import soil.query.SwrClient
 import soil.query.SwrClientPlus
+import soil.query.core.Effect
 import soil.query.core.ErrorRecord
 import soil.query.core.MemoryPressureLevel
 
@@ -35,7 +36,10 @@ class SwrPreviewClient(
 ) : SwrClient, SwrClientPlus, QueryClient by query, MutationClient by mutation, SubscriptionClient by subscription {
     override fun gc(level: MemoryPressureLevel) = Unit
     override fun purgeAll() = Unit
+
+    @Deprecated("Use effect(block: Effect) instead.", replaceWith = ReplaceWith("effect(block)"))
     override fun perform(sideEffects: QueryEffect): Job = Job()
+    override fun effect(block: Effect): Job = Job()
     override fun onMount(id: String) = Unit
     override fun onUnmount(id: String) = Unit
 }

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/util/QueriesErrorReset.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/util/QueriesErrorReset.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.remember
 import soil.query.ResumeQueriesFilter
 import soil.query.SwrClient
 import soil.query.compose.LocalSwrClient
+import soil.query.queryClient
 
 
 typealias QueriesErrorReset = () -> Unit
@@ -25,7 +26,7 @@ fun rememberQueriesErrorReset(
     client: SwrClient = LocalSwrClient.current
 ): QueriesErrorReset {
     val reset = remember<() -> Unit>(client) {
-        { client.perform { resumeQueries(filter) } }
+        { client.effect { queryClient.resumeQueries(filter) } }
     }
     return reset
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationKey.kt
@@ -3,6 +3,7 @@
 
 package soil.query
 
+import soil.query.core.Effect
 import soil.query.core.SurrogateKey
 import soil.query.core.UniqueId
 import soil.query.core.uuid
@@ -70,7 +71,27 @@ interface MutationKey<T, S> {
      * @param variable The variable to be mutated.
      * @param data The data returned by the mutation.
      */
+    @Deprecated(
+        "Use onMutateEffect instead.",
+        ReplaceWith("onMutateEffect(variable, data)")
+    )
     fun onQueryUpdate(variable: S, data: T): QueryEffect? = null
+
+    /**
+     * Function to handle side effects after the mutation is executed.
+     *
+     * This is often referred to as ["Pessimistic Updates"](https://redux-toolkit.js.org/rtk-query/usage/manual-cache-updates#pessimistic-updates).
+     *
+     * ```kotlin
+     * override fun onMutateEffect(variable: PostForm, data: Post): Effect = {
+     *     queryClient.invalidateQueriesBy(GetPostsKey.Id())
+     * }
+     * ```
+     *
+     * @param variable The variable to be mutated.
+     * @param data The data returned by the mutation.
+     */
+    fun onMutateEffect(variable: S, data: T): Effect? = null
 }
 
 /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationNotifier.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationNotifier.kt
@@ -4,6 +4,7 @@
 package soil.query
 
 import kotlinx.coroutines.Job
+import soil.query.core.Effect
 
 /**
  * MutationNotifier is used to notify the mutation result.
@@ -13,11 +14,11 @@ fun interface MutationNotifier {
     /**
      * Notifies the mutation success
      *
-     * Mutation success usually implies data update, causing side effects on related queries.
+     * Mutation success usually implies data update, causing side effects on related queries and subscriptions.
      * This callback is used as a trigger for re-fetching or revalidating data managed by queries.
-     * It invokes with the [QueryEffect] set in [MutationKey.onQueryUpdate].
+     * It invokes with the [Effect] set in [MutationKey.onMutateEffect].
      *
-     * @param sideEffects The side effects of the mutation for related queries.
+     * @param effect The side effects of the mutation for related queries and subscriptions.
      */
-    fun onMutate(sideEffects: QueryEffect): Job
+    fun onMutate(effect: Effect): Job
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
@@ -5,7 +5,6 @@ package soil.query
 
 import kotlinx.coroutines.Job
 import soil.query.core.Marker
-import soil.query.core.UniqueId
 
 /**
  * A Query client, which allows you to make queries actor and handle [QueryKey] and [InfiniteQueryKey].
@@ -72,68 +71,7 @@ interface QueryReadonlyClient {
     fun <T, S> getInfiniteQueryData(id: InfiniteQueryId<T, S>): QueryChunks<T, S>?
 }
 
-/**
- * Interface for causing side effects on [Query] under the control of [QueryClient].
- *
- * [QueryEffect] is designed to allow side effects such as updating, deleting, and revalidating queries.
- * It is useful for handling [MutationKey.onQueryUpdate] after executing [Mutation] that affects [Query] data.
- */
-interface QueryMutableClient : QueryReadonlyClient {
-
-    /**
-     * Updates the data of the [QueryKey] associated with the [id].
-     */
-    fun <T> updateQueryData(
-        id: QueryId<T>,
-        edit: T.() -> T
-    )
-
-    /**
-     * Updates the data of the [InfiniteQueryKey] associated with the [id].
-     */
-    fun <T, S> updateInfiniteQueryData(
-        id: InfiniteQueryId<T, S>,
-        edit: QueryChunks<T, S>.() -> QueryChunks<T, S>
-    )
-
-    /**
-     * Invalidates the queries by the specified [InvalidateQueriesFilter].
-     */
-    fun invalidateQueries(filter: InvalidateQueriesFilter)
-
-    /**
-     * Invalidates the queries by the specified [UniqueId].
-     */
-    fun <U : UniqueId> invalidateQueriesBy(vararg ids: U)
-
-    /**
-     * Removes the queries by the specified [RemoveQueriesFilter].
-     *
-     * **Note:**
-     * Queries will be removed from [QueryClient], but [QueryRef] instances on the subscriber side will remain until they are dereferenced.
-     * Also, the [kotlinx.coroutines.CoroutineScope] associated with the [kotlinx.coroutines.Job] will be canceled at the time of removal.
-     */
-    fun removeQueries(filter: RemoveQueriesFilter)
-
-    /**
-     * Removes the queries by the specified [UniqueId].
-     */
-    fun <U : UniqueId> removeQueriesBy(vararg ids: U)
-
-    /**
-     * Resumes the queries by the specified [ResumeQueriesFilter].
-     */
-    fun resumeQueries(filter: ResumeQueriesFilter)
-
-    /**
-     * Resumes the queries by the specified [UniqueId].
-     */
-    fun <U : UniqueId> resumeQueriesBy(vararg ids: U)
-}
-
 typealias QueryInitialData<T> = QueryReadonlyClient.() -> T?
-typealias QueryEffect = QueryMutableClient.() -> Unit
-
 typealias QueryContentEquals<T> = (oldData: T, newData: T) -> Boolean
 typealias QueryContentCacheable<T> = (currentData: T) -> Boolean
 typealias QueryRecoverData<T> = (error: Throwable) -> T

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryEffect.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryEffect.kt
@@ -1,0 +1,88 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.EffectContext
+import soil.query.core.EffectPropertyKey
+import soil.query.core.UniqueId
+
+typealias QueryEffect = QueryEffectClient.() -> Unit
+
+/**
+ * Interface for causing side effects on [Query] under the control of [QueryClient].
+ *
+ * [QueryEffect] is designed to allow side effects such as updating, deleting, and revalidating queries.
+ * It is useful for handling [MutationKey.onQueryUpdate] after executing [Mutation] that affects [Query] data.
+ */
+interface QueryEffectClient : QueryReadonlyClient {
+
+    /**
+     * Updates the data of the [QueryKey] associated with the [id].
+     */
+    fun <T> updateQueryData(
+        id: QueryId<T>,
+        edit: T.() -> T
+    )
+
+    /**
+     * Updates the data of the [InfiniteQueryKey] associated with the [id].
+     */
+    fun <T, S> updateInfiniteQueryData(
+        id: InfiniteQueryId<T, S>,
+        edit: QueryChunks<T, S>.() -> QueryChunks<T, S>
+    )
+
+    /**
+     * Invalidates the queries by the specified [InvalidateQueriesFilter].
+     */
+    fun invalidateQueries(filter: InvalidateQueriesFilter)
+
+    /**
+     * Invalidates the queries by the specified [UniqueId].
+     */
+    fun <U : UniqueId> invalidateQueriesBy(vararg ids: U)
+
+    /**
+     * Removes the queries by the specified [RemoveQueriesFilter].
+     *
+     * **Note:**
+     * Queries will be removed from [QueryClient], but [QueryRef] instances on the subscriber side will remain until they are dereferenced.
+     * Also, the [kotlinx.coroutines.CoroutineScope] associated with the [kotlinx.coroutines.Job] will be canceled at the time of removal.
+     */
+    fun removeQueries(filter: RemoveQueriesFilter)
+
+    /**
+     * Removes the queries by the specified [UniqueId].
+     */
+    fun <U : UniqueId> removeQueriesBy(vararg ids: U)
+
+    /**
+     * Resumes the queries by the specified [ResumeQueriesFilter].
+     */
+    fun resumeQueries(filter: ResumeQueriesFilter)
+
+    /**
+     * Resumes the queries by the specified [UniqueId].
+     */
+    fun <U : UniqueId> resumeQueriesBy(vararg ids: U)
+}
+
+/**
+ * Executes the specified [block] with the [QueryEffectClient].
+ */
+fun EffectContext.withQuery(block: QueryEffect) = with(queryClient, block)
+
+/**
+ * Gets the [QueryEffectClient] from the [EffectContext].
+ */
+val EffectContext.queryClient: QueryEffectClient
+    get() = get(queryEffectClientPropertyKey)
+
+internal val queryEffectClientPropertyKey = EffectPropertyKey<QueryEffectClient>(
+    errorDescription = """
+        QueryEffectClient is not available.
+        This might indicate an issue within the library.
+        Please report this to the library maintainers.
+    """.trimIndent()
+)

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryFilter.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryFilter.kt
@@ -3,69 +3,49 @@
 
 package soil.query
 
-import soil.query.core.SurrogateKey
-
-/**
- * Interface for filtering side effect queries by [QueryMutableClient].
- */
-interface QueryFilter {
-
-    /**
-     * Management category of queries to be filtered.
-     *
-     * If unspecified, all [QueryFilterType]s are targeted.
-     */
-    val type: QueryFilterType?
-
-    /**
-     * Tag keys of queries to be filtered.
-     */
-    val keys: Array<SurrogateKey>?
-
-    /**
-     * Further conditions to narrow down the filtering targets based on fields of [QueryModel].
-     */
-    val predicate: ((QueryModel<*>) -> Boolean)?
-}
+import soil.query.core.FilterResolver
+import soil.query.core.FilterType
+import soil.query.core.InvalidateFilter
+import soil.query.core.RemoveFilter
+import soil.query.core.ResumeFilter
+import soil.query.core.UniqueId
 
 /**
  * Filter for invalidating queries.
  *
- * @see [QueryMutableClient.invalidateQueries], [QueryMutableClient.invalidateQueriesBy]
+ * @see [QueryEffectClient.invalidateQueries], [QueryEffectClient.invalidateQueriesBy]
  */
-class InvalidateQueriesFilter(
-    override val type: QueryFilterType? = null,
-    override val keys: Array<SurrogateKey>? = null,
-    override val predicate: ((QueryModel<*>) -> Boolean)? = null,
-) : QueryFilter
+typealias InvalidateQueriesFilter = InvalidateFilter<QueryModel<*>>
 
 /**
  * Filter for removing queries.
  *
- * @see [QueryMutableClient.removeQueries], [QueryMutableClient.removeQueriesBy]
+ * @see [QueryEffectClient.removeQueries], [QueryEffectClient.removeQueriesBy]
  */
-class RemoveQueriesFilter(
-    override val type: QueryFilterType? = null,
-    override val keys: Array<SurrogateKey>? = null,
-    override val predicate: ((QueryModel<*>) -> Boolean)? = null,
-) : QueryFilter
+typealias RemoveQueriesFilter = RemoveFilter<QueryModel<*>>
 
 /**
  * Filter for resuming queries.
  *
- * @see [QueryMutableClient.resumeQueries], [QueryMutableClient.resumeQueriesBy]
+ * @see [QueryEffectClient.resumeQueries], [QueryEffectClient.resumeQueriesBy]
  */
-class ResumeQueriesFilter(
-    override val keys: Array<SurrogateKey>? = null,
-    override val predicate: (QueryModel<*>) -> Boolean
-) : QueryFilter {
-    override val type: QueryFilterType = QueryFilterType.Active
-}
+typealias ResumeQueriesFilter = ResumeFilter<QueryModel<*>>
 
 /**
- * Query management categories for filtering.
+ * Filter resolver for queries.
  */
-enum class QueryFilterType {
-    Active,
-    Inactive
+internal class QueryFilterResolver(
+    private val store: Map<UniqueId, Query<*>>,
+    private val cache: QueryCache
+) : FilterResolver<QueryModel<*>> {
+
+    override fun resolveKeys(type: FilterType): Set<UniqueId> = when (type) {
+        FilterType.Active -> store.keys
+        FilterType.Inactive -> cache.keys
+    }
+
+    override fun resolveValue(type: FilterType, id: UniqueId): QueryModel<*>? = when (type) {
+        FilterType.Active -> store[id]?.state?.value
+        FilterType.Inactive -> cache[id]
+    }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/Subscription.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/Subscription.kt
@@ -21,6 +21,11 @@ interface Subscription<T> : Actor {
     val source: SharedFlow<Result<T>>
 
     /**
+     * [Shared Flow][SharedFlow] to receive subscription [events][SubscriptionEvent].
+     */
+    val event: SharedFlow<SubscriptionEvent>
+
+    /**
      * [State Flow][StateFlow] to receive the current state of the subscription.
      */
     val state: StateFlow<SubscriptionState<T>>
@@ -29,4 +34,11 @@ interface Subscription<T> : Actor {
      * [Send Channel][SendChannel] to manipulate the state of the subscription.
      */
     val command: SendChannel<SubscriptionCommand<T>>
+}
+
+/**
+ * Events occurring in the subscription.
+ */
+enum class SubscriptionEvent {
+    Resume
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionClient.kt
@@ -21,6 +21,21 @@ interface SubscriptionClient {
     ): SubscriptionRef<T>
 }
 
+/**
+ * Interface for directly accessing retrieved [Subscription] data by [SubscriptionClient].
+ *
+ * [SubscriptionInitialData] is designed to calculate initial data from other [Subscription].
+ * This is useful when the type included in the list on the overview screen matches the type of content on the detailed screen.
+ */
+interface SubscriptionReadonlyClient {
+
+    /**
+     * Retrieves data of the [SubscriptionKey] associated with the [id].
+     */
+    fun <T> getSubscriptionData(id: SubscriptionId<T>): T?
+}
+
+typealias SubscriptionInitialData<T> = SubscriptionReadonlyClient.() -> T?
 typealias SubscriptionContentEquals<T> = (oldData: T, newData: T) -> Boolean
 typealias SubscriptionContentCacheable<T> = (currentData: T) -> Boolean
 typealias SubscriptionRecoverData<T> = (error: Throwable) -> T

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionCommand.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionCommand.kt
@@ -36,7 +36,7 @@ interface SubscriptionCommand<T> {
 }
 
 internal typealias SubscriptionErrorRelay = (ErrorRecord) -> Unit
-internal typealias SubscriptionRestart = () -> Unit
+internal typealias SubscriptionRestart = (Long) -> Unit
 
 /**
  * Dispatches the result of the subscription.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionEffect.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionEffect.kt
@@ -1,0 +1,68 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.EffectContext
+import soil.query.core.EffectPropertyKey
+import soil.query.core.UniqueId
+
+typealias SubscriptionEffect = SubscriptionEffectClient.() -> Unit
+
+/**
+ * Interface for causing side effects on [Subscription] under the control of [SubscriptionClient].
+ */
+interface SubscriptionEffectClient : SubscriptionReadonlyClient {
+
+    /**
+     * Updates the data of the [SubscriptionKey] associated with the [id].
+     */
+    fun <T> updateSubscriptionData(
+        id: SubscriptionId<T>,
+        edit: T.() -> T
+    )
+
+    /**
+     * Removes the subscriptions by the specified [RemoveSubscriptionsFilter].
+     *
+     * **Note:**
+     * Subscriptions will be removed from [SubscriptionClient], but [SubscriptionRef] instances on the subscriber side will remain until they are dereferenced.
+     * Also, the [kotlinx.coroutines.CoroutineScope] associated with the [kotlinx.coroutines.Job] will be canceled at the time of removal.
+     */
+    fun removeSubscriptions(filter: RemoveSubscriptionsFilter)
+
+    /**
+     * Removes the subscriptions by the specified [UniqueId].
+     */
+    fun <U : UniqueId> removeSubscriptionsBy(vararg ids: U)
+
+    /**
+     * Resumes the subscriptions by the specified [ResumeSubscriptionsFilter].
+     */
+    fun resumeSubscriptions(filter: ResumeSubscriptionsFilter)
+
+    /**
+     * Resumes the subscriptions by the specified [UniqueId].
+     */
+    fun <U : UniqueId> resumeSubscriptionsBy(vararg ids: U)
+}
+
+/**
+ * Creates an [EffectContext] with the specified [SubscriptionEffectClient].
+ */
+fun EffectContext.withSubscription(block: SubscriptionEffect) = with(subscriptionClient, block)
+
+/**
+ * Gets the [SubscriptionEffectClient] from the [EffectContext].
+ */
+val EffectContext.subscriptionClient: SubscriptionEffectClient
+    get() = this[subscriptionEffectClientPropertyKey]
+
+internal val subscriptionEffectClientPropertyKey = EffectPropertyKey<SubscriptionEffectClient>(
+    errorDescription = """
+        SubscriptionEffectClient is not available.
+        This might indicate an issue within the library, or it could be a setup issue.
+        Ensure that you are using SwrClientPlus in your setup.
+        If the issue persists, please report it to the library maintainers.
+    """.trimIndent()
+)

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionFilter.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionFilter.kt
@@ -1,0 +1,39 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.FilterResolver
+import soil.query.core.FilterType
+import soil.query.core.RemoveFilter
+import soil.query.core.ResumeFilter
+import soil.query.core.UniqueId
+
+/**
+ * Filter for removing subscriptions.
+ */
+typealias RemoveSubscriptionsFilter = RemoveFilter<SubscriptionModel<*>>
+
+/**
+ * Filter for resuming subscriptions.
+ */
+typealias ResumeSubscriptionsFilter = ResumeFilter<SubscriptionModel<*>>
+
+/**
+ * Filter resolver for subscriptions.
+ */
+internal class SubscriptionFilterResolver(
+    private val store: Map<UniqueId, Subscription<*>>,
+    private val cache: SubscriptionCache
+) : FilterResolver<SubscriptionModel<*>> {
+
+    override fun resolveKeys(type: FilterType): Set<UniqueId> = when (type) {
+        FilterType.Active -> store.keys
+        FilterType.Inactive -> cache.keys
+    }
+
+    override fun resolveValue(type: FilterType, id: UniqueId): SubscriptionModel<*>? = when (type) {
+        FilterType.Active -> store[id]?.state?.value
+        FilterType.Inactive -> cache[id]
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionKey.kt
@@ -69,6 +69,21 @@ interface SubscriptionKey<T> {
     fun onConfigureOptions(): SubscriptionOptionsOverride? = null
 
     /**
+     * Function to specify initial data.
+     *
+     * You can specify initial data instead of the initial loading state.
+     *
+     * ```kotlin
+     * override fun onInitialData(): SubscriptionInitialData<User> = {
+     *     getSubscriptionData(XxxSubscriptionKey.Id())
+     * }
+     * ```
+     *
+     * @see SubscriptionInitialData
+     */
+    fun onInitialData(): SubscriptionInitialData<T>? = null
+
+    /**
      * Function to recover data from the error.
      *
      * You can recover data from the error instead of the error state.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionModel.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionModel.kt
@@ -15,6 +15,11 @@ import soil.query.core.DataModel
 interface SubscriptionModel<out T> : DataModel<T> {
 
     /**
+     * The timestamp when the subscription was restarted.
+     */
+    val restartedAt: Long
+
+    /**
      * The received status of the subscription.
      */
     val status: SubscriptionStatus

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionOptions.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionOptions.kt
@@ -34,6 +34,22 @@ interface SubscriptionOptions : ActorOptions, LoggingOptions, RetryOptions {
     val errorEquals: ((Throwable, Throwable) -> Boolean)?
 
     /**
+     * Automatically restart active [Subscription] when the network reconnects.
+     *
+     * **Note:**
+     * This setting is only effective when [soil.query.core.NetworkConnectivity] is available.
+     */
+    val restartOnReconnect: Boolean
+
+    /**
+     * Automatically restart active [Subscription] when the window is refocused.
+     *
+     * **Note:**
+     * This setting is only effective when [soil.query.core.WindowVisibility] is available.
+     */
+    val restartOnFocus: Boolean
+
+    /**
      * This callback function will be called if some mutation encounters an error.
      */
     val onError: ((ErrorRecord, SubscriptionModel<*>) -> Unit)?
@@ -47,6 +63,8 @@ interface SubscriptionOptions : ActorOptions, LoggingOptions, RetryOptions {
     companion object Default : SubscriptionOptions {
         override val gcTime: Duration = 5.minutes
         override val errorEquals: ((Throwable, Throwable) -> Boolean)? = null
+        override val restartOnReconnect: Boolean = true
+        override val restartOnFocus: Boolean = true
         override val onError: ((ErrorRecord, SubscriptionModel<*>) -> Unit)? = null
         override val shouldSuppressErrorRelay: ((ErrorRecord, SubscriptionModel<*>) -> Boolean)? = null
 
@@ -74,6 +92,8 @@ interface SubscriptionOptions : ActorOptions, LoggingOptions, RetryOptions {
  *
  * @param gcTime The period during which the Key's return value, if not referenced anywhere, is temporarily cached in memory.
  * @param errorEquals Determines whether two errors are equal.
+ * @param restartOnReconnect Automatically restart active [Subscription] when the network reconnects.
+ * @param restartOnFocus Automatically restart active [Subscription] when the window is refocused.
  * @param onError This callback function will be called if some subscription encounters an error.
  * @param shouldSuppressErrorRelay Determines whether to suppress error information when relaying it using [soil.query.core.ErrorRelay].
  * @param keepAliveTime The duration to keep the actor alive after the last command is executed.
@@ -89,6 +109,8 @@ interface SubscriptionOptions : ActorOptions, LoggingOptions, RetryOptions {
 fun SubscriptionOptions(
     gcTime: Duration = SubscriptionOptions.gcTime,
     errorEquals: ((Throwable, Throwable) -> Boolean)? = SubscriptionOptions.errorEquals,
+    restartOnReconnect: Boolean = SubscriptionOptions.restartOnReconnect,
+    restartOnFocus: Boolean = SubscriptionOptions.restartOnFocus,
     onError: ((ErrorRecord, SubscriptionModel<*>) -> Unit)? = SubscriptionOptions.onError,
     shouldSuppressErrorRelay: ((ErrorRecord, SubscriptionModel<*>) -> Boolean)? = SubscriptionOptions.shouldSuppressErrorRelay,
     keepAliveTime: Duration = SubscriptionOptions.keepAliveTime,
@@ -104,6 +126,8 @@ fun SubscriptionOptions(
     return object : SubscriptionOptions {
         override val gcTime: Duration = gcTime
         override val errorEquals: ((Throwable, Throwable) -> Boolean)? = errorEquals
+        override val restartOnReconnect: Boolean = restartOnReconnect
+        override val restartOnFocus: Boolean = restartOnFocus
         override val onError: ((ErrorRecord, SubscriptionModel<*>) -> Unit)? = onError
         override val shouldSuppressErrorRelay: ((ErrorRecord, SubscriptionModel<*>) -> Boolean)? =
             shouldSuppressErrorRelay
@@ -125,6 +149,8 @@ fun SubscriptionOptions(
 fun SubscriptionOptions.copy(
     gcTime: Duration = this.gcTime,
     errorEquals: ((Throwable, Throwable) -> Boolean)? = this.errorEquals,
+    restartOnReconnect: Boolean = this.restartOnReconnect,
+    restartOnFocus: Boolean = this.restartOnFocus,
     onError: ((ErrorRecord, SubscriptionModel<*>) -> Unit)? = this.onError,
     shouldSuppressErrorRelay: ((ErrorRecord, SubscriptionModel<*>) -> Boolean)? = this.shouldSuppressErrorRelay,
     keepAliveTime: Duration = this.keepAliveTime,
@@ -140,6 +166,8 @@ fun SubscriptionOptions.copy(
     return SubscriptionOptions(
         gcTime = gcTime,
         errorEquals = errorEquals,
+        restartOnReconnect = restartOnReconnect,
+        restartOnFocus = restartOnFocus,
         onError = onError,
         shouldSuppressErrorRelay = shouldSuppressErrorRelay,
         keepAliveTime = keepAliveTime,

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionState.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionState.kt
@@ -15,8 +15,23 @@ data class SubscriptionState<T> internal constructor(
     override val replyUpdatedAt: Long = 0,
     override val error: Throwable? = null,
     override val errorUpdatedAt: Long = 0,
+    override val restartedAt: Long = 0,
     override val status: SubscriptionStatus = SubscriptionStatus.Pending
 ) : SubscriptionModel<T> {
+
+    /**
+     * Workaround:
+     * The following warning appeared when updating the [reply] property within [SwrCachePlusInternal.setQueryData],
+     * so I replaced the update process with a method that includes type information.
+     * ref. https://youtrack.jetbrains.com/issue/KT-49404
+     */
+    internal fun patch(
+        data: T,
+        dataUpdatedAt: Long = epoch()
+    ): SubscriptionState<T> = copy(
+        reply = Reply(data),
+        replyUpdatedAt = dataUpdatedAt
+    )
 
     /**
      * Returns a new [SubscriptionState] with the items included in [keys] omitted from the current [SubscriptionState].
@@ -29,7 +44,8 @@ data class SubscriptionState<T> internal constructor(
         if (keys.isEmpty()) return this
         return copy(
             replyUpdatedAt = if (keys.contains(OmitKey.replyUpdatedAt)) 0 else replyUpdatedAt,
-            errorUpdatedAt = if (keys.contains(OmitKey.errorUpdatedAt)) 0 else errorUpdatedAt
+            errorUpdatedAt = if (keys.contains(OmitKey.errorUpdatedAt)) 0 else errorUpdatedAt,
+            restartedAt = if (keys.contains(OmitKey.restartedAt)) 0 else restartedAt
         )
     }
 
@@ -38,6 +54,7 @@ data class SubscriptionState<T> internal constructor(
         companion object {
             val replyUpdatedAt = OmitKey("replyUpdatedAt")
             val errorUpdatedAt = OmitKey("errorUpdatedAt")
+            val restartedAt = OmitKey("restartedAt")
         }
     }
 
@@ -117,6 +134,7 @@ data class SubscriptionState<T> internal constructor(
             replyUpdatedAt: Long = 0,
             error: Throwable? = null,
             errorUpdatedAt: Long = 0,
+            restartedAt: Long = 0,
             status: SubscriptionStatus = SubscriptionStatus.Pending
         ): SubscriptionState<T> {
             return SubscriptionState(
@@ -124,6 +142,7 @@ data class SubscriptionState<T> internal constructor(
                 replyUpdatedAt = replyUpdatedAt,
                 error = error,
                 errorUpdatedAt = errorUpdatedAt,
+                restartedAt = restartedAt,
                 status = status
             )
         }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlusInternal.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlusInternal.kt
@@ -6,9 +6,11 @@ package soil.query
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -20,18 +22,21 @@ import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.annotation.InternalSoilQueryApi
 import soil.query.core.Actor
 import soil.query.core.ActorBlockRunner
+import soil.query.core.FilterType
 import soil.query.core.Marker
 import soil.query.core.Reply
 import soil.query.core.UniqueId
 import soil.query.core.WhileSubscribedAlt
 import soil.query.core.epoch
+import soil.query.core.forEach
+import soil.query.core.getOrNull
 import soil.query.core.retryWithExponentialBackoff
 import soil.query.core.toResultFlow
 import soil.query.core.vvv
 
 @ExperimentalSoilQueryApi
 @InternalSoilQueryApi
-abstract class SwrCachePlusInternal : SwrCacheInternal(), SubscriptionClient {
+abstract class SwrCachePlusInternal : SwrCacheInternal(), SubscriptionClient, SubscriptionEffectClient {
 
     protected abstract val subscriptionOptions: SubscriptionOptions
     protected abstract val subscriptionReceiver: SubscriptionReceiver
@@ -56,7 +61,7 @@ abstract class SwrCachePlusInternal : SwrCacheInternal(), SubscriptionClient {
             subscription = newSubscription(
                 id = id,
                 options = key.onConfigureOptions()?.invoke(subscriptionOptions) ?: subscriptionOptions,
-                initialValue = subscriptionCache[key.id] as? SubscriptionState<T> ?: SubscriptionState(),
+                initialValue = subscriptionCache[key.id] as? SubscriptionState<T> ?: newSubscriptionState(key),
                 subscribe = key.subscribe,
                 contentCacheable = key.contentCacheable
             ).also { subscriptionStore[id] = it }
@@ -77,15 +82,19 @@ abstract class SwrCachePlusInternal : SwrCacheInternal(), SubscriptionClient {
         contentCacheable: SubscriptionContentCacheable<T>?
     ): ManagedSubscription<T> {
         val scope = CoroutineScope(newCoroutineContext(coroutineScope))
+        val event = MutableSharedFlow<SubscriptionEvent>(
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST
+        )
         val state = MutableStateFlow(initialValue)
         val reducer = createSubscriptionReducer<T>()
         val dispatch: SubscriptionDispatch<T> = { action ->
             options.vvv(id) { "dispatching $action" }
             state.value = reducer(state.value, action)
         }
-        val refresh = MutableStateFlow(epoch())
-        val restart: SubscriptionRestart = {
-            scope.launch { refresh.emit(epoch()) }
+        val refresh = MutableStateFlow(0L)
+        val restart: SubscriptionRestart = { restartAt ->
+            scope.launch { refresh.emit(restartAt) }
         }
         val relay: SubscriptionErrorRelay? = errorRelaySource?.let { it::send }
         val command = Channel<SubscriptionCommand<T>>()
@@ -133,11 +142,19 @@ abstract class SwrCachePlusInternal : SwrCacheInternal(), SubscriptionClient {
             id = id,
             options = options,
             source = source,
+            event = event,
             state = state,
             command = command,
             actor = actor,
+            dispatch = dispatch,
             cacheable = contentCacheable
         )
+    }
+
+    private fun <T> newSubscriptionState(key: SubscriptionKey<T>): SubscriptionState<T> {
+        val onInitialData = key.onInitialData() ?: return SubscriptionState()
+        val initialData = with(this) { onInitialData() } ?: return SubscriptionState()
+        return SubscriptionState.success(data = initialData, dataUpdatedAt = 0)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -165,20 +182,117 @@ abstract class SwrCachePlusInternal : SwrCacheInternal(), SubscriptionClient {
         }
     }
 
+    // ----- SubscriptionEffectClient ----- //
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getSubscriptionData(id: SubscriptionId<T>): T? {
+        val subscription = subscriptionStore[id] as? ManagedSubscription<T>
+        if (subscription != null) {
+            return subscription.state.value.reply.getOrNull()
+        }
+        val state = subscriptionCache[id] as? SubscriptionState<T>
+        if (state != null) {
+            return state.reply.getOrNull()
+        }
+        return null
+    }
+
+    override fun <T> updateSubscriptionData(
+        id: SubscriptionId<T>,
+        edit: T.() -> T
+    ) {
+        val data = getSubscriptionData(id)
+        if (data != null) {
+            setSubscriptionData(id, data.edit())
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> setSubscriptionData(id: SubscriptionId<T>, data: T) {
+        val subscription = subscriptionStore[id] as? ManagedSubscription<T>
+        subscription?.forceUpdate(data)
+        subscriptionCache.swap(id) {
+            this as SubscriptionState<T>
+            patch(data)
+        }
+    }
+
+    override fun removeSubscriptions(filter: RemoveSubscriptionsFilter) {
+        SubscriptionFilterResolver(subscriptionStore, subscriptionCache)
+            .forEach(filter, ::removeSubscription)
+    }
+
+    override fun <U : UniqueId> removeSubscriptionsBy(vararg ids: U) {
+        require(ids.isNotEmpty())
+        ids.forEach { id ->
+            removeSubscription(id, FilterType.Active)
+            removeSubscription(id, FilterType.Inactive)
+        }
+    }
+
+    private fun removeSubscription(id: UniqueId, type: FilterType) {
+        when (type) {
+            FilterType.Active -> subscriptionStore.remove(id)?.cancel()
+            FilterType.Inactive -> subscriptionCache.delete(id)
+        }
+    }
+
+    override fun resumeSubscriptions(filter: ResumeSubscriptionsFilter) {
+        // NOTE: resume targets only active subscriptions.
+        SubscriptionFilterResolver(subscriptionStore, subscriptionCache)
+            .forEach(filter) { id, _ -> resumeSubscription(id) }
+    }
+
+    protected fun resumeSubscriptionsWhenNetworkReconnect(filter: ResumeSubscriptionsFilter) {
+        SubscriptionFilterResolver(subscriptionStore, subscriptionCache)
+            .forEach(filter) { id, _ ->
+                resumeSubscription(id) { it.options.restartOnReconnect }
+            }
+    }
+
+    protected fun resumeSubscriptionsWhenWindowFocus(filter: ResumeSubscriptionsFilter) {
+        SubscriptionFilterResolver(subscriptionStore, subscriptionCache)
+            .forEach(filter) { id, _ ->
+                resumeSubscription(id) { it.options.restartOnFocus }
+            }
+    }
+
+    override fun <U : UniqueId> resumeSubscriptionsBy(vararg ids: U) {
+        require(ids.isNotEmpty())
+        ids.forEach { id -> resumeSubscription(id) }
+    }
+
+    private fun resumeSubscription(id: UniqueId) {
+        subscriptionStore[id]?.resume()
+    }
+
+    private fun resumeSubscription(id: UniqueId, predicate: (ManagedSubscription<*>) -> Boolean) {
+        subscriptionStore[id]?.takeIf(predicate)?.resume()
+    }
+
     @InternalSoilQueryApi
     class ManagedSubscription<T> internal constructor(
         val id: UniqueId,
         val options: SubscriptionOptions,
         override val source: SharedFlow<Result<T>>,
+        override val event: MutableSharedFlow<SubscriptionEvent>,
         override val state: StateFlow<SubscriptionState<T>>,
         override val command: SendChannel<SubscriptionCommand<T>>,
         private val scope: CoroutineScope,
         private val actor: ActorBlockRunner,
+        private val dispatch: SubscriptionDispatch<T>,
         private val cacheable: SubscriptionContentCacheable<T>?
     ) : Subscription<T>, Actor by actor {
 
         fun cancel() {
             scope.cancel()
+        }
+
+        fun resume() {
+            event.tryEmit(SubscriptionEvent.Resume)
+        }
+
+        fun forceUpdate(data: T) {
+            dispatch(SubscriptionAction.ForceUpdate(data = data, dataUpdatedAt = epoch()))
         }
 
         fun isCacheable(reply: Reply<T>): Boolean {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlusPolicy.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlusPolicy.kt
@@ -35,6 +35,22 @@ interface SwrCachePlusPolicy : SwrCachePolicy {
      * Management of cached data for inactive [Subscription] instances.
      */
     val subscriptionCache: SubscriptionCache
+
+    /**
+     * The specified filter to resume subscriptions after network connectivity is reconnected.
+     *
+     * **Note:**
+     * This setting is only effective when [networkConnectivity] is available.
+     */
+    val networkResumeSubscriptionsFilter: ResumeSubscriptionsFilter
+
+    /**
+     * The specified filter to resume subscriptions after window visibility is refocused.
+     *
+     * **Note:**
+     * This setting is only effective when [windowVisibility] is available.
+     */
+    val windowResumeSubscriptionsFilter: ResumeSubscriptionsFilter
 }
 
 /**
@@ -56,8 +72,10 @@ interface SwrCachePlusPolicy : SwrCachePolicy {
  * @param networkConnectivity Management of network connectivity.
  * @param networkResumeAfterDelay Duration after which the network resumes.
  * @param networkResumeQueriesFilter Filter for resuming queries after a network error.
+ * @param networkResumeSubscriptionsFilter Filter for resuming subscriptions after a network error.
  * @param windowVisibility Management of window visibility.
  * @param windowResumeQueriesFilter Filter for resuming queries after a window focus.
+ * @param windowResumeSubscriptionsFilter Filter for resuming subscriptions after a window focus.
  */
 @ExperimentalSoilQueryApi
 fun SwrCachePlusPolicy(
@@ -79,9 +97,15 @@ fun SwrCachePlusPolicy(
     networkResumeQueriesFilter: ResumeQueriesFilter = ResumeQueriesFilter(
         predicate = { it.isFailure }
     ),
+    networkResumeSubscriptionsFilter: ResumeSubscriptionsFilter = ResumeSubscriptionsFilter(
+        predicate = { it.isFailure }
+    ),
     windowVisibility: WindowVisibility = WindowVisibility,
     windowResumeQueriesFilter: ResumeQueriesFilter = ResumeQueriesFilter(
         predicate = { it.isStaled() }
+    ),
+    windowResumeSubscriptionsFilter: ResumeSubscriptionsFilter = ResumeSubscriptionsFilter(
+        predicate = { it.isFailure }
     )
 ): SwrCachePlusPolicy = SwrCachePlusPolicyImpl(
     coroutineScope = coroutineScope,
@@ -100,8 +124,10 @@ fun SwrCachePlusPolicy(
     networkConnectivity = networkConnectivity,
     networkResumeAfterDelay = networkResumeAfterDelay,
     networkResumeQueriesFilter = networkResumeQueriesFilter,
+    networkResumeSubscriptionsFilter = networkResumeSubscriptionsFilter,
     windowVisibility = windowVisibility,
-    windowResumeQueriesFilter = windowResumeQueriesFilter
+    windowResumeQueriesFilter = windowResumeQueriesFilter,
+    windowResumeSubscriptionsFilter = windowResumeSubscriptionsFilter
 )
 
 /**
@@ -120,8 +146,10 @@ fun SwrCachePlusPolicy(
  * @param networkConnectivity Management of network connectivity.
  * @param networkResumeAfterDelay Duration after which the network resumes.
  * @param networkResumeQueriesFilter Filter for resuming queries after a network error.
+ * @param networkResumeSubscriptionsFilter Filter for resuming subscriptions after a network error.
  * @param windowVisibility Management of window visibility.
  * @param windowResumeQueriesFilter Filter for resuming queries after a window focus.
+ * @param windowResumeSubscriptionsFilter Filter for resuming subscriptions after a window focus.
  * @param receiverBuilder Receiver builder for [MutationReceiver], [QueryReceiver] and [SubscriptionReceiver].
  */
 @ExperimentalSoilQueryApi
@@ -141,9 +169,15 @@ fun SwrCachePlusPolicy(
     networkResumeQueriesFilter: ResumeQueriesFilter = ResumeQueriesFilter(
         predicate = { it.isFailure }
     ),
+    networkResumeSubscriptionsFilter: ResumeSubscriptionsFilter = ResumeSubscriptionsFilter(
+        predicate = { it.isFailure }
+    ),
     windowVisibility: WindowVisibility = WindowVisibility,
     windowResumeQueriesFilter: ResumeQueriesFilter = ResumeQueriesFilter(
         predicate = { it.isStaled() }
+    ),
+    windowResumeSubscriptionsFilter: ResumeSubscriptionsFilter = ResumeSubscriptionsFilter(
+        predicate = { it.isFailure }
     ),
     receiverBuilder: SwrReceiverBuilderPlus.() -> Unit
 ): SwrCachePlusPolicy {
@@ -165,8 +199,10 @@ fun SwrCachePlusPolicy(
         networkConnectivity = networkConnectivity,
         networkResumeAfterDelay = networkResumeAfterDelay,
         networkResumeQueriesFilter = networkResumeQueriesFilter,
+        networkResumeSubscriptionsFilter = networkResumeSubscriptionsFilter,
         windowVisibility = windowVisibility,
-        windowResumeQueriesFilter = windowResumeQueriesFilter
+        windowResumeQueriesFilter = windowResumeQueriesFilter,
+        windowResumeSubscriptionsFilter = windowResumeSubscriptionsFilter
     )
 }
 
@@ -188,6 +224,8 @@ internal class SwrCachePlusPolicyImpl(
     override val networkConnectivity: NetworkConnectivity,
     override val networkResumeAfterDelay: Duration,
     override val networkResumeQueriesFilter: ResumeQueriesFilter,
+    override val networkResumeSubscriptionsFilter: ResumeSubscriptionsFilter,
     override val windowVisibility: WindowVisibility,
-    override val windowResumeQueriesFilter: ResumeQueriesFilter
+    override val windowResumeQueriesFilter: ResumeQueriesFilter,
+    override val windowResumeSubscriptionsFilter: ResumeSubscriptionsFilter
 ) : SwrCachePlusPolicy

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrClient.kt
@@ -5,6 +5,7 @@ package soil.query
 
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
+import soil.query.core.Effect
 import soil.query.core.ErrorRecord
 import soil.query.core.MemoryPressureLevel
 
@@ -40,7 +41,13 @@ interface SwrClient : MutationClient, QueryClient {
     /**
      * Executes side effects for queries.
      */
+    @Deprecated("Use effect(block: Effect) instead.", ReplaceWith("effect(block)"))
     fun perform(sideEffects: QueryEffect): Job
+
+    /**
+     * Executes side effects for queries.
+     */
+    fun effect(block: Effect): Job
 
     /**
      * Executes initialization procedures based on events.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrClientPlus.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrClientPlus.kt
@@ -3,6 +3,9 @@
 
 package soil.query
 
+import kotlinx.coroutines.Job
+import soil.query.core.Effect
+
 /**
  * An enhanced version of [SwrClient] that integrates [SubscriptionClient] into SwrClient.
  */
@@ -16,4 +19,9 @@ interface SwrClientPlus : SwrClient, SubscriptionClient {
      * This method should only be used for full resets, such as during sign-out.
      */
     override fun purgeAll()
+
+    /**
+     * Executes side effects for queries and subscriptions.
+     */
+    override fun effect(block: Effect): Job
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/Effect.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/Effect.kt
@@ -1,0 +1,42 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+/**
+ * A type used to handle side effects.
+ */
+typealias Effect = suspend EffectContext.() -> Unit
+
+/**
+ * An interface to access contextual information within an [Effect] operation.
+ */
+interface EffectContext {
+    operator fun <T : Any> get(key: EffectPropertyKey<T>): T
+}
+
+/**
+ * Creates an [EffectContext] with the specified properties.
+ */
+fun EffectContext(vararg pairs: Pair<EffectPropertyKey<*>, Any>): EffectContext {
+    return EffectContextImpl(pairs.toMap())
+}
+
+/**
+ * A class representing one of the property types referenced within an [Effect] operation.
+ *
+ * ```kotlin
+ * val queryEffectClientPropertyKey = EffectPropertyKey<QueryEffectClient>()
+ * ```
+ */
+class EffectPropertyKey<T : Any>(val errorDescription: String)
+
+internal class EffectContextImpl(
+    private val context: Map<EffectPropertyKey<*>, Any>
+) : EffectContext {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> get(key: EffectPropertyKey<T>): T {
+        return checkNotNull(context[key]) { key.errorDescription } as T
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/Filter.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/Filter.kt
@@ -1,0 +1,60 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+/**
+ * Interface for filtering side effect
+ */
+interface Filter<T : DataModel<*>> {
+
+    /**
+     * Management category of queries to be filtered.
+     *
+     * If unspecified, all [FilterType]s are targeted.
+     */
+    val type: FilterType?
+
+    /**
+     * Tag keys of queries to be filtered.
+     */
+    val keys: Array<SurrogateKey>?
+
+    /**
+     * Further conditions to narrow down the filtering targets based on fields of [T].
+     */
+    val predicate: ((T) -> Boolean)?
+}
+
+/**
+ * Filter for invalidating targets.
+ */
+class InvalidateFilter<T : DataModel<*>>(
+    override val type: FilterType? = null,
+    override val keys: Array<SurrogateKey>? = null,
+    override val predicate: ((T) -> Boolean)? = null,
+) : Filter<T>
+
+/**
+ * Filter for removing targets.
+ */
+class RemoveFilter<T : DataModel<*>>(
+    override val type: FilterType? = null,
+    override val keys: Array<SurrogateKey>? = null,
+    override val predicate: ((T) -> Boolean)? = null,
+) : Filter<T>
+
+/**
+ * Filter for resuming targets.
+ */
+class ResumeFilter<T : DataModel<*>>(
+    override val keys: Array<SurrogateKey>? = null,
+    override val predicate: (T) -> Boolean
+) : Filter<T> {
+    override val type: FilterType = FilterType.Active
+}
+
+enum class FilterType {
+    Active,
+    Inactive
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/FilterResolver.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/FilterResolver.kt
@@ -1,0 +1,57 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+/**
+ * An interface for resolving the data sources targeted by a [Filter].
+ */
+internal interface FilterResolver<T : DataModel<*>> {
+
+    /**
+     * Resolves a list of [UniqueId]s managed under the specified [FilterType].
+     */
+    fun resolveKeys(type: FilterType): Set<UniqueId>
+
+    /**
+     * Resolves the data corresponding to the [UniqueId] managed under the specified [FilterType].
+     */
+    fun resolveValue(type: FilterType, id: UniqueId): T?
+}
+
+
+internal fun <T : DataModel<*>> FilterResolver<T>.forEach(
+    filter: Filter<T>,
+    action: (UniqueId, FilterType) -> Unit
+) {
+    if (filter.type == null || filter.type == FilterType.Active) {
+        forEach(FilterType.Active, filter.keys, filter.predicate) { id ->
+            action(id, FilterType.Active)
+        }
+    }
+    if (filter.type == null || filter.type == FilterType.Inactive) {
+        forEach(FilterType.Inactive, filter.keys, filter.predicate) { id ->
+            action(id, FilterType.Inactive)
+        }
+    }
+}
+
+private fun <T : DataModel<*>> FilterResolver<T>.forEach(
+    type: FilterType,
+    keys: Array<SurrogateKey>?,
+    predicate: ((T) -> Boolean)?,
+    action: (UniqueId) -> Unit
+) {
+    resolveKeys(type)
+        .toSet()
+        .asSequence()
+        .filter { id ->
+            if (keys.isNullOrEmpty()) true
+            else keys.any { id.tags.contains(it) }
+        }
+        .filter { id ->
+            if (predicate == null) true
+            else resolveValue(type, id)?.let(predicate) ?: false
+        }
+        .forEach(action)
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/core/EffectTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/core/EffectTest.kt
@@ -1,0 +1,30 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class EffectTest : UnitTest() {
+
+    @Test
+    fun testEffectContext() {
+        val testPropertyKey = EffectPropertyKey<String>("test")
+        val context = EffectContext(testPropertyKey to "value")
+        val value = context[testPropertyKey]
+        assertEquals("value", value)
+    }
+
+    @Test
+    fun testEffectContext_keyNotFound() {
+        val testPropertyKey = EffectPropertyKey<String>("test")
+        val context = EffectContext()
+        val t = assertFails {
+            context[testPropertyKey]
+        }
+        assertEquals("test", t.message)
+    }
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/core/FilterResolverTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/core/FilterResolverTest.kt
@@ -1,0 +1,166 @@
+// Copyright 2024 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FilterResolverTest : UnitTest() {
+
+    @Test
+    fun testForEach_type() {
+        val store = mapOf<UniqueId, TestModel>(
+            TestId("1") to TestModel.create("1"),
+            TestId("2") to TestModel.create(RuntimeException("2")),
+            TestId("3") to TestModel.create("3")
+        )
+        val cache = mapOf<UniqueId, TestModel>(
+            TestId("4") to TestModel.create("4"),
+            TestId("5") to TestModel.create("5"),
+            TestId("6") to TestModel.create("6")
+        )
+        val resolver = TestFilterResolver(store, cache)
+        val filter1 = InvalidateFilter<TestModel>()
+        val keys1 = mutableSetOf<UniqueId>()
+        resolver.forEach(filter1) { id, _ -> keys1.add(id) }
+        assertEquals(keys1.map { it.namespace }.toSet(), setOf("1", "2", "3", "4", "5", "6"))
+
+        val filter2 = InvalidateFilter<TestModel>(
+            type = FilterType.Active
+        )
+        val keys2 = mutableSetOf<UniqueId>()
+        resolver.forEach(filter2) { id, _ -> keys2.add(id) }
+        assertEquals(keys2.map { it.namespace }.toSet(), setOf("1", "2", "3"))
+
+        val filter3 = InvalidateFilter<TestModel>(
+            type = FilterType.Inactive
+        )
+        val keys3 = mutableSetOf<UniqueId>()
+        resolver.forEach(filter3) { id, _ -> keys3.add(id) }
+        assertEquals(keys3.map { it.namespace }.toSet(), setOf("4", "5", "6"))
+    }
+
+    @Test
+    fun testForEach_keys() {
+        val store = mapOf<UniqueId, TestModel>(
+            TestId("1") to TestModel.create("1"),
+            TestId("2") to TestModel.create(RuntimeException("2")),
+            TestId("3", "bar") to TestModel.create("3")
+        )
+        val cache = mapOf<UniqueId, TestModel>(
+            TestId("4", "test") to TestModel.create("4"),
+            TestId("5") to TestModel.create("5"),
+            TestId("6", "foo") to TestModel.create("6")
+        )
+        val resolver = TestFilterResolver(store, cache)
+        val filter1 = InvalidateFilter<TestModel>(
+            keys = arrayOf("bar", "foo")
+        )
+        val keys1 = mutableSetOf<UniqueId>()
+        resolver.forEach(filter1) { id, _ -> keys1.add(id) }
+        assertEquals(keys1.map { it.namespace }.toSet(), setOf("3", "6"))
+    }
+
+    @Test
+    fun testForEach_predicate() {
+        val store = mapOf<UniqueId, TestModel>(
+            TestId("1") to TestModel.create("1"),
+            TestId("2") to TestModel.create(RuntimeException("2")),
+            TestId("3") to TestModel.create("3")
+        )
+        val cache = mapOf<UniqueId, TestModel>(
+            TestId("4") to TestModel.create("4"),
+            TestId("5") to TestModel.create("5"),
+            TestId("6") to TestModel.create("6")
+        )
+        val resolver = TestFilterResolver(store, cache)
+        val filter1 = InvalidateFilter<TestModel>(
+            predicate = { it.error != null }
+        )
+        val keys1 = mutableSetOf<UniqueId>()
+        resolver.forEach(filter1) { id, _ -> keys1.add(id) }
+        assertEquals(keys1.map { it.namespace }.toSet(), setOf("2"))
+    }
+
+    @Test
+    fun testForEach_combination() {
+        val store = mapOf<UniqueId, TestModel>(
+            TestId("1") to TestModel.create("1"),
+            TestId("2") to TestModel.create(RuntimeException("2")),
+            TestId("3", "test") to TestModel.create("3")
+        )
+        val cache = mapOf<UniqueId, TestModel>(
+            TestId("4") to TestModel.create("4"),
+            TestId("5") to TestModel.create("5"),
+            TestId("6") to TestModel.create("6")
+        )
+        val resolver = TestFilterResolver(store, cache)
+        val filter1 = InvalidateFilter<TestModel>(
+            type = FilterType.Active,
+            keys = arrayOf("test"),
+            predicate = { !it.reply.isNone }
+        )
+        val keys1 = mutableSetOf<UniqueId>()
+        resolver.forEach(filter1) { id, _ -> keys1.add(id) }
+        assertEquals(keys1.map { it.namespace }.toSet(), setOf("3"))
+    }
+
+    class TestId(
+        override val namespace: String,
+        override vararg val tags: SurrogateKey = emptyArray()
+    ) : UniqueId {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as TestId
+
+            if (namespace != other.namespace) return false
+            if (!tags.contentEquals(other.tags)) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = namespace.hashCode()
+            result = 31 * result + tags.contentHashCode()
+            return result
+        }
+    }
+
+    data class TestModel(
+        override val reply: Reply<String>,
+        override val replyUpdatedAt: Long,
+        override val error: Throwable?,
+        override val errorUpdatedAt: Long,
+    ) : DataModel<String> {
+        override fun isAwaited(): Boolean = false
+
+        companion object {
+            fun create(value: String): TestModel {
+                return TestModel(Reply.some(value), epoch(), null, 0)
+            }
+
+            fun create(error: Throwable): TestModel {
+                return TestModel(Reply.none(), epoch(), error, epoch())
+            }
+        }
+    }
+
+    class TestFilterResolver(
+        private val store: Map<UniqueId, TestModel>,
+        private val cache: Map<UniqueId, TestModel>
+    ) : FilterResolver<TestModel> {
+        override fun resolveKeys(type: FilterType): Set<UniqueId> = when (type) {
+            FilterType.Active -> store.keys
+            FilterType.Inactive -> cache.keys
+        }
+
+        override fun resolveValue(type: FilterType, id: UniqueId): TestModel? = when (type) {
+            FilterType.Active -> store[id]
+            FilterType.Inactive -> cache[id]
+        }
+    }
+}


### PR DESCRIPTION
This PR extends the Subscription API to allow invoking side effects, similar to the Query API. With this enhancement, the following functionalities are now supported:

Filter execution upon network reconnection:

* `SubscriptionOptions#restartOnReconnect`
* `SwrCachePlusPolicy#networkResumeSubscriptionsFilter`

Filter execution upon a window refocused:

* `SubscriptionOptions#restartOnFocus`
* `SwrCachePlusPolicy#windowResumeSubscriptionsFilter`

Triggering side effects via SwrClient:

* `SwrClient#effect`

Triggering side effects upon a successful mutation:

* `MutationKey#onMutateEffect`