### PR TITLE
Partial Integration of Await and Catch Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ dependencies {
 
     // Query
     implementation("com.soil-kt.soil:query-core:$soil")
-    // Query utilities for Compose
+    // Query for Compose
     implementation("com.soil-kt.soil:query-compose:$soil")
-    // optional - helpers for Compose
+    // optional - experimental helpers for Compose
     implementation("com.soil-kt.soil:query-compose-runtime:$soil")
     // optional - receivers for Ktor (3.x)
     implementation("com.soil-kt.soil:query-receivers-ktor:$soil")

--- a/sample/composeApp/src/commonMain/kotlin/soil/kmp/screen/HelloQueryDetailScreen.kt
+++ b/sample/composeApp/src/commonMain/kotlin/soil/kmp/screen/HelloQueryDetailScreen.kt
@@ -22,7 +22,6 @@ import soil.playground.query.data.Post
 import soil.playground.query.data.Posts
 import soil.playground.query.data.User
 import soil.query.compose.runtime.Await
-import soil.query.compose.runtime.Catch
 import soil.query.compose.runtime.ErrorBoundary
 import soil.query.compose.runtime.Suspense
 import soil.query.compose.util.rememberQueriesErrorReset
@@ -91,7 +90,6 @@ private fun PostDetailContainer(
     Await(query) { post ->
         content(post)
     }
-    Catch(query)
 }
 
 @Composable
@@ -109,5 +107,4 @@ private fun PostUserDetailContainer(
             content(user, posts)
         }
     }
-    Catch(userQuery, postsQuery)
 }

--- a/sample/composeApp/src/commonMain/kotlin/soil/kmp/screen/HelloQueryScreen.kt
+++ b/sample/composeApp/src/commonMain/kotlin/soil/kmp/screen/HelloQueryScreen.kt
@@ -13,8 +13,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.ktor.client.plugins.ResponseException
-import soil.playground.Alert
 import soil.playground.query.compose.ContentLoading
 import soil.playground.query.compose.ContentUnavailable
 import soil.playground.query.compose.PostListItem
@@ -24,7 +22,6 @@ import soil.playground.query.data.Posts
 import soil.playground.router.NavLink
 import soil.playground.style.withAppTheme
 import soil.query.compose.runtime.Await
-import soil.query.compose.runtime.Catch
 import soil.query.compose.runtime.ErrorBoundary
 import soil.query.compose.runtime.LazyLoadEffect
 import soil.query.compose.runtime.Suspense
@@ -113,15 +110,6 @@ private fun ListSectionContainer(
             derivedStateOf { ListSectionState(posts, query.loadMoreParam, query.loadMore) }
         }
         content(state)
-    }
-    Catch(query) { e ->
-        // You can also write your own error handling logic.
-        // Try testing the error by setting your mobile device to AirPlane mode.
-        if (e !is ResponseException) {
-            Alert(message = "Unexpected error :(")
-            return@Catch
-        }
-        Throw(e)
     }
 }
 

--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Catch.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/Catch.kt
@@ -11,192 +11,21 @@ import soil.query.core.DataModel
 import soil.query.core.uuid
 
 /**
- * Catch for a [DataModel] to be rejected.
- *
- * @param state The [DataModel] to catch.
- * @param isEnabled Whether to catch the error.
- * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
- */
-@Composable
-fun Catch(
-    state: DataModel<*>,
-    isEnabled: Boolean = true,
-    content: @Composable CatchScope.(err: Throwable) -> Unit = { Throw(error = it) }
-) {
-    Catch(
-        state = state,
-        filterIsInstance = { it },
-        isEnabled = isEnabled,
-        content = content
-    )
-}
-
-/**
- * Catch for any [DataModel]s to be rejected.
- *
- * @param state1 The first [DataModel] to catch.
- * @param state2 The second [DataModel] to catch.
- * @param isEnabled Whether to catch the error.
- * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
- */
-@Composable
-fun Catch(
-    state1: DataModel<*>,
-    state2: DataModel<*>,
-    isEnabled: Boolean = true,
-    content: @Composable CatchScope.(err: Throwable) -> Unit = { Throw(error = it) }
-) {
-    Catch(
-        state1 = state1,
-        state2 = state2,
-        filterIsInstance = { it },
-        isEnabled = isEnabled,
-        content = content
-    )
-}
-
-/**
- * Catch for any [DataModel]s to be rejected.
- *
- * @param state1 The first [DataModel] to catch.
- * @param state2 The second [DataModel] to catch.
- * @param state3 The third [DataModel] to catch.
- * @param isEnabled Whether to catch the error.
- * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
- */
-@Composable
-fun Catch(
-    state1: DataModel<*>,
-    state2: DataModel<*>,
-    state3: DataModel<*>,
-    isEnabled: Boolean = true,
-    content: @Composable CatchScope.(err: Throwable) -> Unit = { Throw(error = it) }
-) {
-    Catch(
-        state1 = state1,
-        state2 = state2,
-        state3 = state3,
-        filterIsInstance = { it },
-        isEnabled = isEnabled,
-        content = content
-    )
-}
-
-/**
  * Catch for any [DataModel]s to be rejected.
  *
  * @param states The [DataModel]s to catch.
- * @param isEnabled Whether to catch the error.
+ * @param filter A function to filter the error.
  * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
  */
 @Composable
