### PR TITLE
Add isValidating flag to QueryFetchStatus.Fetching

### DIFF
--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizer.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizer.kt
@@ -42,16 +42,12 @@ private object InfiniteQueryRecompositionOptimizerEnabled : InfiniteQueryRecompo
 
                 QueryStatus.Success -> {
                     add(QueryState.OmitKey.errorUpdatedAt)
-                    if (!state.isInvalidated) {
+                    if (state.isValidating && !state.isInvalidated) {
                         add(QueryState.OmitKey.fetchStatus)
                     }
                 }
 
-                QueryStatus.Failure -> {
-                    if (!state.isInvalidated) {
-                        add(QueryState.OmitKey.fetchStatus)
-                    }
-                }
+                QueryStatus.Failure -> Unit
             }
         }
         return state.omit(keys)

--- a/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryRecompositionOptimizer.kt
+++ b/soil-query-compose/src/commonMain/kotlin/soil/query/compose/QueryRecompositionOptimizer.kt
@@ -41,16 +41,12 @@ private object QueryRecompositionOptimizerEnabled : QueryRecompositionOptimizer 
 
                 QueryStatus.Success -> {
                     add(QueryState.OmitKey.errorUpdatedAt)
-                    if (!state.isInvalidated) {
+                    if (state.isValidating && !state.isInvalidated) {
                         add(QueryState.OmitKey.fetchStatus)
                     }
                 }
 
-                QueryStatus.Failure -> {
-                    if (!state.isInvalidated) {
-                        add(QueryState.OmitKey.fetchStatus)
-                    }
-                }
+                QueryStatus.Failure -> Unit
             }
         }
         return state.omit(keys)

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/InfiniteQueryRecompositionOptimizerTest.kt
@@ -108,7 +108,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Pending,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
             isInvalidated = false
         )
         val actual = InfiniteQueryRecompositionOptimizer.Enabled.omit(state)
@@ -132,7 +132,31 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Success,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
+            isInvalidated = false
+        )
+        val actual = InfiniteQueryRecompositionOptimizer.Enabled.omit(state)
+        val expected = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 0,
+            errorUpdatedAt = 0,
+            staleAt = 0,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching(),
+            isInvalidated = false
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_success_isValidating() {
+        val state = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
             isInvalidated = false
         )
         val actual = InfiniteQueryRecompositionOptimizer.Enabled.omit(state)
@@ -156,7 +180,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Success,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
             isInvalidated = true
         )
         val actual = InfiniteQueryRecompositionOptimizer.Enabled.omit(state)
@@ -166,7 +190,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 0,
             staleAt = 0,
             status = QueryStatus.Success,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
             isInvalidated = true
         )
         assertEquals(expected, actual)
@@ -182,7 +206,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Failure,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
             isInvalidated = false
         )
         val actual = InfiniteQueryRecompositionOptimizer.Enabled.omit(state)
@@ -193,7 +217,34 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 0,
             status = QueryStatus.Failure,
-            fetchStatus = QueryFetchStatus.Idle,
+            fetchStatus = QueryFetchStatus.Fetching(),
+            isInvalidated = false
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_failure_isValidating() {
+        val error = RuntimeException("error")
+        val state = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
+            isInvalidated = false
+        )
+        val actual = InfiniteQueryRecompositionOptimizer.Enabled.omit(state)
+        val expected = QueryState.test<QueryChunks<Int, Int>>(
+            reply = Reply.some(emptyChunks()),
+            replyUpdatedAt = 0,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 0,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
             isInvalidated = false
         )
         assertEquals(expected, actual)
@@ -209,7 +260,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Failure,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
             isInvalidated = true
         )
         val actual = InfiniteQueryRecompositionOptimizer.Enabled.omit(state)
@@ -220,7 +271,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 0,
             status = QueryStatus.Failure,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
             isInvalidated = true
         )
         assertEquals(expected, actual)
