### PR TITLE
Redesign of the Marker Interface

### DIFF
--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/Marker.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/Marker.kt
@@ -3,6 +3,11 @@
 
 package soil.query.core
 
+// ---------------------------------------------------------------------------- //
+// The design of this code draws significant inspiration from CoroutineContext.
+// Many thanks to the original authors for their excellent work.
+// ---------------------------------------------------------------------------- //
+
 /**
  * An interface for providing additional information based on the caller of a query or mutation.
  *
@@ -12,5 +17,116 @@ package soil.query.core
  * even if the same query or mutation is used in multiple places.
  */
 interface Marker {
-    companion object None : Marker
+
+    operator fun <E : Element> get(key: Key<E>): E?
+
+    operator fun plus(other: Marker): Marker {
+        if (other === None) return this
+        return other.fold(this) { acc, element ->
+            val removed = acc.minusKey(element.key)
+            if (removed === None) {
+                element
+            } else {
+                CombinedMarker(removed, element)
+            }
+        }
+    }
+
+    fun <R> fold(initial: R, operation: (R, Element) -> R): R
+
+    fun minusKey(key: Key<*>): Marker
+
+    interface Key<E : Element>
+
+    interface Element : Marker {
+        val key: Key<*>
+
+        @Suppress("UNCHECKED_CAST")
+        override operator fun <E : Element> get(key: Key<E>): E? {
+            return if (this.key == key) this as E else null
+        }
+
+        override fun <R> fold(initial: R, operation: (R, Element) -> R): R {
+            return operation(initial, this)
+        }
+
+        override fun minusKey(key: Key<*>): Marker {
+            return if (this.key == key) None else this
+        }
+    }
+
+    companion object None : Marker {
+        override fun <E : Element> get(key: Key<E>): E? = null
+        override fun <R> fold(initial: R, operation: (R, Element) -> R): R = initial
+        override fun plus(other: Marker): Marker = other
+        override fun minusKey(key: Key<*>): Marker = this
+    }
+}
+
+internal class CombinedMarker(
+    private val left: Marker,
+    private val element: Marker.Element
+) : Marker {
+
+    override fun <E : Marker.Element> get(key: Marker.Key<E>): E? {
+        var cur = this
+        while (true) {
+            cur.element[key]?.let { return it }
+            val next = cur.left
+            if (next is CombinedMarker) {
+                cur = next
+            } else {
+                return next[key]
+            }
+        }
+    }
+
+    override fun <R> fold(initial: R, operation: (R, Marker.Element) -> R): R {
+        return operation(left.fold(initial, operation), element)
+    }
+
+    override fun minusKey(key: Marker.Key<*>): Marker {
+        element[key]?.let { return left }
+        val newLeft = left.minusKey(key)
+        return when {
+            newLeft === left -> this
+            newLeft === Marker -> element
+            else -> CombinedMarker(newLeft, element)
+        }
+    }
+
+    private fun size(): Int {
+        var cur = this
+        var size = 2
+        while (true) {
+            cur = cur.left as? CombinedMarker ?: return size
+            size++
+        }
+    }
+
+    private fun contains(element: Marker.Element): Boolean {
+        return get(element.key) == element
+    }
+
+    private fun containsAll(context: CombinedMarker): Boolean {
+        var cur = context
+        while (true) {
+            if (!contains(cur.element)) return false
+            val next = cur.left
+            if (next is CombinedMarker) {
+                cur = next
+            } else {
+                return contains(next as Marker.Element)
+            }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return this === other ||
+            other is CombinedMarker && other.size() == size() && other.containsAll(this)
+    }
+
+    override fun hashCode(): Int {
+        return left.hashCode() + element.hashCode()
+    }
 }

--- a/soil-query-core/src/commonTest/kotlin/soil/query/core/ErrorRelayTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/core/ErrorRelayTest.kt
@@ -96,14 +96,14 @@ class ErrorRelayTest : UnitTest() {
         val relay = ErrorRelay.newAnycast(
             scope = backgroundScope,
             policy = TestErrorRelayPolicy(
-                shouldSuppressError = { it.marker == SuppressMarker }
+                shouldSuppressError = { it.marker == ErrorMarker.Suppress }
             )
         )
 
         val err1 = ErrorRecord(
             exception = RuntimeException("Error 1"),
             keyId = QueryId<String>(namespace = "test"),
-            marker = SuppressMarker
+            marker = ErrorMarker.Suppress
         )
 
         relay.send(err1)
@@ -126,7 +126,7 @@ class ErrorRelayTest : UnitTest() {
         val err1 = ErrorRecord(
             exception = RuntimeException("Error 1"),
             keyId = QueryId<String>(namespace = "test"),
-            marker = SuppressMarker
+            marker = ErrorMarker.Suppress
         )
 
         relay.send(err1)
@@ -152,5 +152,12 @@ class ErrorRelayTest : UnitTest() {
         override val areErrorsEqual: (ErrorRecord, ErrorRecord) -> Boolean = ErrorRelayPolicy.None.areErrorsEqual
     ) : ErrorRelayPolicy
 
-    object SuppressMarker : Marker
+    sealed class ErrorMarker : Marker.Element {
+        override val key: Marker.Key<*>
+            get() = Key
+
+        companion object Key : Marker.Key<ErrorMarker>
+
+        data object Suppress : ErrorMarker()
+    }
 }


### PR DESCRIPTION
The `Marker` introduced in #80 has the potential to be used more extensively within the library in the future. Inspired by `CoroutineContext`, we decided to redesign it to allow combining custom Marker elements.

```kotlin
val marker: Marker = XxxMarker.Foo + YyyMarker.Bar

val xxxMarker = marker[XxxMarker]
if (xxxMarker != null) { .. }
```

As a result of this change, users currently utilizing the `Marker` interface will need to migrate their implementations. Please refer to the implementation of `ErrorRelayTest`.

```
sealed class ErrorMarker : Marker.Element {
    override val key: Marker.Key<*>
        get() = Key

    companion object Key : Marker.Key<ErrorMarker>

    data object Suppress : ErrorMarker()
}
```