### PR TITLE
Introduce Optimistic Update Module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,6 +86,7 @@ kover {
 }
 
 dependencies {
+    kover(projects.soilExperimental.soilOptimisticUpdate)
     kover(projects.soilQueryCore)
     kover(projects.soilQueryCompose)
     kover(projects.soilQueryComposeRuntime)

--- a/buildSrc/src/main/kotlin/BuildModule.kt
+++ b/buildSrc/src/main/kotlin/BuildModule.kt
@@ -1,4 +1,5 @@
 val publicModules = setOf(
+    ":soil-experimental:soil-optimistic-update",
     ":soil-query-core",
     ":soil-query-compose",
     ":soil-query-compose-runtime",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 // Public modules
 include(
+    ":soil-experimental:soil-optimistic-update",
     ":soil-query-core",
     ":soil-query-compose",
     ":soil-query-compose-runtime",

--- a/soil-experimental/soil-optimistic-update/build.gradle.kts
+++ b/soil-experimental/soil-optimistic-update/build.gradle.kts
@@ -1,0 +1,117 @@
+import org.jetbrains.compose.ExperimentalComposeLibrary
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.kotlin.compose.compiler)
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.maven.publish)
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.kover)
+}
+
+val buildTarget = the<BuildTargetExtension>()
+
+kotlin {
+    applyDefaultHierarchyTemplate()
+
+    jvm()
+    androidTarget {
+        publishLibraryVariants("release")
+    }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser {
+            // TODO: We will consider using wasm tests when we update to 'org.jetbrains.compose.ui:ui:1.7.0' or later.
+            //  - https://slack-chats.kotlinlang.org/t/22883390/wasmjs-unit-testing-what-is-the-status-of-unit-testing-on-wa
+            testTask {
+                enabled = false
+            }
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(compose.runtime)
+        }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            @OptIn(ExperimentalComposeLibrary::class)
+            implementation(compose.uiTest)
+            implementation(compose.runtime)
+            implementation(compose.ui)
+            implementation(compose.material)
+            implementation(projects.internal.testing)
+        }
+
+        val androidUnitTest by getting {
+            dependencies {
+                implementation(libs.compose.ui.test.junit4.android)
+                implementation(libs.compose.ui.test.manifest)
+            }
+        }
+
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
+        }
+    }
+}
+
+android {
+    namespace = "soil.optimistic"
+    compileSdk = buildTarget.androidCompileSdk.get()
+
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    sourceSets["main"].res.srcDirs("src/androidMain/res")
+    sourceSets["main"].resources.srcDirs("src/commonMain/resources")
+
+    defaultConfig {
+        minSdk = buildTarget.androidMinSdk.get()
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+        }
+    }
+    compileOptions {
+        sourceCompatibility = buildTarget.javaVersion.get()
+        targetCompatibility = buildTarget.javaVersion.get()
+    }
+    @Suppress("UnstableApiUsage")
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
+    dependencies {
+        debugImplementation(libs.compose.ui.tooling)
+    }
+}
+
+composeCompiler {
+    if (buildTarget.composeCompilerMetrics.getOrElse(false)) {
+        metricsDestination = buildTarget.composeCompilerDestination
+    }
+    if (buildTarget.composeCompilerReports.getOrElse(false)) {
+        reportsDestination = buildTarget.composeCompilerDestination
+    }
+}
+
+kover {
+    currentProject {
+        createVariant("soil") {
+            add("debug")
+        }
+    }
+}

--- a/soil-experimental/soil-optimistic-update/gradle.properties
+++ b/soil-experimental/soil-optimistic-update/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=optimistic-update
+POM_NAME=optimistic-update

