### PR TITLE
Remove unnecessary logger from SwrCachePolicy in KeepAliveTest

### DIFF
--- a/soil-query-core/src/jvmTest/kotlin/soil/query/KeepAliveTest.kt
+++ b/soil-query-core/src/jvmTest/kotlin/soil/query/KeepAliveTest.kt
@@ -65,8 +65,7 @@ class KeepAliveTest : UnitTest() {
                 policy = SwrCachePolicy(
                     coroutineScope = swrScope,
                     queryOptions = QueryOptions(
-                        keepAliveTime = keepAliveTime,
-                        logger = { println(it) }
+                        keepAliveTime = keepAliveTime
                     )
                 )
             )


### PR DESCRIPTION
Removed redundant logging settings from the tests, as test logs are now output to stdout since #152.