### PR TITLE
Add platform-specific coroutine dispatchers dependencies

### DIFF
--- a/soil-query-core/build.gradle.kts
+++ b/soil-query-core/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
         }
 
         androidMain.dependencies {
+            api(libs.kotlinx.coroutines.android)
             implementation(libs.androidx.annotation)
             implementation(libs.androidx.lifecycle.process)
         }
@@ -54,6 +55,9 @@ kotlin {
 
         jvmMain {
             dependsOn(skikoMain)
+            dependencies {
+                api(libs.kotlinx.coroutines.swing)
+            }
         }
 
         wasmJsMain {


### PR DESCRIPTION
This PR adds the necessary platform-specific dependencies to support `Dispatchers.Main` across all target platforms:

- Android: Added kotlinx.coroutines.android
- JVM: Added kotlinx.coroutines.swing
- iOS: Uses the default implementation from kotlin-coroutines-core
- Wasm: Uses the default implementation from kotlin-coroutines-core