--- a/soil-experimental/soil-optimistic-update/src/commonMain/kotlin/soil/optimistic/compose/OptimisticUpdate.kt
+++ b/soil-experimental/soil-optimistic-update/src/commonMain/kotlin/soil/optimistic/compose/OptimisticUpdate.kt
@@ -1,0 +1,204 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
+
+package soil.optimistic.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DisposableHandle
+import kotlinx.coroutines.Job
+
+/**
+ * Function type for updating state with optimistic values.
+ *
+ * @param T The type of the current state.
+ * @param D The type of the optimistic value.
+ * @return The updated state after applying the optimistic value.
+ */
+typealias OptimisticUpdate<T, D> = (currentState: T, optimisticValue: D) -> T
+
+/**
+ * Function type for handling completion of optimistic updates.
+ *
+ * This handle is intended for manual use when you need to explicitly complete an optimistic update.
+ * The parameter represents the throwable that caused the completion, null if completed successfully.
+ */
+typealias OptimisticCompletionHandle = (cause: Throwable?) -> Unit
+
+/**
+ * Creates and remembers an optimistic state object where the state and optimistic value are of the same type.
+ *
+ * This is a convenience overload for when the optimistic value directly replaces the current state.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * var counter by remember { mutableStateOf(0) }
+ * // Using destructuring declaration for cleaner access
+ * val (optimisticState, addOptimistic) = rememberOptimistic(counter)
+ * // Inside a coroutine scope - addOptimistic must be called within a coroutine context
+ * scope.launch {
+ *     // Apply an optimistic update
+ *     val completion = addOptimistic(counter + 1)
+ *
+ *     // Perform the actual operation (e.g. network request)
+ *     try {
+ *         api.incrementCounter()
+ *         counter += 1
+ *         // Signal successful completion
+ *         completion(null)
+ *     } catch (e: Exception) {
+ *         // Signal error - resets optimistic state by default
+ *         completion(e)
+ *     }
+ * }
+ * ```
+ *
+ * @param T The type of both the state and optimistic values.
+ * @param state The initial state.
+ * @param policy The policy that determines how to handle errors in optimistic updates.
+ * @return An [OptimisticObject] that manages optimistic updates.
+ */
+@Composable
+inline fun <T> rememberOptimistic(
+    state: T,
+    policy: OptimisticUpdatePolicy = OptimisticUpdatePolicy.Default,
+): OptimisticObject<T, T> {
+    return rememberOptimistic(
+        state = state,
+        updateFn = { _, optimisticValue -> optimisticValue },
+        policy = policy
+    )
+}
+
+/**
+ * Creates and remembers an optimistic state object that can track optimistic updates.
+ *
+ * Optimistic updates allow showing immediate UI feedback for operations that may take time
+ * to complete, such as network requests. The UI can be updated optimistically assuming
+ * the operation will succeed, then reconciled later if it fails.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * // A list that we want to update optimistically
+ * var items by remember { mutableStateOf(listOf("A", "B", "C")) }
+ *
+ * // Create optimistic state with a custom update function
+ * val (optimisticItems, addItem) = rememberOptimistic<List<String>, String>(
+ *     state = items,
+ *     updateFn = { currentList, newItem -> currentList + newItem }
+ * )
+ *
+ * // Inside a coroutine scope - addItem must be called within a coroutine context
+ * scope.launch {
+ *     // Apply an optimistic update - adds the new item right away
+ *     val completion = addItem("D")
+ *
+ *     // Perform the actual operation
+ *     try {
+ *         api.addItem("D")
+ *         items = items + "D"
+ *         completion(null) // Success
+ *     } catch (e: Exception) {
+ *         completion(e) // Error - reverts the optimistic update
+ *     }
+ * }
+ * ```
+ *
+ * @param T The type of the state.
+ * @param D The type of the optimistic value.
+ * @param state The initial state.
+ * @param policy The policy that determines how to handle errors in optimistic updates.
+ * @param updateFn Function that determines how an optimistic value updates the current state.
+ * @return An [OptimisticObject] that manages optimistic updates.
+ */
+@Composable
+fun <T, D> rememberOptimistic(
+    state: T,
+    policy: OptimisticUpdatePolicy = OptimisticUpdatePolicy.Default,
+    updateFn: OptimisticUpdate<T, D>
+): OptimisticObject<T, D> {
+
+    var pendingUpdates by remember { mutableStateOf(emptyList<Triple<D, Job, DisposableHandle>>()) }
+    val optimisticState = remember(state, pendingUpdates) {
+        pendingUpdates.fold(state) { acc, (optimisticValue, _, _) ->
+            updateFn(acc, optimisticValue)
+        }
+    }
+
+    val addOptimistic = remember<CoroutineScope.(D) -> OptimisticCompletionHandle>() {
+        { value ->
+            val currentJob = coroutineContext[Job] ?: error("No Job in CoroutineScope")
+            val completionHandle: OptimisticCompletionHandle = { err ->
+                if (err != null && policy.shouldResetOnError(cause = err)) {
+                    pendingUpdates.forEach { (_, job, handle) ->
+                        handle.dispose()
+                        job.cancel()
+                    }
+                    pendingUpdates = emptyList()
+                } else {
+                    pendingUpdates = pendingUpdates.filterNot { (_, job, _) -> job === currentJob }
+                }
+            }
+            val disposableHandle = currentJob.invokeOnCompletion { err -> completionHandle(err) }
+            pendingUpdates += Triple(value, currentJob, disposableHandle)
+            completionHandle
+        }
+    }
+
+    return OptimisticObject(optimisticState, addOptimistic)
+}
+
+/**
+ * Data class representing an optimistic state with methods to apply optimistic updates.
+ *
+ * **This class is designed to be used with destructuring declarations for clean access to its properties:**
+ *
+ * ```kotlin
+ * val (optimisticState, addOptimistic) = rememberOptimistic(initialState)
+ * ```
+ *
+ * @param T The type of the state.
+ * @param D The type of the optimistic value.
+ * @property optimisticState The current state including any applied optimistic updates.
+ * @property addOptimistic A function to add a new optimistic update within a CoroutineScope.
+ *             Returns a completion handle that can be used to manually signal completion.
+ */
+@Immutable
+data class OptimisticObject<T, D> internal constructor(
+    val optimisticState: T,
+    val addOptimistic: CoroutineScope.(D) -> OptimisticCompletionHandle,
+)
+
+/**
+ * Interface defining a policy for handling errors in optimistic updates.
+ *
+ * This policy determines whether to reset all pending optimistic updates when an error occurs.
+ */
+@Stable
+interface OptimisticUpdatePolicy {
+
+    /**
+     * Determines whether all optimistic updates should be reset when an error occurs.
+     *
+     * @param cause The throwable that caused the error.
+     * @return True if all pending optimistic updates should be reset, false otherwise.
+     */
+    fun shouldResetOnError(cause: Throwable): Boolean
+
+    /**
+     * Default implementation of [OptimisticUpdatePolicy] that resets all updates on any error.
+     */
+    companion object Default : OptimisticUpdatePolicy {
+        override fun shouldResetOnError(cause: Throwable): Boolean = true
+    }
+}

