### PR TITLE
Add new soil-lazyload module for better modularity

### DIFF
--- a/buildSrc/src/main/kotlin/BuildModule.kt
+++ b/buildSrc/src/main/kotlin/BuildModule.kt
@@ -1,4 +1,5 @@
 val publicModules = setOf(
+    ":soil-experimental:soil-lazyload",
     ":soil-experimental:soil-optimistic-update",
     ":soil-query-core",
     ":soil-query-compose",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 // Public modules
 include(
+    ":soil-experimental:soil-lazyload",
     ":soil-experimental:soil-optimistic-update",
     ":soil-query-core",
     ":soil-query-compose",

--- a/soil-experimental/soil-lazyload/build.gradle.kts
+++ b/soil-experimental/soil-lazyload/build.gradle.kts
@@ -1,0 +1,118 @@
+import org.jetbrains.compose.ExperimentalComposeLibrary
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.kotlin.compose.compiler)
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.maven.publish)
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.kover)
+}
+
+val buildTarget = the<BuildTargetExtension>()
+
+kotlin {
+    applyDefaultHierarchyTemplate()
+
+    jvm()
+    androidTarget {
+        publishLibraryVariants("release")
+    }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser {
+            // TODO: We will consider using wasm tests when we update to 'org.jetbrains.compose.ui:ui:1.7.0' or later.
+            //  - https://slack-chats.kotlinlang.org/t/22883390/wasmjs-unit-testing-what-is-the-status-of-unit-testing-on-wa
+            testTask {
+                enabled = false
+            }
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(compose.runtime)
+            implementation(compose.foundation)
+        }
+
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            @OptIn(ExperimentalComposeLibrary::class)
+            implementation(compose.uiTest)
+            implementation(compose.runtime)
+            implementation(compose.ui)
+            implementation(compose.material)
+            implementation(projects.internal.testing)
+        }
+
+        val androidUnitTest by getting {
+            dependencies {
+                implementation(libs.compose.ui.test.junit4.android)
+                implementation(libs.compose.ui.test.manifest)
+            }
+        }
+
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
+        }
+    }
+}
+
+android {
+    namespace = "soil.plant.compose.lazy"
+    compileSdk = buildTarget.androidCompileSdk.get()
+
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    sourceSets["main"].res.srcDirs("src/androidMain/res")
+    sourceSets["main"].resources.srcDirs("src/commonMain/resources")
+
+    defaultConfig {
+        minSdk = buildTarget.androidMinSdk.get()
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+        }
+    }
+    compileOptions {
+        sourceCompatibility = buildTarget.javaVersion.get()
+        targetCompatibility = buildTarget.javaVersion.get()
+    }
+    @Suppress("UnstableApiUsage")
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
+    dependencies {
+        debugImplementation(libs.compose.ui.tooling)
+    }
+}
+
+composeCompiler {
+    if (buildTarget.composeCompilerMetrics.getOrElse(false)) {
+        metricsDestination = buildTarget.composeCompilerDestination
+    }
+    if (buildTarget.composeCompilerReports.getOrElse(false)) {
+        reportsDestination = buildTarget.composeCompilerDestination
+    }
+}
+
+kover {
+    currentProject {
+        createVariant("soil") {
+            add("debug")
+        }
+    }
+}

--- a/soil-experimental/soil-lazyload/gradle.properties
+++ b/soil-experimental/soil-lazyload/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=lazyload
+POM_NAME=lazyload