@@ -234,7 +285,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Pending,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
             isInvalidated = false
         )
         val actual = InfiniteQueryRecompositionOptimizer.Disabled.omit(expected)
@@ -249,7 +300,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Success,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
             isInvalidated = false
         )
         val actual = InfiniteQueryRecompositionOptimizer.Disabled.omit(expected)
@@ -266,7 +317,7 @@ class InfiniteQueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Failure,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
             isInvalidated = false
         )
         val actual = InfiniteQueryRecompositionOptimizer.Disabled.omit(expected)

--- a/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryRecompositionOptimizerTest.kt
+++ b/soil-query-compose/src/commonTest/kotlin/soil/query/compose/QueryRecompositionOptimizerTest.kt
@@ -83,7 +83,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Pending,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
             isInvalidated = false
         )
         val actual = QueryRecompositionOptimizer.Enabled.omit(state)
@@ -107,7 +107,31 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Success,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
+            isInvalidated = false
+        )
+        val actual = QueryRecompositionOptimizer.Enabled.omit(state)
+        val expected = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            errorUpdatedAt = 0,
+            staleAt = 0,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching(),
+            isInvalidated = false
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_success_isValidating() {
+        val state = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Success,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
             isInvalidated = false
         )
         val actual = QueryRecompositionOptimizer.Enabled.omit(state)
@@ -131,7 +155,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Success,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
             isInvalidated = true
         )
         val actual = QueryRecompositionOptimizer.Enabled.omit(state)
@@ -141,7 +165,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 0,
             staleAt = 0,
             status = QueryStatus.Success,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
             isInvalidated = true
         )
         assertEquals(expected, actual)
@@ -157,7 +181,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Failure,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
             isInvalidated = false
         )
         val actual = QueryRecompositionOptimizer.Enabled.omit(state)
@@ -168,7 +192,34 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 0,
             status = QueryStatus.Failure,
-            fetchStatus = QueryFetchStatus.Idle,
+            fetchStatus = QueryFetchStatus.Fetching(),
+            isInvalidated = false
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOmit_default_failure_isValidating() {
+        val error = RuntimeException("error")
+        val state = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 300,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 400,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
+            isInvalidated = false
+        )
+        val actual = QueryRecompositionOptimizer.Enabled.omit(state)
+        val expected = QueryState.test(
+            reply = Reply.some(1),
+            replyUpdatedAt = 0,
+            error = error,
+            errorUpdatedAt = 200,
+            staleAt = 0,
+            status = QueryStatus.Failure,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
             isInvalidated = false
         )
         assertEquals(expected, actual)
@@ -184,7 +235,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Failure,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
             isInvalidated = true
         )
         val actual = QueryRecompositionOptimizer.Enabled.omit(state)
@@ -195,7 +246,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 0,
             status = QueryStatus.Failure,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(isValidating = true),
             isInvalidated = true
         )
         assertEquals(expected, actual)
@@ -209,7 +260,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Pending,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
             isInvalidated = false
         )
         val actual = QueryRecompositionOptimizer.Disabled.omit(expected)
@@ -224,7 +275,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Success,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
             isInvalidated = false
         )
         val actual = QueryRecompositionOptimizer.Disabled.omit(expected)
@@ -241,7 +292,7 @@ class QueryRecompositionOptimizerTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 400,
             status = QueryStatus.Failure,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
             isInvalidated = false
         )
         val actual = QueryRecompositionOptimizer.Disabled.omit(expected)

--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryCommands.kt
@@ -33,11 +33,12 @@ object InfiniteQueryCommands {
                 callback?.invoke(Result.failure(CancellationException("skip fetch")))
                 return
             }
-            ctx.dispatch(QueryAction.Fetching())
             val chunks = ctx.state.reply.getOrNull()
             if (chunks.isNullOrEmpty()) {
+                ctx.dispatch(QueryAction.Fetching())
                 ctx.dispatchFetchChunksResult(key, key.initialParam(), marker, callback)
             } else {
+                ctx.dispatch(QueryAction.Fetching(isValidating = true))
                 ctx.dispatchRevalidateChunksResult(key, chunks, marker, callback)
             }
         }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryAction.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryAction.kt
