### PR TITLE
Introduce TestTag

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/MutationPreviewClient.kt
@@ -12,9 +12,12 @@ import soil.query.MutationKey
 import soil.query.MutationReceiver
 import soil.query.MutationRef
 import soil.query.MutationState
+import soil.query.MutationTestTag
 import soil.query.core.Marker
+import soil.query.core.TestTag
 import soil.query.core.UniqueId
 import soil.query.core.getOrThrow
+import soil.query.marker.TestTagMarker
 
 /**
  * Usage:
@@ -27,7 +30,8 @@ import soil.query.core.getOrThrow
  */
 @Stable
 class MutationPreviewClient(
-    private val previewData: Map<UniqueId, MutationState<*>>
+    private val previewData: Map<UniqueId, MutationState<*>>,
+    private val previewDataByTag: Map<TestTag, MutationState<*>>
 ) : MutationClient {
 
     override val mutationReceiver: MutationReceiver = MutationReceiver
@@ -37,7 +41,9 @@ class MutationPreviewClient(
         key: MutationKey<T, S>,
         marker: Marker
     ): MutationRef<T, S> {
-        val state = previewData[key.id] as? MutationState<T> ?: MutationState.initial()
+        val state = previewData[key.id] as? MutationState<T>
+            ?: marker[TestTagMarker.Key]?.value?.let { previewDataByTag[it] as? MutationState<T> }
+            ?: MutationState.initial()
         return SnapshotMutation(key.id, MutableStateFlow(state))
     }
 
@@ -56,17 +62,42 @@ class MutationPreviewClient(
      */
     class Builder {
         private val previewData = mutableMapOf<UniqueId, MutationState<*>>()
+        private val previewDataByTag = mutableMapOf<TestTag, MutationState<*>>()
 
+        /**
+         * Registers a preview state for the mutation with the specified ID.
+         *
+         * @param id The mutation ID that identifies this mutation
+         * @param snapshot A function that provides the mutation state to be returned for this ID
+         */
         fun <T, S> on(id: MutationId<T, S>, snapshot: () -> MutationState<T>) {
             previewData[id] = snapshot()
         }
 
-        fun build(): MutationPreviewClient = MutationPreviewClient(previewData)
+        /**
+         * Registers a preview state for the mutation with the specified test tag.
+         *
+         * @param testTag The test tag that identifies this mutation
+         * @param snapshot A function that provides the mutation state to be returned for this tag
+         */
+        fun <T, S> on(testTag: MutationTestTag<T, S>, snapshot: () -> MutationState<T>) {
+            previewDataByTag[testTag] = snapshot()
+        }
+
+        /**
+         * Builds a new instance of [MutationPreviewClient] with the registered preview states.
+         *
+         * @return A new [MutationPreviewClient] instance
+         */
+        fun build(): MutationPreviewClient = MutationPreviewClient(previewData, previewDataByTag)
     }
 }
 
 /**
  * Creates a [MutationPreviewClient] with the provided [initializer].
+ *
+ * @param initializer A lambda with [MutationPreviewClient.Builder] receiver that initializes preview states
+ * @return A mutation client that can be used to provide mock data for mutations in Compose previews
  */
 fun MutationPreviewClient(initializer: MutationPreviewClient.Builder.() -> Unit): MutationPreviewClient {
     return MutationPreviewClient.Builder().apply(initializer).build()

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SwrPreviewClient.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/tooling/SwrPreviewClient.kt
@@ -29,9 +29,21 @@ import soil.query.core.MemoryPressureLevel
  */
 @Stable
 class SwrPreviewClient(
-    query: QueryPreviewClient = QueryPreviewClient(emptyMap()),
-    mutation: MutationPreviewClient = MutationPreviewClient(emptyMap()),
-    subscription: SubscriptionPreviewClient = SubscriptionPreviewClient(emptyMap()),
+    /**
+     * The query client to handle query operations in the preview environment.
+     */
+    query: QueryPreviewClient = QueryPreviewClient(emptyMap(), emptyMap()),
+    /**
+     * The mutation client to handle mutation operations in the preview environment.
+     */
+    mutation: MutationPreviewClient = MutationPreviewClient(emptyMap(), emptyMap()),
+    /**
+     * The subscription client to handle subscription operations in the preview environment.
+     */
+    subscription: SubscriptionPreviewClient = SubscriptionPreviewClient(emptyMap(), emptyMap()),
+    /**
+     * The error relay flow to emit error records.
+     */
     override val errorRelay: Flow<ErrorRecord> = flow { }
 ) : SwrClient, SwrClientPlus, QueryClient by query, MutationClient by mutation, SubscriptionClient by subscription {
     override fun gc(level: MemoryPressureLevel) = Unit

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryId.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryId.kt
@@ -1,0 +1,80 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.SurrogateKey
+import soil.query.core.TestTag
+import soil.query.core.UniqueId
+
+/**
+ * Unique identifier for [InfiniteQueryKey].
+ */
+@Suppress("unused")
+open class InfiniteQueryId<T, S>(
+    override val namespace: String,
+    override vararg val tags: SurrogateKey
+) : UniqueId {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is InfiniteQueryId<*, *>) return false
+        if (namespace != other.namespace) return false
+        return tags.contentEquals(other.tags)
+    }
+
+    override fun hashCode(): Int {
+        var result = namespace.hashCode()
+        result = 31 * result + tags.contentHashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "InfiniteQueryId(namespace='$namespace', tags=${tags.contentToString()})"
+    }
+
+    companion object
+}
+
+/**
+ * TestTag implementation for InfiniteQuery operations that provides tag-based identification.
+ * 
+ * This class is used to identify infinite queries for mocking in test and preview environments,
+ * particularly when dealing with auto-generated query IDs that may change during
+ * configuration changes or recompositions.
+ * 
+ * Unlike [InfiniteQueryId] which might use auto-generated values that can change across
+ * recompositions, InfiniteQueryTestTag provides a stable identifier that can be consistently
+ * referenced in tests and previews.
+ * 
+ * Usage example:
+ * ```kotlin
+ * // Define a test tag
+ * class UserListQueryTestTag : InfiniteQueryTestTag<User, PageParams>("user-list")
+ * 
+ * // Use with test client
+ * testClient.on(UserListQueryTestTag()) { QueryState.success(mockUserChunks) }
+ * 
+ * // Apply when getting an infinite query
+ * val query = client.getInfiniteQuery(queryKey, Marker.testTag(UserListQueryTestTag()))
+ * ```
+ * 
+ * @param T The type of data that will be returned by the infinite query
+ * @param S The type of pagination parameters for loading more data
+ * @param tag A unique string identifier for this test tag
+ */
+@Suppress("unused")
+open class InfiniteQueryTestTag<T, S>(override val tag: String) : TestTag {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as InfiniteQueryTestTag<*, *>
+
+        return tag == other.tag
+    }
+
+    override fun hashCode(): Int {
+        return tag.hashCode()
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryId.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryId.kt
@@ -38,27 +38,27 @@ open class InfiniteQueryId<T, S>(
 
 /**
  * TestTag implementation for InfiniteQuery operations that provides tag-based identification.
- * 
+ *
  * This class is used to identify infinite queries for mocking in test and preview environments,
  * particularly when dealing with auto-generated query IDs that may change during
  * configuration changes or recompositions.
- * 
+ *
  * Unlike [InfiniteQueryId] which might use auto-generated values that can change across
  * recompositions, InfiniteQueryTestTag provides a stable identifier that can be consistently
  * referenced in tests and previews.
- * 
+ *
  * Usage example:
  * ```kotlin
  * // Define a test tag
  * class UserListQueryTestTag : InfiniteQueryTestTag<User, PageParams>("user-list")
- * 
+ *
  * // Use with test client
  * testClient.on(UserListQueryTestTag()) { QueryState.success(mockUserChunks) }
- * 
+ *
  * // Apply when getting an infinite query
  * val query = client.getInfiniteQuery(queryKey, Marker.testTag(UserListQueryTestTag()))
  * ```
- * 
+ *
  * @param T The type of data that will be returned by the infinite query
  * @param S The type of pagination parameters for loading more data
  * @param tag A unique string identifier for this test tag

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryKey.kt
@@ -3,9 +3,6 @@
 
 package soil.query
 
-import soil.query.core.SurrogateKey
-import soil.query.core.UniqueId
-
 /**
  * [InfiniteQueryKey] for managing [Query] associated with [id].
  *
@@ -83,35 +80,6 @@ interface InfiniteQueryKey<T, S> {
      * @see QueryKey.onRecoverData
      */
     fun onRecoverData(): QueryRecoverData<QueryChunks<T, S>>? = null
-}
-
-/**
- * Unique identifier for [InfiniteQueryKey].
- */
-@Suppress("unused")
-open class InfiniteQueryId<T, S>(
-    override val namespace: String,
-    override vararg val tags: SurrogateKey
-) : UniqueId {
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is InfiniteQueryId<*, *>) return false
-        if (namespace != other.namespace) return false
-        return tags.contentEquals(other.tags)
-    }
-
-    override fun hashCode(): Int {
-        var result = namespace.hashCode()
-        result = 31 * result + tags.contentHashCode()
-        return result
-    }
-
-    override fun toString(): String {
-        return "InfiniteQueryId(namespace='$namespace', tags=${tags.contentToString()})"
-    }
-
-    companion object
 }
 
 internal fun <T, S> InfiniteQueryKey<T, S>.hasMore(chunks: QueryChunks<T, S>): Boolean {

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationId.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationId.kt
@@ -61,27 +61,27 @@ open class MutationId<T, S>(
 
 /**
  * TestTag implementation for Mutation operations that provides tag-based identification.
- * 
+ *
  * This class is used to identify mutations for mocking in test and preview environments,
  * particularly when dealing with auto-generated mutation IDs that may change during
  * configuration changes or recompositions.
- * 
+ *
  * Unlike [MutationId] which might use auto-generated values that can change across
  * recompositions, MutationTestTag provides a stable identifier that can be consistently
  * referenced in tests and previews.
- * 
+ *
  * Usage example:
  * ```kotlin
  * // Define a test tag
  * class UpdateUserMutationTestTag : MutationTestTag<User, UserUpdateParams>("update-user")
- * 
+ *
  * // Use with test client
  * testClient.on(UpdateUserMutationTestTag()) { updatedUser }
- * 
+ *
  * // Apply when getting a mutation
  * val mutation = client.getMutation(mutationKey, Marker.testTag(UpdateUserMutationTestTag()))
  * ```
- * 
+ *
  * @param T The type of data that will be returned by the mutation
  * @param S The type of input parameters for the mutation
  * @param tag A unique string identifier for this test tag

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationId.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationId.kt
@@ -1,0 +1,103 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.SurrogateKey
+import soil.query.core.TestTag
+import soil.query.core.UniqueId
+import soil.query.core.uuid
+
+/**
+ * Unique identifier for [MutationKey].
+ */
+@Suppress("unused")
+open class MutationId<T, S>(
+    override val namespace: String,
+    override vararg val tags: SurrogateKey
+) : UniqueId {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is MutationId<*, *>) return false
+        if (namespace != other.namespace) return false
+        return tags.contentEquals(other.tags)
+    }
+
+    override fun hashCode(): Int {
+        var result = namespace.hashCode()
+        result = 31 * result + tags.contentHashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "MutationId(namespace='$namespace', tags=${tags.contentToString()})"
+    }
+
+    companion object {
+
+        /**
+         * Automatically generates a [MutationId].
+         *
+         * Generates an ID for one-time use, so it cannot be shared among multiple places of use.
+         *
+         * FIXME: Since this function is for automatic ID assignment, it might be better not to have arguments.
+         */
+        @Deprecated(
+            """
+            This function is deprecated because it does not retain automatically generated values when used within Compose.
+            As a result, values are regenerated after configuration changes, leading to different values.
+            Consider using an alternative approach that preserves state across recompositions.
+        """, ReplaceWith("MutationId(namespace, *tags)", "soil.query.MutationId")
+        )
+        fun <T, S> auto(
+            namespace: String = "auto/${uuid()}",
+            vararg tags: SurrogateKey
+        ): MutationId<T, S> {
+            return MutationId(namespace, *tags)
+        }
+    }
+}
+
+/**
+ * TestTag implementation for Mutation operations that provides tag-based identification.
+ * 
+ * This class is used to identify mutations for mocking in test and preview environments,
+ * particularly when dealing with auto-generated mutation IDs that may change during
+ * configuration changes or recompositions.
+ * 
+ * Unlike [MutationId] which might use auto-generated values that can change across
+ * recompositions, MutationTestTag provides a stable identifier that can be consistently
+ * referenced in tests and previews.
+ * 
+ * Usage example:
+ * ```kotlin
+ * // Define a test tag
+ * class UpdateUserMutationTestTag : MutationTestTag<User, UserUpdateParams>("update-user")
+ * 
+ * // Use with test client
+ * testClient.on(UpdateUserMutationTestTag()) { updatedUser }
+ * 
+ * // Apply when getting a mutation
+ * val mutation = client.getMutation(mutationKey, Marker.testTag(UpdateUserMutationTestTag()))
+ * ```
+ * 
+ * @param T The type of data that will be returned by the mutation
+ * @param S The type of input parameters for the mutation
+ * @param tag A unique string identifier for this test tag
+ */
+@Suppress("unused")
+open class MutationTestTag<T, S>(override val tag: String) : TestTag {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as MutationTestTag<*, *>
+
+        return tag == other.tag
+    }
+
+    override fun hashCode(): Int {
+        return tag.hashCode()
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/MutationKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/MutationKey.kt
@@ -4,9 +4,6 @@
 package soil.query
 
 import soil.query.core.Effect
-import soil.query.core.SurrogateKey
-import soil.query.core.UniqueId
-import soil.query.core.uuid
 
 /**
  * Interface for mutations key.
@@ -92,57 +89,6 @@ interface MutationKey<T, S> {
      * @param data The data returned by the mutation.
      */
     fun onMutateEffect(variable: S, data: T): Effect? = null
-}
-
-/**
- * Unique identifier for [MutationKey].
- */
-@Suppress("unused")
-open class MutationId<T, S>(
-    override val namespace: String,
-    override vararg val tags: SurrogateKey
-) : UniqueId {
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is MutationId<*, *>) return false
-        if (namespace != other.namespace) return false
-        return tags.contentEquals(other.tags)
-    }
-
-    override fun hashCode(): Int {
-        var result = namespace.hashCode()
-        result = 31 * result + tags.contentHashCode()
-        return result
-    }
-
-    override fun toString(): String {
-        return "MutationId(namespace='$namespace', tags=${tags.contentToString()})"
-    }
-
-    companion object {
-
-        /**
-         * Automatically generates a [MutationId].
-         *
-         * Generates an ID for one-time use, so it cannot be shared among multiple places of use.
-         *
-         * FIXME: Since this function is for automatic ID assignment, it might be better not to have arguments.
-         */
-        @Deprecated(
-            """
-            This function is deprecated because it does not retain automatically generated values when used within Compose.
-            As a result, values are regenerated after configuration changes, leading to different values.
-            Consider using an alternative approach that preserves state across recompositions.
-        """, ReplaceWith("MutationId(namespace, *tags)", "soil.query.MutationId")
-        )
-        fun <T, S> auto(
-            namespace: String = "auto/${uuid()}",
-            vararg tags: SurrogateKey
-        ): MutationId<T, S> {
-            return MutationId(namespace, *tags)
-        }
-    }
 }
 
 /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryId.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryId.kt