--- a/soil-experimental/soil-lazyload/src/commonMain/kotlin/soil/plant/compose/lazy/LazyGridLoad.kt
+++ b/soil-experimental/soil-lazyload/src/commonMain/kotlin/soil/plant/compose/lazy/LazyGridLoad.kt
@@ -1,0 +1,101 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.plant.compose.lazy
+
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * A composable function that enables infinite scrolling for a LazyVerticalGrid or LazyHorizontalGrid.
+ *
+ * This function automatically triggers the [loadMore] callback when the user scrolls
+ * close to the end of the grid, based on the specified [threshold].
+ *
+ * **NOTE:** For each unique [loadMoreParam] value, the [loadMore] callback will be invoked at most once.
+ * When [loadMoreParam] changes, the load detection will start over with the new parameter.
+ *
+ * @param T The type of parameter to pass to the [loadMore] callback
+ * @param state The [LazyGridState] of the lazy grid to monitor
+ * @param loadMore Callback function that will be invoked to load additional data
+ * @param loadMoreParam Parameter to pass to the [loadMore] callback, if null no loading will occur
+ * @param threshold Configuration that determines when to trigger loading more items
+ * @param debounceTimeout Duration to debounce scroll events to prevent multiple rapid load requests
+ */
+@Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
+@Composable
+inline fun <T : Any> LazyLoad(
+    state: LazyGridState,
+    loadMore: LazyLoadMore<T>,
+    loadMoreParam: T?,
+    threshold: LazyGridThreshold = LazyGridThreshold(),
+    debounceTimeout: Duration = 200.milliseconds
+) {
+    LazyLoad(
+        state = state,
+        loadMore = loadMore,
+        loadMoreParam = loadMoreParam,
+        strategy = remember { defaultLazyGridStrategy(threshold) },
+        debounceTimeout = debounceTimeout
+    )
+}
+
+/**
+ * Configuration class for determining when to load more items in a LazyVerticalGrid or LazyHorizontalGrid.
+ *
+ * Loading more items is triggered when both of the following conditions are met:
+ * - The number of remaining items is less than or equal to [remainingItems]
+ * - The ratio of remaining items to total items is less than or equal to [remainingRatio]
+ *
+ * @property remainingItems Threshold for the number of remaining items before triggering load more
+ * @property remainingRatio Threshold for the ratio of remaining items to total items (0.2f = 20%)
+ */
+class LazyGridThreshold(
+    val remainingItems: Int = 6,
+    val remainingRatio: Float = 0.2f
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as LazyGridThreshold
+
+        if (remainingItems != other.remainingItems) return false
+        if (remainingRatio != other.remainingRatio) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = remainingItems
+        result = 31 * result + remainingRatio.hashCode()
+        return result
+    }
+}
+
+/**
+ * Creates a default [LazyLoadStrategy] for lazy grids based on the specified [threshold].
+ *
+ * The strategy evaluates the current state of the lazy grid and determines if more items
+ * should be loaded based on the remaining items count and ratio.
+ *
+ * @param threshold Configuration that determines when to trigger loading more items
+ * @return A [LazyLoadStrategy] for lazy grids
+ */
+@PublishedApi
+internal fun defaultLazyGridStrategy(threshold: LazyGridThreshold) = LazyLoadStrategy<LazyGridState> { state ->
+    val layoutInfo = state.layoutInfo
+    val totalItemsNumber = layoutInfo.totalItemsCount
+    val lastVisibleItemIndex = (layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0) + 1
+    val remainingItems = totalItemsNumber - lastVisibleItemIndex
+    val remainingRatio = if (totalItemsNumber > 0) {
+        remainingItems.toFloat() / totalItemsNumber.toFloat()
+    } else {
+        0f
+    }
+    remainingItems <= threshold.remainingItems &&
+        remainingRatio <= threshold.remainingRatio
+}