--- a/soil-experimental/soil-optimistic-update/src/commonTest/kotlin/soil/optimistic/compose/OptimisticUpdateTest.kt
+++ b/soil-experimental/soil-optimistic-update/src/commonTest/kotlin/soil/optimistic/compose/OptimisticUpdateTest.kt
@@ -1,0 +1,211 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.optimistic.compose
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import soil.testing.UnitTest
+import kotlin.test.Test
+
+@ExperimentalTestApi
+class OptimisticUpdateTest : UnitTest() {
+
+    @Test
+    fun testOptimisticUpdate() = runComposeUiTest {
+        val deferred1 = CompletableDeferred<Unit>()
+        var job: Job? = null
+
+        setContent {
+            var counter by remember { mutableStateOf(0) }
+            val (optimisticState, addOptimistic) = rememberOptimistic(counter)
+            val scope = rememberCoroutineScope()
+
+            Column {
+                Text(
+                    "Counter: $optimisticState",
+                    modifier = Modifier.testTag("counter")
+                )
+                Button(
+                    onClick = {
+                        job = scope.launch {
+                            addOptimistic(counter + 1)
+                            deferred1.await()
+                            counter += 1
+                        }
+                    },
+                    modifier = Modifier.testTag("increment")
+                ) {
+                    Text("Increment")
+                }
+            }
+        }
+
+        onNodeWithTag("counter").assertTextEquals("Counter: 0")
+        onNodeWithTag("increment").performClick()
+
+        waitForIdle()
+        onNodeWithTag("counter").assertTextEquals("Counter: 1")
+
+        deferred1.complete(Unit)
+        waitUntil { job?.isActive != true }
+        waitForIdle()
+        onNodeWithTag("counter").assertTextEquals("Counter: 1")
+    }
+
+    @Test
+    fun testOptimisticUpdate_withCustomMapper() = runComposeUiTest {
+        val deferred1 = CompletableDeferred<Unit>()
+        var job: Job? = null
+
+        setContent {
+            var list by remember { mutableStateOf(listOf("A", "B", "C")) }
+            val (optimisticState, addOptimistic) = rememberOptimistic<List<String>, String>(
+                state = list,
+                updateFn = { currentList, newItem -> currentList + newItem }
+            )
+            val scope = rememberCoroutineScope()
+
+            Column {
+                Text(
+                    "List: ${optimisticState.joinToString()}",
+                    modifier = Modifier.testTag("list")
+                )
+                Button(
+                    onClick = {
+                        job = scope.launch {
+                            addOptimistic("D")
+                            deferred1.await()
+                            list = list + "D"
+                        }
+                    },
+                    modifier = Modifier.testTag("add")
+                ) {
+                    Text("Add Item")
+                }
+            }
+        }
+
+        onNodeWithTag("list").assertTextEquals("List: A, B, C")
+        onNodeWithTag("add").performClick()
+
+        waitForIdle()
+        onNodeWithTag("list").assertTextEquals("List: A, B, C, D")
+
+        deferred1.complete(Unit)
+        waitUntil { job?.isActive != true }
+        waitForIdle()
+        onNodeWithTag("list").assertTextEquals("List: A, B, C, D")
+    }
+
+    @Test
+    fun testOptimisticUpdate_withExplicitCompletion() = runComposeUiTest {
+        val deferred1 = CompletableDeferred<Unit>()
+        val deferred2 = CompletableDeferred<Unit>()
+        var job: Job? = null
+
+        setContent {
+            var counter by remember { mutableStateOf(0) }
+            val (optimisticState, addOptimistic) = rememberOptimistic(counter)
+            val scope = rememberCoroutineScope()
+
+            Column {
+                Text(
+                    "Counter: $optimisticState",
+                    modifier = Modifier.testTag("counter")
+                )
+                Button(
+                    onClick = {
+                        job = scope.launch {
+                            val completion = addOptimistic(counter + 1)
+                            deferred1.await()
+                            counter += 1
+                            completion(null)
+                            deferred2.await()
+                        }
+                    },
+                    modifier = Modifier.testTag("increment")
+                ) {
+                    Text("Increment")
+                }
+            }
+        }
+
+        onNodeWithTag("counter").assertTextEquals("Counter: 0")
+        onNodeWithTag("increment").performClick()
+
+        waitForIdle()
+        onNodeWithTag("counter").assertTextEquals("Counter: 1")
+
+        deferred1.complete(Unit)
+        waitForIdle()
+        onNodeWithTag("counter").assertTextEquals("Counter: 1")
+
+        deferred2.complete(Unit)
+        waitUntil { job?.isActive != true }
+        onNodeWithTag("counter").assertTextEquals("Counter: 1")
+    }
+
+    @Test
+    fun testOptimisticUpdate_withErrorRollback() = runComposeUiTest {
+        val deferred1 = CompletableDeferred<Boolean>()
+        var job: Job? = null
+
+        setContent {
+            var counter by remember { mutableStateOf(0) }
+            val (optimisticState, addOptimistic) = rememberOptimistic(counter)
+            val scope = rememberCoroutineScope()
+
+            Column {
+                Text(
+                    "Counter: $optimisticState",
+                    modifier = Modifier.testTag("counter")
+                )
+                Button(
+                    onClick = {
+                        job = scope.launch {
+                            addOptimistic(counter + 1)
+                            try {
+                                deferred1.await()
+                                counter += 1
+                            } catch (e: Exception) {
+                                cancel("Failed to increment", e)
+                            }
+                        }
+                    },
+                    modifier = Modifier.testTag("increment")
+                ) {
+                    Text("Increment")
+                }
+            }
+        }
+
+        onNodeWithTag("counter").assertTextEquals("Counter: 0")
+        onNodeWithTag("increment").performClick()
+
+        waitForIdle()
+        onNodeWithTag("counter").assertTextEquals("Counter: 1")
+
+        deferred1.completeExceptionally(IllegalStateException("Simulated error"))
+        waitUntil { job?.isActive != true }
+        waitForIdle()
+        onNodeWithTag("counter").assertTextEquals("Counter: 0")
+    }
+}


### PR DESCRIPTION
The Optimistic Update API allows UI feedback to be displayed immediately for operations that may take time to complete, such as network requests. If the operation fails, the state is automatically rolled back.

The API interface is heavily inspired by the [useOptimistic](https://react.dev/reference/react/useOptimistic) API introduced in React 19, but it has been carefully designed for seamless integration with Soil Query.

```kotlin
val coroutine = rememberCoroutineScope()
val bookmarkQuery = rememberBookmarkQuery(..)
val bookmarkMutation = rememberBookmarkMutation(..)
val (optimisticState, addOptimistic) = rememberOptimistic(state = bookmarkQuery.data)

fun toggleBookmark() {
    coroutine.launch {
        addOptimistic(!optimisticState)            
        try {
            favoriteMutation.mutate(!optimisticState)
            favoriteQuery.refresh() // alternatively, use MutationKey#onMutateEffect
        } catch (e: Throwable) {
            // ... error feedback                
            cancel("Failed to update bookmark", e)
        }
    }
}
```