@@ -1,0 +1,79 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.SurrogateKey
+import soil.query.core.TestTag
+import soil.query.core.UniqueId
+
+/**
+ * Unique identifier for [QueryKey].
+ */
+@Suppress("unused")
+open class QueryId<T>(
+    override val namespace: String,
+    override vararg val tags: SurrogateKey
+) : UniqueId {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is QueryId<*>) return false
+        if (namespace != other.namespace) return false
+        return tags.contentEquals(other.tags)
+    }
+
+    override fun hashCode(): Int {
+        var result = namespace.hashCode()
+        result = 31 * result + tags.contentHashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "QueryId(namespace='$namespace', tags=${tags.contentToString()})"
+    }
+
+    companion object
+}
+
+/**
+ * TestTag implementation for Query operations that provides tag-based identification.
+ * 
+ * This class is used to identify queries for mocking in test and preview environments,
+ * particularly when dealing with auto-generated query IDs that may change during
+ * configuration changes or recompositions.
+ * 
+ * Unlike [QueryId] which might use auto-generated values that can change across
+ * recompositions, QueryTestTag provides a stable identifier that can be consistently
+ * referenced in tests and previews.
+ * 
+ * Usage example:
+ * ```kotlin
+ * // Define a test tag
+ * class UserQueryTestTag : QueryTestTag<User>("user-query")
+ * 
+ * // Use with test client
+ * testClient.on(UserQueryTestTag()) { QueryState.success(mockUser) }
+ * 
+ * // Apply when getting a query
+ * val query = client.getQuery(queryKey, Marker.testTag(UserQueryTestTag()))
+ * ```
+ * 
+ * @param T The type of data that will be returned by the query
+ * @param tag A unique string identifier for this test tag
+ */
+@Suppress("unused")
+open class QueryTestTag<T>(override val tag: String) : TestTag {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as QueryTestTag<*>
+
+        return tag == other.tag
+    }
+
+    override fun hashCode(): Int {
+        return tag.hashCode()
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryId.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryId.kt
@@ -38,27 +38,27 @@ open class QueryId<T>(
 
 /**
  * TestTag implementation for Query operations that provides tag-based identification.
- * 
+ *
  * This class is used to identify queries for mocking in test and preview environments,
  * particularly when dealing with auto-generated query IDs that may change during
  * configuration changes or recompositions.
- * 
+ *
  * Unlike [QueryId] which might use auto-generated values that can change across
  * recompositions, QueryTestTag provides a stable identifier that can be consistently
  * referenced in tests and previews.
- * 
+ *
  * Usage example:
  * ```kotlin
  * // Define a test tag
  * class UserQueryTestTag : QueryTestTag<User>("user-query")
- * 
+ *
  * // Use with test client
  * testClient.on(UserQueryTestTag()) { QueryState.success(mockUser) }
- * 
+ *
  * // Apply when getting a query
  * val query = client.getQuery(queryKey, Marker.testTag(UserQueryTestTag()))
  * ```
- * 
+ *
  * @param T The type of data that will be returned by the query
  * @param tag A unique string identifier for this test tag
  */

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
@@ -3,9 +3,6 @@
 
 package soil.query
 
-import soil.query.core.SurrogateKey
-import soil.query.core.UniqueId
-
 /**
  * [QueryKey] for managing [Query] associated with [id].
  *
@@ -101,35 +98,6 @@ interface QueryKey<T> {
      * @see QueryRecoverData
      */
     fun onRecoverData(): QueryRecoverData<T>? = null
-}
-
-/**
- * Unique identifier for [QueryKey].
- */
-@Suppress("unused")
-open class QueryId<T>(
-    override val namespace: String,
-    override vararg val tags: SurrogateKey
-) : UniqueId {
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is QueryId<*>) return false
-        if (namespace != other.namespace) return false
-        return tags.contentEquals(other.tags)
-    }
-
-    override fun hashCode(): Int {
-        var result = namespace.hashCode()
-        result = 31 * result + tags.contentHashCode()
-        return result
-    }
-
-    override fun toString(): String {
-        return "QueryId(namespace='$namespace', tags=${tags.contentToString()})"
-    }
-
-    companion object
 }
 
 /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionId.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionId.kt