--- a/soil-experimental/soil-lazyload/src/commonMain/kotlin/soil/plant/compose/lazy/LazyListLoad.kt
+++ b/soil-experimental/soil-lazyload/src/commonMain/kotlin/soil/plant/compose/lazy/LazyListLoad.kt
@@ -1,0 +1,101 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.plant.compose.lazy
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * A composable function that enables infinite scrolling for a LazyColumn or LazyRow.
+ *
+ * This function automatically triggers the [loadMore] callback when the user scrolls
+ * close to the end of the list, based on the specified [threshold].
+ *
+ * **NOTE:** For each unique [loadMoreParam] value, the [loadMore] callback will be invoked at most once.
+ * When [loadMoreParam] changes, the load detection will start over with the new parameter.
+ *
+ * @param T The type of parameter to pass to the [loadMore] callback
+ * @param state The [LazyListState] of the lazy list to monitor
+ * @param loadMore Callback function that will be invoked to load additional data
+ * @param loadMoreParam Parameter to pass to the [loadMore] callback, if null no loading will occur
+ * @param threshold Configuration that determines when to trigger loading more items
+ * @param debounceTimeout Duration to debounce scroll events to prevent multiple rapid load requests
+ */
+@Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
+@Composable
+inline fun <T : Any> LazyLoad(
+    state: LazyListState,
+    loadMore: LazyLoadMore<T>,
+    loadMoreParam: T?,
+    threshold: LazyListThreshold = LazyListThreshold(),
+    debounceTimeout: Duration = 200.milliseconds
+) {
+    LazyLoad(
+        state = state,
+        loadMore = loadMore,
+        loadMoreParam = loadMoreParam,
+        strategy = remember { defaultLazyListStrategy(threshold) },
+        debounceTimeout = debounceTimeout
+    )
+}
+
+/**
+ * Configuration class for determining when to load more items in a [LazyColumn] or [LazyRow].
+ *
+ * Loading more items is triggered when both of the following conditions are met:
+ * - The number of remaining items is less than or equal to [remainingItems]
+ * - The ratio of remaining items to total items is less than or equal to [remainingRatio]
+ *
+ * @property remainingItems Threshold for the number of remaining items before triggering load more
+ * @property remainingRatio Threshold for the ratio of remaining items to total items (0.2f = 20%)
+ */
+class LazyListThreshold(
+    val remainingItems: Int = 6,
+    val remainingRatio: Float = 0.2f
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as LazyListThreshold
+
+        if (remainingItems != other.remainingItems) return false
+        if (remainingRatio != other.remainingRatio) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = remainingItems
+        result = 31 * result + remainingRatio.hashCode()
+        return result
+    }
+}
+
+/**
+ * Creates a default [LazyLoadStrategy] for lazy lists based on the specified [threshold].
+ *
+ * The strategy evaluates the current state of the lazy list and determines if more items
+ * should be loaded based on the remaining items count and ratio.
+ *
+ * @param threshold Configuration that determines when to trigger loading more items
+ * @return A [LazyLoadStrategy] for lazy lists
+ */
+@PublishedApi
+internal fun defaultLazyListStrategy(threshold: LazyListThreshold) = LazyLoadStrategy<LazyListState> { state ->
+    val layoutInfo = state.layoutInfo
+    val totalItemsNumber = layoutInfo.totalItemsCount
+    val lastVisibleItemIndex = (layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0) + 1
+    val remainingItems = totalItemsNumber - lastVisibleItemIndex
+    val remainingRatio = if (totalItemsNumber > 0) {
+        remainingItems.toFloat() / totalItemsNumber.toFloat()
+    } else {
+        0f
+    }
+    remainingItems <= threshold.remainingItems &&
+        remainingRatio <= threshold.remainingRatio
+}

