### PR TITLE
Add Receiver Properties to Each Client for Receiver Interfaces

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import soil.query.MutationClient
 import soil.query.MutationId
 import soil.query.MutationKey
+import soil.query.MutationReceiver
 import soil.query.MutationRef
 import soil.query.MutationState
 import soil.query.core.Marker
@@ -28,6 +29,8 @@ import soil.query.core.getOrThrow
 class MutationPreviewClient(
     private val previewData: Map<UniqueId, MutationState<*>>
 ) : MutationClient {
+
+    override val mutationReceiver: MutationReceiver = MutationReceiver
 
     @Suppress("UNCHECKED_CAST")
     override fun <T, S> getMutation(

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/QueryPreviewClient.kt
@@ -14,6 +14,7 @@ import soil.query.QueryChunks
 import soil.query.QueryClient
 import soil.query.QueryId
 import soil.query.QueryKey
+import soil.query.QueryReceiver
 import soil.query.QueryRef
 import soil.query.QueryState
 import soil.query.core.Marker
@@ -32,6 +33,8 @@ import soil.query.core.UniqueId
 class QueryPreviewClient(
     private val previewData: Map<UniqueId, QueryState<*>>
 ) : QueryClient {
+
+    override val queryReceiver: QueryReceiver = QueryReceiver
 
     @Suppress("UNCHECKED_CAST")
     override fun <T> getQuery(

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SubscriptionPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SubscriptionPreviewClient.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import soil.query.SubscriptionClient
 import soil.query.SubscriptionId
 import soil.query.SubscriptionKey
+import soil.query.SubscriptionReceiver
 import soil.query.SubscriptionRef
 import soil.query.SubscriptionState
 import soil.query.annotation.ExperimentalSoilQueryApi
@@ -28,6 +29,8 @@ import soil.query.core.UniqueId
 class SubscriptionPreviewClient(
     private val previewData: Map<UniqueId, SubscriptionState<*>>
 ) : SubscriptionClient {
+
+    override val subscriptionReceiver = SubscriptionReceiver
 
     @ExperimentalSoilQueryApi
     @Suppress("UNCHECKED_CAST")

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationClient.kt
@@ -11,6 +11,12 @@ import soil.query.core.Marker
 interface MutationClient {
 
     /**
+     * **Note:** This property is exposed for limited use cases where you may need to call [MutationKey.mutate] manually.
+     * It can be useful as an escape hatch or for synchronous invocations within the data layer.
+     */
+    val mutationReceiver: MutationReceiver
+
+    /**
      * Gets the [MutationRef] by the specified [MutationKey].
      */
     fun <T, S> getMutation(

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
@@ -12,6 +12,12 @@ import soil.query.core.Marker
 interface QueryClient {
 
     /**
+     * **Note:** This property is exposed for limited use cases where you may need to call [QueryKey.fetch] and [InfiniteQueryKey.fetch] manually.
+     * It can be useful as an escape hatch or for synchronous invocations within the data layer.
+     */
+    val queryReceiver: QueryReceiver
+
+    /**
      * Gets the [QueryRef] by the specified [QueryKey].
      */
     fun <T> getQuery(

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionClient.kt
@@ -12,6 +12,12 @@ import soil.query.core.Marker
 interface SubscriptionClient {
 
     /**
+     * **Note:** This property is exposed for limited use cases where you may need to call [SubscriptionKey.subscribe] manually.
+     * It can be useful as an escape hatch or for synchronous invocations within the data layer.
+     */
+    val subscriptionReceiver: SubscriptionReceiver
+
+    /**
      * Gets the [SubscriptionRef] by the specified [SubscriptionKey].
      */
     @ExperimentalSoilQueryApi

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCacheInternal.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCacheInternal.kt
@@ -38,10 +38,8 @@ abstract class SwrCacheInternal : MutationClient, QueryClient, QueryEffectClient
     protected abstract val coroutineScope: CoroutineScope
     protected abstract val mainDispatcher: CoroutineDispatcher
     protected abstract val mutationOptions: MutationOptions
-    protected abstract val mutationReceiver: MutationReceiver
     protected abstract val mutationStore: MutableMap<UniqueId, ManagedMutation<*>>
     protected abstract val queryOptions: QueryOptions
-    protected abstract val queryReceiver: QueryReceiver
     protected abstract val queryStore: MutableMap<UniqueId, ManagedQuery<*>>
     protected abstract val queryCache: QueryCache
     protected abstract val batchScheduler: BatchScheduler

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlusInternal.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SwrCachePlusInternal.kt
@@ -39,7 +39,6 @@ import soil.query.core.vvv
 abstract class SwrCachePlusInternal : SwrCacheInternal(), SubscriptionClient, SubscriptionEffectClient {
 
     protected abstract val subscriptionOptions: SubscriptionOptions
-    protected abstract val subscriptionReceiver: SubscriptionReceiver
     protected abstract val subscriptionStore: MutableMap<UniqueId, ManagedSubscription<*>>
     protected abstract val subscriptionCache: SubscriptionCache
 


### PR DESCRIPTION
We decided to expose corresponding receiver properties to make each Key implementation in soil.query usable as a simplified API wrapper. This is useful when calling from non-Compose parts of the application.

```kotlin
suspend fun doSomething() {
  val key = ExampleQueryKey(..)
  val swrClient = ...
  val data = with(key) { swrClient.queryReceiver.fetch() }
}
```