### PR TITLE
Use Dependabot to keep the GitHub Actions commit hashes up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Update commit hash
+  # https://github.com/soil-kt/soil/pull/149
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
In #149, we switched to using commit hashes to mitigate the risk of supply chain attacks.
To keep them regularly updated, we've added Dependabot.
3rd dependencies library version upgrades will still be handled manually.