--- a/soil-experimental/soil-lazyload/src/commonMain/kotlin/soil/plant/compose/lazy/LazyLoad.kt
+++ b/soil-experimental/soil-lazyload/src/commonMain/kotlin/soil/plant/compose/lazy/LazyLoad.kt
@@ -1,0 +1,93 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.plant.compose.lazy
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.take
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Core composable that implements infinite scrolling logic for any scrollable state.
+ *
+ * This function sets up a [LaunchedEffect] that monitors the scroll state and triggers
+ * the [loadMore] callback when the scrolling position meets the conditions defined by the [strategy].
+ *
+ * **NOTE**: For each unique [loadMoreParam] value, the [loadMore] callback will be invoked at most once.
+ * When [loadMoreParam] changes, the load detection will start over with the new parameter.
+ *
+ * @param T The type of parameter to pass to the [loadMore] callback
+ * @param S The type of scrollable state being monitored
+ * @param state The scrollable state to monitor (e.g., LazyListState, LazyGridState)
+ * @param loadMore Callback function that will be invoked to load additional data
+ * @param loadMoreParam Parameter to pass to the [loadMore] callback, if null no loading will occur
+ * @param strategy Strategy that determines when additional data should be loaded
+ * @param debounceTimeout Duration to debounce scroll events to prevent multiple rapid load requests
+ */
+@Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
+@OptIn(FlowPreview::class)
+@Composable
+inline fun <T : Any, S> LazyLoad(
+    state: S,
+    loadMore: LazyLoadMore<T>,
+    loadMoreParam: T?,
+    strategy: LazyLoadStrategy<S>,
+    debounceTimeout: Duration = 200.milliseconds
+) {
+    LaunchedEffect(state, loadMoreParam) {
+        if (loadMoreParam == null) {
+            return@LaunchedEffect
+        }
+        snapshotFlow { strategy.shouldLoadMore(state) }
+            .debounce(debounceTimeout)
+            .filter { it }
+            .take(1)
+            .collect {
+                loadMore(loadMoreParam)
+            }
+    }
+}
+
+/**
+ * Interface that defines the strategy for determining when to load more items.
+ *
+ * Implement this interface to customize when the infinite scrolling should trigger
+ * the load more callback based on the current scroll state.
+ *
+ * @param T The type of scrollable state to evaluate
+ */
+@Stable
+fun interface LazyLoadStrategy<T> {
+    /**
+     * Determines if more data should be loaded based on the current scroll state.
+     *
+     * @param state The current scroll state to evaluate
+     * @return True if more data should be loaded, false otherwise
+     */
+    fun shouldLoadMore(state: T): Boolean
+}
+
+/**
+ * Interface that defines the callback for loading more items.
+ *
+ * This callback is triggered when the scrolling position meets the conditions
+ * defined by the [LazyLoadStrategy].
+ *
+ * @param T The type of parameter that will be passed to the callback
+ */
+@Stable
+fun interface LazyLoadMore<T> {
+    /**
+     * Invokes the load more operation with the specified parameter.
+     *
+     * @param param The parameter to use for loading more data
+     */
+    suspend operator fun invoke(param: T)
+}

