### PR TITLE
Rename soil-optimistic package to soil.plant.compose.optimistic

### DIFF
--- a/soil-experimental/soil-optimistic-update/build.gradle.kts
+++ b/soil-experimental/soil-optimistic-update/build.gradle.kts
@@ -65,7 +65,7 @@ kotlin {
 }
 
 android {
-    namespace = "soil.optimistic"
+    namespace = "soil.plant.compose.optimistic"
     compileSdk = buildTarget.androidCompileSdk.get()
 
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")

--- a/soil-experimental/soil-optimistic-update/src/commonMain/kotlin/soil/plant/compose/optimistic/OptimisticUpdate.kt
+++ b/soil-experimental/soil-optimistic-update/src/commonMain/kotlin/soil/plant/compose/optimistic/OptimisticUpdate.kt
@@ -3,7 +3,7 @@
 
 @file:Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
 
-package soil.optimistic.compose
+package soil.plant.compose.optimistic
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
@@ -70,7 +70,7 @@ typealias OptimisticCompletionHandle = (cause: Throwable?) -> Unit
 @Composable
 inline fun <T> rememberOptimistic(
     state: T,
-    policy: OptimisticUpdatePolicy = OptimisticUpdatePolicy.Default,
+    policy: OptimisticUpdatePolicy = OptimisticUpdatePolicy,
 ): OptimisticObject<T, T> {
     return rememberOptimistic(
         state = state,
@@ -124,7 +124,7 @@ inline fun <T> rememberOptimistic(
 @Composable
 fun <T, D> rememberOptimistic(
     state: T,
-    policy: OptimisticUpdatePolicy = OptimisticUpdatePolicy.Default,
+    policy: OptimisticUpdatePolicy = OptimisticUpdatePolicy,
     updateFn: OptimisticUpdate<T, D>
 ): OptimisticObject<T, D> {
 

--- a/soil-experimental/soil-optimistic-update/src/commonTest/kotlin/soil/plant/compose/optimistic/OptimisticUpdateTest.kt
+++ b/soil-experimental/soil-optimistic-update/src/commonTest/kotlin/soil/plant/compose/optimistic/OptimisticUpdateTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2025 Soil Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-package soil.optimistic.compose
+package soil.plant.compose.optimistic
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Button


### PR DESCRIPTION
This change aligns the optimistic update package with our naming convention, following the same pattern as `soil-lazyload` which uses the `soil.plant` prefix. 

Since the `soil-optimistic` package has not been publicly released yet, there is no impact on existing dependencies or users.