### PR TITLE
Try using IdlingResource to stabilize a flaky test

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,14 @@ allprojects {
         }
     }
 
+    tasks.withType<Test>().configureEach {
+        testLogging {
+            events("passed", "skipped", "failed")
+            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+            showStandardStreams = true
+        }
+    }
+
     apply(plugin = "com.diffplug.spotless")
     configure<com.diffplug.gradle.spotless.SpotlessExtension> {
         format("format") {

--- a/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/AwaitTest.kt
+++ b/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/AwaitTest.kt
@@ -17,6 +17,7 @@ import soil.query.InfiniteQueryId
 import soil.query.InfiniteQueryKey
 import soil.query.QueryId
 import soil.query.QueryKey
+import soil.query.QueryOptionsOverride
 import soil.query.QueryState
 import soil.query.SwrCache
 import soil.query.SwrCacheScope
@@ -28,6 +29,7 @@ import soil.query.compose.rememberInfiniteQuery
 import soil.query.compose.rememberQuery
 import soil.query.compose.tooling.QueryPreviewClient
 import soil.query.compose.tooling.SwrPreviewClient
+import soil.query.copy
 import soil.query.test.test
 import soil.testing.UnitTest
 import kotlin.test.Test
@@ -45,6 +47,7 @@ class AwaitTest : UnitTest() {
         val client = SwrCache(coroutineScope = SwrCacheScope()).test {
             on(key.id) { deferred.await() }
         }
+        useIdlingResource(client)
         setContent {
             SwrClientProvider(client) {
                 val query = rememberQuery(key)
@@ -71,6 +74,7 @@ class AwaitTest : UnitTest() {
             on(key1.id) { deferred1.await() }
             on(key2.id) { deferred2.await() }
         }
+        useIdlingResource(client)
         setContent {
             SwrClientProvider(client) {
                 val query1 = rememberQuery(key1)
@@ -105,6 +109,7 @@ class AwaitTest : UnitTest() {
             on(key2.id) { deferred2.await() }
             on(key3.id) { deferred3.await() }
         }
+        useIdlingResource(client)
         setContent {
             SwrClientProvider(client) {
                 val query1 = rememberQuery(key1)
@@ -280,6 +285,12 @@ class AwaitTest : UnitTest() {
         id = Id(variant),
         fetch = { "Hello, Soil!" }
     ) {
+
+        override fun onConfigureOptions(): QueryOptionsOverride = { options ->
+            // NOTE: To investigate flaky tests.
+            options.copy(logger = { println(it) })
+        }
+
         class Id(variant: String) : QueryId<String>("test/query", "variant" to variant)
     }
 

--- a/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/CatchTest.kt
+++ b/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/CatchTest.kt
@@ -47,6 +47,7 @@ class CatchTest : UnitTest() {
                 }
             }
         }
+        useIdlingResource(client)
         setContent {
             SwrClientProvider(client) {
                 val query = rememberQuery(key)
@@ -91,6 +92,7 @@ class CatchTest : UnitTest() {
                 }
             }
         }
+        useIdlingResource(client)
         setContent {
             SwrClientProvider(client) {
                 val query = rememberQuery(key)

--- a/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/ComposeUiTestExt.kt
+++ b/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/ComposeUiTestExt.kt
@@ -1,0 +1,35 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file: Suppress("unused")
+package soil.query.compose.runtime
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.IdlingResource
+import soil.query.test.TestSwrClient
+import soil.query.test.TestSwrClientPlus
+
+@OptIn(ExperimentalTestApi::class)
+fun ComposeUiTest.useIdlingResource(client: TestSwrClient): () -> Unit {
+    val idlingResource = object : IdlingResource {
+        override val isIdleNow: Boolean
+            get() = client.isIdleNow()
+    }
+    registerIdlingResource(idlingResource)
+    return {
+        unregisterIdlingResource(idlingResource)
+    }
+}
+
+@OptIn(ExperimentalTestApi::class)
+fun ComposeUiTest.useIdlingResource(client: TestSwrClientPlus): () -> Unit {
+    val idlingResource = object : IdlingResource {
+        override val isIdleNow: Boolean
+            get() = client.isIdleNow()
+    }
+    registerIdlingResource(idlingResource)
+    return {
+        unregisterIdlingResource(idlingResource)
+    }
+}


### PR DESCRIPTION
Not sure why the test is flaky on [CI](https://github.com/soil-kt/soil/actions/runs/14369361465/job/40289333872#step:7:693),
so I tried registering a client to the IdlingResource provided by the ComposeUiTest API to see if it helps. If this works, I'll apply the same approach to other tests as well.

https://github.com/soil-kt/soil/blob/087fe9864bfd4b3544e09183d9e185a46a85c282/soil-query-compose-runtime/src/commonTest/kotlin/soil/query/compose/runtime/AwaitTest.kt#L39-L42
