### PR TITLE
Bump Android compile and target SDK to 35

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@ development=true
 #Product
 group=com.soil-kt.soil
 version=1.0.0-alpha09
-androidCompileSdk=34
-androidTargetSdk=34
+androidCompileSdk=35
+androidTargetSdk=35
 androidMinSdk=23
 composeCompilerMetrics=false
 composeCompilerReports=false


### PR DESCRIPTION
Before merging https://github.com/soil-kt/soil/pull/145, we need to update the Android SDK to 35.