@@ -1,0 +1,94 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import soil.query.core.SurrogateKey
+import soil.query.core.TestTag
+import soil.query.core.UniqueId
+import soil.query.core.uuid
+
+/**
+ * Unique identifier for [SubscriptionKey].
+ */
+@Suppress("unused")
+open class SubscriptionId<T>(
+    override val namespace: String,
+    override vararg val tags: SurrogateKey
+) : UniqueId {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SubscriptionId<*>) return false
+        if (namespace != other.namespace) return false
+        return tags.contentEquals(other.tags)
+    }
+
+    override fun hashCode(): Int {
+        var result = namespace.hashCode()
+        result = 31 * result + tags.contentHashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "SubscriptionId(namespace='$namespace', tags=${tags.contentToString()})"
+    }
+
+    companion object {
+        @Deprecated(
+            """
+            This function is deprecated because it does not retain automatically generated values when used within Compose.
+            As a result, values are regenerated after configuration changes, leading to different values.
+            Consider using an alternative approach that preserves state across recompositions.
+        """, ReplaceWith("SubscriptionId(namespace, *tags)", "soil.query.SubscriptionId")
+        )
+        fun <T> auto(
+            namespace: String = "auto/${uuid()}",
+            vararg tags: SurrogateKey
+        ): SubscriptionId<T> {
+            return SubscriptionId(namespace, *tags)
+        }
+    }
+}
+
+/**
+ * TestTag implementation for Subscription operations that provides tag-based identification.
+ * 
+ * This class is used to identify subscriptions for mocking in test and preview environments,
+ * particularly when dealing with auto-generated subscription IDs that may change during
+ * configuration changes or recompositions.
+ * 
+ * Unlike [SubscriptionId] which might use auto-generated values that can change across
+ * recompositions, SubscriptionTestTag provides a stable identifier that can be consistently
+ * referenced in tests and previews.
+ * 
+ * Usage example:
+ * ```kotlin
+ * // Define a test tag
+ * class UserUpdatesTestTag : SubscriptionTestTag<User>("user-updates")
+ * 
+ * // Use with test client
+ * testClient.on(UserUpdatesTestTag()) { MutableStateFlow(mockUser) }
+ * 
+ * // Apply when getting a subscription
+ * val subscription = client.getSubscription(subscriptionKey, Marker.testTag(UserUpdatesTestTag()))
+ * ```
+ * 
+ * @param T The type of data that will be received by the subscription
+ * @param tag A unique string identifier for this test tag
+ */
+@Suppress("unused")
+open class SubscriptionTestTag<T>(override val tag: String) : TestTag {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as SubscriptionTestTag<*>
+
+        return tag == other.tag
+    }
+
+    override fun hashCode(): Int {
+        return tag.hashCode()
+    }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionId.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionId.kt
@@ -53,27 +53,27 @@ open class SubscriptionId<T>(
 
 /**
  * TestTag implementation for Subscription operations that provides tag-based identification.
- * 
+ *
  * This class is used to identify subscriptions for mocking in test and preview environments,
  * particularly when dealing with auto-generated subscription IDs that may change during
  * configuration changes or recompositions.
- * 
+ *
  * Unlike [SubscriptionId] which might use auto-generated values that can change across
  * recompositions, SubscriptionTestTag provides a stable identifier that can be consistently
  * referenced in tests and previews.
- * 
+ *
  * Usage example:
  * ```kotlin
  * // Define a test tag
  * class UserUpdatesTestTag : SubscriptionTestTag<User>("user-updates")
- * 
+ *
  * // Use with test client
  * testClient.on(UserUpdatesTestTag()) { MutableStateFlow(mockUser) }
- * 
+ *
  * // Apply when getting a subscription
  * val subscription = client.getSubscription(subscriptionKey, Marker.testTag(UserUpdatesTestTag()))
  * ```
- * 
+ *
  * @param T The type of data that will be received by the subscription
  * @param tag A unique string identifier for this test tag
  */

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionKey.kt
@@ -4,9 +4,6 @@
 package soil.query
 
 import kotlinx.coroutines.flow.Flow
-import soil.query.core.SurrogateKey
-import soil.query.core.UniqueId
-import soil.query.core.uuid
 
 /**
  * [SubscriptionKey] for managing [Subscription] associated with [id].
@@ -89,49 +86,6 @@ interface SubscriptionKey<T> {
      * You can recover data from the error instead of the error state.
      */
     fun onRecoverData(): SubscriptionRecoverData<T>? = null
-}
-
-/**
- * Unique identifier for [SubscriptionKey].
- */
-@Suppress("unused")
-open class SubscriptionId<T>(
-    override val namespace: String,
-    override vararg val tags: SurrogateKey
-) : UniqueId {
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is SubscriptionId<*>) return false
-        if (namespace != other.namespace) return false
-        return tags.contentEquals(other.tags)
-    }
-
-    override fun hashCode(): Int {
-        var result = namespace.hashCode()
-        result = 31 * result + tags.contentHashCode()
-        return result
-    }
-
-    override fun toString(): String {
-        return "SubscriptionId(namespace='$namespace', tags=${tags.contentToString()})"
-    }
-
-    companion object {
-        @Deprecated(
-            """
-            This function is deprecated because it does not retain automatically generated values when used within Compose.
-            As a result, values are regenerated after configuration changes, leading to different values.
-            Consider using an alternative approach that preserves state across recompositions.
-        """, ReplaceWith("SubscriptionId(namespace, *tags)", "soil.query.SubscriptionId")
-        )
-        fun <T> auto(
-            namespace: String = "auto/${uuid()}",
-            vararg tags: SurrogateKey
-        ): SubscriptionId<T> {
-            return SubscriptionId(namespace, *tags)
-        }
-    }
 }
 
 /**

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/TestTag.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/TestTag.kt
@@ -5,22 +5,22 @@ package soil.query.core
 
 /**
  * Interface for tagging queries, mutations, and subscriptions to enable mocking during testing and previews.
- * 
- * TestTag provides an alternative to ID-based mocking, which is particularly useful when dealing with 
+ *
+ * TestTag provides an alternative to ID-based mocking, which is particularly useful when dealing with
  * automatically generated IDs that may change during configuration changes or recompositions.
- * 
+ *
  * Usage example:
  * ```kotlin
  * // Define a test tag
  * class MyQueryTestTag : QueryTestTag<String>("my-query")
- * 
+ *
  * // Use the test tag with a mocking client
  * testClient.on(MyQueryTestTag()) { "mocked data" }
- * 
+ *
  * // Apply the test tag when getting a query
  * val query = client.getQuery(queryKey, Marker.testTag(MyQueryTestTag()))
  * ```
- * 
+ *
  * This approach allows for consistent mocking even when queries use auto-generated IDs,
  * ensuring reliable test and preview behavior in UI components.
  */

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/TestTag.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/TestTag.kt
@@ -1,0 +1,29 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+/**
+ * Interface for tagging queries, mutations, and subscriptions to enable mocking during testing and previews.
+ * 
+ * TestTag provides an alternative to ID-based mocking, which is particularly useful when dealing with 
+ * automatically generated IDs that may change during configuration changes or recompositions.
+ * 
+ * Usage example:
+ * ```kotlin
+ * // Define a test tag
+ * class MyQueryTestTag : QueryTestTag<String>("my-query")
+ * 
+ * // Use the test tag with a mocking client
+ * testClient.on(MyQueryTestTag()) { "mocked data" }
+ * 
+ * // Apply the test tag when getting a query
+ * val query = client.getQuery(queryKey, Marker.testTag(MyQueryTestTag()))
+ * ```
+ * 
+ * This approach allows for consistent mocking even when queries use auto-generated IDs,
+ * ensuring reliable test and preview behavior in UI components.
+ */
+interface TestTag {
+    val tag: String
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/marker/TestTagMarker.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/marker/TestTagMarker.kt
@@ -8,17 +8,17 @@ import soil.query.core.TestTag
 
 /**
  * Extension function to add a TestTag to a Marker.
- * 
+ *
  * This function is used to attach a TestTag to a Marker, which can then be passed to query, mutation,
  * or subscription operations to identify them for mocking in test and preview environments.
- * 
+ *
  * Usage example:
  * ```kotlin
  * val testTag = MyQueryTestTag()
  * val marker = Marker.testTag(testTag)
  * val query = client.getQuery(queryKey, marker)
  * ```
- * 
+ *
  * @param value The TestTag to attach to the Marker
  * @return A new Marker with the TestTag attached
  */
@@ -28,10 +28,10 @@ fun Marker.testTag(value: TestTag): Marker {
 
 /**
  * Marker element that holds a TestTag for identification in test and preview environments.
- * 
+ *
  * This marker element is used internally by the testTag extension function to attach a TestTag
  * to a Marker that will be passed to query, mutation, or subscription operations.
- * 
+ *
  * The TestTagMarker allows the client implementation to identify the operation by its
  * TestTag rather than its ID, which is particularly useful when dealing with auto-generated
  * IDs that might change during configuration changes or recompositions.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/marker/TestTagMarker.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/marker/TestTagMarker.kt
@@ -1,0 +1,44 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.marker
+
+import soil.query.core.Marker
+import soil.query.core.TestTag
+
+/**
+ * Extension function to add a TestTag to a Marker.
+ * 
+ * This function is used to attach a TestTag to a Marker, which can then be passed to query, mutation,
+ * or subscription operations to identify them for mocking in test and preview environments.
+ * 
+ * Usage example:
+ * ```kotlin
+ * val testTag = MyQueryTestTag()
+ * val marker = Marker.testTag(testTag)
+ * val query = client.getQuery(queryKey, marker)
+ * ```
+ * 
+ * @param value The TestTag to attach to the Marker
+ * @return A new Marker with the TestTag attached
+ */
+fun Marker.testTag(value: TestTag): Marker {
+    return this + TestTagMarker(value)
+}
+
+/**
+ * Marker element that holds a TestTag for identification in test and preview environments.
+ * 
+ * This marker element is used internally by the testTag extension function to attach a TestTag
+ * to a Marker that will be passed to query, mutation, or subscription operations.
+ * 
+ * The TestTagMarker allows the client implementation to identify the operation by its
+ * TestTag rather than its ID, which is particularly useful when dealing with auto-generated
+ * IDs that might change during configuration changes or recompositions.
+ */
+class TestTagMarker internal constructor(val value: TestTag) : Marker.Element {
+    override val key: Marker.Key<*>
+        get() = Key
+
+    companion object Key : Marker.Key<TestTagMarker>
+}

--- a/soil-query-test/src/commonMain/kotlin/soil/query/test/TestSwrClientPlus.kt
+++ b/soil-query-test/src/commonMain/kotlin/soil/query/test/TestSwrClientPlus.kt
@@ -6,19 +6,26 @@ package soil.query.test
 import soil.query.InfiniteQueryId
 import soil.query.InfiniteQueryKey
 import soil.query.InfiniteQueryRef
+import soil.query.InfiniteQueryTestTag
 import soil.query.MutationId
 import soil.query.MutationKey
 import soil.query.MutationRef
+import soil.query.MutationTestTag
 import soil.query.QueryId
 import soil.query.QueryKey
 import soil.query.QueryRef
+import soil.query.QueryTestTag
 import soil.query.SubscriptionId
 import soil.query.SubscriptionKey
 import soil.query.SubscriptionRef
+import soil.query.SubscriptionTestTag
 import soil.query.SwrCachePlus
 import soil.query.SwrClientPlus
 import soil.query.annotation.ExperimentalSoilQueryApi
 import soil.query.core.Marker
+import soil.query.core.TestTag
+import soil.query.core.UniqueId
+import soil.query.marker.TestTagMarker
 
 /**
  * This extended interface of the [SwrClientPlus] provides the capability to mock specific queries, mutations, and subscriptions for the purpose of testing.
@@ -38,12 +45,26 @@ interface TestSwrClientPlus : TestSwrClient, SwrClientPlus {
 
     /**
      * Mocks the subscription process corresponding to [SubscriptionId].
+     *
+     * @param id The subscription ID that identifies this subscription
+     * @param subscribe A function that mocks the subscription behavior
      */
     fun <T> on(id: SubscriptionId<T>, subscribe: FakeSubscriptionSubscribe<T>)
+
+    /**
+     * Mocks the subscription process corresponding to the given test tag.
+     *
+     * @param testTag The test tag that identifies this subscription
+     * @param subscribe A function that mocks the subscription behavior
+     */
+    fun <T> on(testTag: SubscriptionTestTag<T>, subscribe: FakeSubscriptionSubscribe<T>)
 }
 
 /**
  * Switches [SwrCachePlus] to a test interface.
+ *
+ * @param initializer A lambda with [TestSwrClientPlus] receiver that initializes mocks
+ * @return A test client that can be used to mock queries, mutations, and subscriptions
  */
 @OptIn(ExperimentalSoilQueryApi::class)
 fun SwrCachePlus.test(initializer: TestSwrClientPlus.() -> Unit = {}): TestSwrClientPlus {
@@ -55,26 +76,48 @@ internal class TestSwrClientPlusImpl(
     private val cache: SwrCachePlus
 ) : TestSwrClientPlus, SwrClientPlus by cache {
 
-    private val mockMutations = mutableMapOf<MutationId<*, *>, FakeMutationMutate<*, *>>()
-    private val mockQueries = mutableMapOf<QueryId<*>, FakeQueryFetch<*>>()
-    private val mockInfiniteQueries = mutableMapOf<InfiniteQueryId<*, *>, FakeInfiniteQueryFetch<*, *>>()
-    private val mockSubscriptions = mutableMapOf<SubscriptionId<*>, FakeSubscriptionSubscribe<*>>()
+    private val mockMutations = mutableMapOf<UniqueId, FakeMutationMutate<*, *>>()
+    private val mockQueries = mutableMapOf<UniqueId, FakeQueryFetch<*>>()
+    private val mockInfiniteQueries = mutableMapOf<UniqueId, FakeInfiniteQueryFetch<*, *>>()
+    private val mockSubscriptions = mutableMapOf<UniqueId, FakeSubscriptionSubscribe<*>>()
+
+    private val mockMutationsByTag = mutableMapOf<TestTag, FakeMutationMutate<*, *>>()
+    private val mockQueriesByTag = mutableMapOf<TestTag, FakeQueryFetch<*>>()
+    private val mockInfiniteQueriesByTag = mutableMapOf<TestTag, FakeInfiniteQueryFetch<*, *>>()
+    private val mockSubscriptionsByTag = mutableMapOf<TestTag, FakeSubscriptionSubscribe<*>>()
 
     override fun <T, S> on(id: MutationId<T, S>, mutate: FakeMutationMutate<T, S>) {
         mockMutations[id] = mutate
+    }
+
+    override fun <T, S> on(testTag: MutationTestTag<T, S>, mutate: FakeMutationMutate<T, S>) {
+        mockMutationsByTag[testTag] = mutate
     }
 
     override fun <T> on(id: QueryId<T>, fetch: FakeQueryFetch<T>) {
         mockQueries[id] = fetch
     }
 
+    override fun <T> on(testTag: QueryTestTag<T>, fetch: FakeQueryFetch<T>) {
+        mockQueriesByTag[testTag] = fetch
+    }
+
     override fun <T, S> on(id: InfiniteQueryId<T, S>, fetch: FakeInfiniteQueryFetch<T, S>) {
         mockInfiniteQueries[id] = fetch
+    }
+
+    override fun <T, S> on(testTag: InfiniteQueryTestTag<T, S>, fetch: FakeInfiniteQueryFetch<T, S>) {
+        mockInfiniteQueriesByTag[testTag] = fetch
     }
 
     override fun <T> on(id: SubscriptionId<T>, subscribe: FakeSubscriptionSubscribe<T>) {
         mockSubscriptions[id] = subscribe
     }
+
+    override fun <T> on(testTag: SubscriptionTestTag<T>, subscribe: FakeSubscriptionSubscribe<T>) {
+        mockSubscriptionsByTag[testTag] = subscribe
+    }
+
 
     override fun isIdleNow(): Boolean {
         if (cache.mutationStoreView.values.any { it.state.value.isAwaited() }) {
@@ -95,11 +138,15 @@ internal class TestSwrClientPlusImpl(
         marker: Marker
     ): MutationRef<T, S> {
         val mock = mockMutations[key.id] as? FakeMutationMutate<T, S>
-        return if (mock != null) {
-            cache.getMutation(FakeMutationKey(key, mock), marker)
-        } else {
-            cache.getMutation(key, marker)
+        if (mock != null) {
+            return cache.getMutation(FakeMutationKey(key, mock), marker)
         }
+        val testTag = marker[TestTagMarker.Key]?.value
+        val testTagMock = testTag?.let { mockMutationsByTag[it] } as? FakeMutationMutate<T, S>
+        if (testTagMock != null) {
+            return cache.getMutation(FakeMutationKey(key, testTagMock), marker)
+        }
+        return cache.getMutation(key, marker)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -108,11 +155,15 @@ internal class TestSwrClientPlusImpl(
         marker: Marker
     ): QueryRef<T> {
         val mock = mockQueries[key.id] as? FakeQueryFetch<T>
-        return if (mock != null) {
-            cache.getQuery(FakeQueryKey(key, mock), marker)
-        } else {
-            cache.getQuery(key, marker)
+        if (mock != null) {
+            return cache.getQuery(FakeQueryKey(key, mock), marker)
         }
+        val testTag = marker[TestTagMarker.Key]?.value
+        val testTagMock = testTag?.let { mockQueriesByTag[it] } as? FakeQueryFetch<T>
+        if (testTagMock != null) {
+            return cache.getQuery(FakeQueryKey(key, testTagMock), marker)
+        }
+        return cache.getQuery(key, marker)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -121,21 +172,29 @@ internal class TestSwrClientPlusImpl(
         marker: Marker
     ): InfiniteQueryRef<T, S> {
         val mock = mockInfiniteQueries[key.id] as? FakeInfiniteQueryFetch<T, S>
-        return if (mock != null) {
-            cache.getInfiniteQuery(FakeInfiniteQueryKey(key, mock), marker)
-        } else {
-            cache.getInfiniteQuery(key, marker)
+        if (mock != null) {
+            return cache.getInfiniteQuery(FakeInfiniteQueryKey(key, mock), marker)
         }
+        val testTag = marker[TestTagMarker.Key]?.value
+        val testTagMock = testTag?.let { mockInfiniteQueriesByTag[it] } as? FakeInfiniteQueryFetch<T, S>
+        if (testTagMock != null) {
+            return cache.getInfiniteQuery(FakeInfiniteQueryKey(key, testTagMock), marker)
+        }
+        return cache.getInfiniteQuery(key, marker)
     }
 
     @ExperimentalSoilQueryApi
     @Suppress("UNCHECKED_CAST")
     override fun <T> getSubscription(key: SubscriptionKey<T>, marker: Marker): SubscriptionRef<T> {
         val mock = mockSubscriptions[key.id] as? FakeSubscriptionSubscribe<T>
-        return if (mock != null) {
-            cache.getSubscription(FakeSubscriptionKey(key, mock), marker)
-        } else {
-            cache.getSubscription(key, marker)
+        if (mock != null) {
+            return cache.getSubscription(FakeSubscriptionKey(key, mock), marker)
         }
+        val testTag = marker[TestTagMarker.Key]?.value
+        val testTagMock = testTag?.let { mockSubscriptionsByTag[it] } as? FakeSubscriptionSubscribe<T>
+        if (testTagMock != null) {
+            return cache.getSubscription(FakeSubscriptionKey(key, testTagMock), marker)
+        }
+        return cache.getSubscription(key, marker)
     }
 }


### PR DESCRIPTION
Introduces the TestTag API, a new approach for identifying and mocking queries, mutations, and subscriptions in test and preview environments. This feature addresses the challenge of working with automatically generated IDs that may change during configuration changes or recompositions, providing a more stable and reliable way to reference these operations in tests and previews.

Usage example:

```kotlin
// Define a test tag
val testTag = MutationTestTag<Response, Variable>("example")

// Apply a mutation
val ... = rememberMutation(key, config = config = MutationConfig { marker = Marker.testTag(testTag) }

// Use with test client
testClient.on(testTag) { Response("mocked") }
```