--- a/soil-experimental/soil-lazyload/src/commonTest/kotlin/soil/plant/compose/lazy/LazyLoadTest.kt
+++ b/soil-experimental/soil-lazyload/src/commonTest/kotlin/soil/plant/compose/lazy/LazyLoadTest.kt
@@ -1,0 +1,211 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.plant.compose.lazy
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import androidx.compose.ui.unit.dp
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class LazyLoadTest : UnitTest() {
+
+    @Test
+    fun testLazyLoad_withLazyList() = runComposeUiTest {
+        var loadMoreCalled = 0
+        var pageNumber = 0
+        val loadMore = LazyLoadMore<Int> { param ->
+            loadMoreCalled += 1
+            pageNumber = param
+        }
+        val items = List(30) { "Item $it" }
+        setContent {
+            val lazyListState = rememberLazyListState()
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().testTag("lazyColumn"),
+                state = lazyListState,
+                contentPadding = PaddingValues(16.dp)
+            ) {
+                items(items) { item ->
+                    Text(
+                        text = item,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(48.dp)
+                            .padding(16.dp)
+                            .testTag(item)
+                    )
+                }
+            }
+            LazyLoad(
+                state = lazyListState,
+                loadMore = loadMore,
+                loadMoreParam = 1,
+                threshold = LazyListThreshold(
+                    remainingItems = 6
+                )
+            )
+        }
+
+        waitUntilExactlyOneExists(hasTestTag("Item 0"))
+        assertEquals(0, loadMoreCalled)
+        assertEquals(0, pageNumber)
+
+        onNodeWithTag("lazyColumn")
+            .performScrollToIndex(items.lastIndex - 6)
+
+        waitUntilExactlyOneExists(hasTestTag("Item ${items.lastIndex - 6}"))
+        waitUntil { loadMoreCalled == 1 }
+        assertEquals(1, pageNumber)
+
+        onNodeWithTag("lazyColumn")
+            .performScrollToIndex(0)
+
+        waitUntilExactlyOneExists(hasTestTag("Item 0"))
+
+        onNodeWithTag("lazyColumn")
+            .performScrollToIndex(items.lastIndex - 6)
+
+        waitUntilExactlyOneExists(hasTestTag("Item ${items.lastIndex - 6}"))
+        waitForIdle()
+        // LazyLoad called only once
+        assertEquals(1, loadMoreCalled)
+        assertEquals(1, pageNumber)
+    }
+
+    @Test
+    fun testLazyLoad_withLazyGrid() = runComposeUiTest {
+        var loadMoreCalled = 0
+        var pageNumber = 0
+        val loadMore = LazyLoadMore<Int> { param ->
+            loadMoreCalled += 1
+            pageNumber = param
+        }
+        val items = List(30) { "Item $it" }
+        setContent {
+            val lazyGridState = rememberLazyGridState()
+            LazyVerticalGrid(
+                modifier = Modifier.fillMaxSize().testTag("lazyGrid"),
+                state = lazyGridState,
+                columns = GridCells.Fixed(2),
+                contentPadding = PaddingValues(16.dp)
+            ) {
+                items(items) { item ->
+                    Text(
+                        text = item,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(72.dp)
+                            .padding(16.dp)
+                            .testTag(item)
+                    )
+                }
+            }
+            LazyLoad(
+                state = lazyGridState,
+                loadMore = loadMore,
+                loadMoreParam = 1,
+                threshold = LazyGridThreshold(
+                    remainingItems = 6
+                )
+            )
+        }
+
+        waitUntilExactlyOneExists(hasTestTag("Item 0"))
+        assertEquals(0, loadMoreCalled)
+        assertEquals(0, pageNumber)
+
+        onNodeWithTag("lazyGrid")
+            .performScrollToIndex(items.lastIndex - 6)
+
+        waitUntilExactlyOneExists(hasTestTag("Item ${items.lastIndex - 6}"))
+        waitUntil { loadMoreCalled == 1 }
+        assertEquals(1, pageNumber)
+
+        onNodeWithTag("lazyGrid")
+            .performScrollToIndex(0)
+
+        waitUntilExactlyOneExists(hasTestTag("Item 0"))
+
+        onNodeWithTag("lazyGrid")
+            .performScrollToIndex(items.lastIndex - 6)
+
+        waitUntilExactlyOneExists(hasTestTag("Item ${items.lastIndex - 6}"))
+        // LazyLoad called only once
+        waitForIdle()
+        assertEquals(1, loadMoreCalled)
+        assertEquals(1, pageNumber)
+    }
+
+    @Test
+    fun testLazyLoad_nextParamIsNull() = runComposeUiTest {
+        var loadMoreCalled = 0
+        var pageNumber = 0
+        val loadMore = LazyLoadMore<Int> { param ->
+            loadMoreCalled += 1
+            pageNumber = param
+        }
+        val items = List(30) { "Item $it" }
+        setContent {
+            val lazyListState = rememberLazyListState()
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().testTag("lazyColumn"),
+                state = lazyListState,
+                contentPadding = PaddingValues(16.dp)
+            ) {
+                items(items) { item ->
+                    Text(
+                        text = item,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(48.dp)
+                            .padding(16.dp)
+                            .testTag(item)
+                    )
+                }
+            }
+            LazyLoad(
+                state = lazyListState,
+                loadMore = loadMore,
+                loadMoreParam = null,
+                threshold = LazyListThreshold(
+                    remainingItems = 6
+                )
+            )
+        }
+
+        waitUntilExactlyOneExists(hasTestTag("Item 0"))
+        assertEquals(0, loadMoreCalled)
+        assertEquals(0, pageNumber)
+
+        onNodeWithTag("lazyColumn")
+            .performScrollToIndex(items.lastIndex - 6)
+
+        waitUntilExactlyOneExists(hasTestTag("Item ${items.lastIndex - 6}"))
+        waitForIdle()
+        assertEquals(0, loadMoreCalled)
+        assertEquals(0, pageNumber)
+    }
+}