@@ -16,9 +16,11 @@ sealed interface QueryAction<out T> {
      * Indicates that the query is fetching data.
      *
      * @param isInvalidated Indicates whether the query is invalidated.
+     * @param isValidating Indicates whether the query is validating existing data.
      */
     data class Fetching(
-        val isInvalidated: Boolean? = null
+        val isInvalidated: Boolean? = null,
+        val isValidating: Boolean = isInvalidated ?: false
     ) : QueryAction<Nothing>
 
     /**
@@ -74,7 +76,7 @@ fun <T> createQueryReducer(): QueryReducer<T> = { state, action ->
     when (action) {
         is QueryAction.Fetching -> {
             state.copy(
-                fetchStatus = QueryFetchStatus.Fetching,
+                fetchStatus = QueryFetchStatus.Fetching(isValidating = action.isValidating),
                 isInvalidated = action.isInvalidated ?: state.isInvalidated
             )
         }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommands.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryCommands.kt
@@ -4,6 +4,7 @@
 package soil.query
 
 import soil.query.core.Marker
+import soil.query.core.isNone
 import soil.query.core.vvv
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -32,7 +33,7 @@ object QueryCommands {
                 callback?.invoke(Result.failure(CancellationException("skip fetch")))
                 return
             }
-            ctx.dispatch(QueryAction.Fetching())
+            ctx.dispatch(QueryAction.Fetching(isValidating = !ctx.state.reply.isNone))
             ctx.dispatchFetchResult(key, marker, callback)
         }
     }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryModel.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryModel.kt
@@ -59,7 +59,12 @@ interface QueryModel<out T> : DataModel<T> {
     /**
      * Returns `true` if the query is fetching, `false` otherwise.
      */
-    val isFetching: Boolean get() = fetchStatus == QueryFetchStatus.Fetching
+    val isFetching: Boolean get() = fetchStatus is QueryFetchStatus.Fetching
+
+    /**
+     * Returns `true` if the query is validating, `false` otherwise.
+     */
+    val isValidating: Boolean get() = (fetchStatus as? QueryFetchStatus.Fetching)?.isValidating ?: false
 
     /**
      * Returns `true` if the query is staled, `false` otherwise.
@@ -106,7 +111,10 @@ enum class QueryStatus {
 sealed class QueryFetchStatus {
 
     data object Idle : QueryFetchStatus()
-    data object Fetching : QueryFetchStatus()
+    data class Fetching(
+        val isValidating: Boolean = false
+    ) : QueryFetchStatus()
+
     data class Paused(
         val unpauseAt: Long
     ) : QueryFetchStatus()

--- a/soil-query-core/src/commonTest/kotlin/soil/query/QueryStateTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/QueryStateTest.kt
@@ -19,7 +19,7 @@ class QueryStateTest : UnitTest() {
             errorUpdatedAt = 200,
             staleAt = 300,
             status = QueryStatus.Success,
-            fetchStatus = QueryFetchStatus.Fetching,
+            fetchStatus = QueryFetchStatus.Fetching(),
             isInvalidated = true
         )
         val actual = state.omit(


### PR DESCRIPTION
This PR introduces a new `isValidating` boolean flag to the `QueryFetchStatus.Fetching` data class. This flag helps distinguish between initial data fetch operations and validation of existing data, along with adjustments to the Compose RecompositionOptimizer's default behavior to work with this new flag.

The `isValidating` flag is particularly useful for:

1. InfiniteQuery - It helps determine if the query is fetching additional chunks or validating existing data
2. UI rendering - Allows different loading indicators for initial load vs. background validation
3. Performance optimization - Better control over when to trigger recompositions in Compose UI