### PR TITLE
Add soil-lazyload dependency to kover configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,7 @@ kover {
 }
 
 dependencies {
+    kover(projects.soilExperimental.soilLazyload)
     kover(projects.soilExperimental.soilOptimisticUpdate)
     kover(projects.soilExperimental.soilReacty)
     kover(projects.soilQueryCore)


### PR DESCRIPTION
Setting for additional modules was missing in #167.