-fun Catch(
+inline fun Catch(
     vararg states: DataModel<*>,
-    isEnabled: Boolean = true,
+    filter: (DataModel<*>) -> Boolean = { true },
     content: @Composable CatchScope.(err: Throwable) -> Unit = { Throw(error = it) }
 ) {
-    Catch(
-        states = states,
-        filterIsInstance = { it },
-        isEnabled = isEnabled,
-        content = content
-    )
-}
-
-/**
- * Catch for a [DataModel] to be rejected.
- *
- * @param state The [DataModel] to catch.
- * @param filterIsInstance A function to filter the error.
- * @param isEnabled Whether to catch the error.
- * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
- */
-@Composable
-fun <T : Throwable> Catch(
-    state: DataModel<*>,
-    filterIsInstance: (err: Throwable) -> T?,
-    isEnabled: Boolean = true,
-    content: @Composable CatchScope.(err: T) -> Unit = { Throw(error = it) }
-) {
-    val err = state.error.takeIf { isEnabled }?.let(filterIsInstance)
-    if (err != null) {
-        with(CatchScope) { content(err) }
-    }
-}
-
-/**
- * Catch for any [DataModel]s to be rejected.
- *
- * @param state1 The first [DataModel] to catch.
- * @param state2 The second [DataModel] to catch.
- * @param filterIsInstance A function to filter the error.
- * @param isEnabled Whether to catch the error.
- * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
- */
-@Composable
-fun <T : Throwable> Catch(
-    state1: DataModel<*>,
-    state2: DataModel<*>,
-    filterIsInstance: (err: Throwable) -> T?,
-    isEnabled: Boolean = true,
-    content: @Composable CatchScope.(err: T) -> Unit = { Throw(error = it) }
-) {
-    val err = listOf(state1, state2).takeIf { isEnabled }
-        ?.firstNotNullOfOrNull { it.error }
-        ?.let(filterIsInstance)
-
-    if (err != null) {
-        with(CatchScope) { content(err) }
-    }
-}
-
-/**
- * Catch for any [DataModel]s to be rejected.
- *
- * @param state1 The first [DataModel] to catch.
- * @param state2 The second [DataModel] to catch.
- * @param state3 The third [DataModel] to catch.
- * @param filterIsInstance A function to filter the error.
- * @param isEnabled Whether to catch the error.
- * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
- */
-@Composable
-fun <T : Throwable> Catch(
-    state1: DataModel<*>,
-    state2: DataModel<*>,
-    state3: DataModel<*>,
-    filterIsInstance: (err: Throwable) -> T?,
-    isEnabled: Boolean = true,
-    content: @Composable CatchScope.(err: T) -> Unit = { Throw(error = it) }
-) {
-    val err = listOf(state1, state2, state3).takeIf { isEnabled }
-        ?.firstNotNullOfOrNull { it.error }
-        ?.let(filterIsInstance)
-
-    if (err != null) {
-        with(CatchScope) { content(err) }
-    }
-}
-
-/**
- * Catch for any [DataModel]s to be rejected.
- *
- * @param states The [DataModel]s to catch.
- * @param filterIsInstance A function to filter the error.
- * @param isEnabled Whether to catch the error.
- * @param content The content to display when the query is rejected. By default, it [throws][CatchScope.Throw] the error.
- */
-@Composable
-fun <T : Throwable> Catch(
-    vararg states: DataModel<*>,
-    filterIsInstance: (err: Throwable) -> T?,
-    isEnabled: Boolean = true,
-    content: @Composable CatchScope.(err: T) -> Unit = { Throw(error = it) }
-) {
-    val err = states.takeIf { isEnabled }
-        ?.firstNotNullOfOrNull { it.error }
-        ?.let(filterIsInstance)
-
+    val err = states
+        .filter { it.error != null && filter(it) }
+        .minByOrNull { it.errorUpdatedAt }?.error
     if (err != null) {
         with(CatchScope) { content(err) }
     }


### PR DESCRIPTION
We have decided to partially integrate the functionality of the `Await` and `Catch` composable functions provided in the experimental *query-compose-runtime package*.

Previously, the implementation required placing the `Await` and `Catch` components in parallel. With this integration, a single `Await` component can now achieve the same functionality.

Please note that the `Catch` component will still be available for independent use if needed.