### PR TITLE
Remove skiko.js script reference from index.html in the sample app

### DIFF
--- a/sample/composeApp/src/wasmJsMain/resources/index.html
+++ b/sample/composeApp/src/wasmJsMain/resources/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sample - Soil</title>
-    <script type="application/javascript" src="skiko.js"></script>
     <script type="application/javascript" src="composeApp.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Removed the `skiko.js` reference from the `index.html` file in the sample app, as it's redundant when targeting Kotlin/Wasm.

Note: `skiko.js` is unnecessary in Kotlin/Wasm Compose for Web applications and is expected to be removed from the distribution in future versions of Compose Multiplatform.

Reference:
https://github.com/JetBrains/compose-multiplatform/blob/v1.7.3/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt#L95-L103