--- a/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/LazyLoadEffect.kt
+++ b/soil-query-compose-runtime/src/commonMain/kotlin/soil/query/compose/runtime/LazyLoadEffect.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.take
 import kotlin.jvm.JvmInline
+import kotlin.DeprecationLevel
+import kotlin.ReplaceWith
 
 /**
  * Provides a [LaunchedEffect] to perform additional loading for [soil.query.compose.InfiniteQueryObject].
@@ -30,6 +32,14 @@ import kotlin.jvm.JvmInline
  * @param computeVisibleItemIndex A function that calculates the index of the visible item used as the reference for additional loading.
  */
 @Composable
+@Deprecated(
+    message = "This implementation is deprecated. Please use the new LazyLoad from soil-experimental:soil-lazyload module instead.",
+    replaceWith = ReplaceWith(
+        "LazyLoad(state, loadMore, loadMoreParam)",
+        "soil.plant.compose.lazy.LazyLoad"
+    ),
+    level = DeprecationLevel.WARNING
+)
 inline fun <T : Any> LazyLoadEffect(
     state: LazyListState,
     noinline loadMore: suspend (T) -> Unit,
@@ -67,6 +77,14 @@ inline fun <T : Any> LazyLoadEffect(
  * @param computeVisibleItemIndex A function that calculates the index of the visible item used as the reference for additional loading.
  */
 @Composable
+@Deprecated(
+    message = "This implementation is deprecated. Please use the new LazyLoad from soil-experimental:soil-lazyload module instead.",
+    replaceWith = ReplaceWith(
+        "LazyLoad(state, loadMore, loadMoreParam)",
+        "soil.plant.compose.lazy.LazyLoad"
+    ),
+    level = DeprecationLevel.WARNING
+)
 inline fun <T : Any> LazyLoadEffect(
     state: LazyGridState,
     noinline loadMore: suspend (T) -> Unit,


### PR DESCRIPTION
We've implemented a new standalone soil-lazyload module as part of our modularization efforts. This module provides a completely rewritten implementation of the LazyLoad functionality that was previously contained within the soil-query-compose-runtime module.

The LazyLoad functionality in soil-query-compose-runtime is now considered deprecated. We plan to remove this deprecated functionality in a future release.

Example:

```kotlin
// It has been carefully designed for seamless integration with InfiniteQuery.
val query = rememberInfiniteQuery(
    key = GetTestInfiniteQueryKey(),
    select = { it.chunkedData }
)
LazyLoadContent(
    list = query.data.orEmpty(),
    loadMore = query.loadMore,
    loadMoreParam = query.loadMoreParam,
)


@Composable
private fun LazyLoadContent(
    list: List<String>,
    loadMore: LazyLoadMore<Int>,
    loadMoreParam: Int?,
    modifier: Modifier = Modifier,
    contentPadding: PaddingValues = PaddingValues(0.dp)
) {
    val lazyListState = rememberLazyListState()
    LazyColumn(
        modifier = modifier.fillMaxWidth(),
        state = lazyListState,
        contentPadding = contentPadding
    ) {
        items(list, key = { it }, contentType = { "main" }) { item ->
            LazyLoadItem(item, modifier = Modifier.height(48.dp))
        }
    }
    LazyLoad(
        state = lazyListState,
        loadMore = loadMore,
        loadMoreParam = loadMoreParam
    )
}
```