### PR TITLE
Add tests for Query and Mutation command functions

### DIFF
--- a/soil-query-core/src/commonTest/kotlin/soil/query/InfiniteQueryCommandTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/InfiniteQueryCommandTest.kt
@@ -1,0 +1,352 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import app.cash.turbine.test
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import soil.query.core.ErrorRelay
+import soil.query.core.Marker
+import soil.query.core.RetryFn
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InfiniteQueryCommandTest : UnitTest() {
+
+    @Test
+    fun testFetch_success() = runTest {
+        val ctx = TestInfiniteQueryContext()
+        val key = TestInfiniteQueryKey(mockFetch = { "test-data-$it" })
+        val variable = 0
+        val job = launch {
+            val result = ctx.fetch(key, variable, TestNonRetry)
+            assertTrue(result.isSuccess)
+            assertEquals("test-data-$variable", result.getOrThrow())
+        }
+        job.join()
+        assertTrue(job.isCompleted)
+    }
+
+    @Test
+    fun testFetch_failure() = runTest {
+        val ctx = TestInfiniteQueryContext()
+        val key = TestInfiniteQueryKey(mockFetch = { error("Test") })
+        val variable = 0
+        val job = launch {
+            val result = ctx.fetch(key, variable, TestNonRetry)
+            assertTrue(result.isFailure)
+            assertEquals("Test", result.exceptionOrNull()?.message)
+        }
+        job.join()
+        assertTrue(job.isCompleted)
+    }
+
+    @Test
+    fun testFetch_cancel() = runTest {
+        val ctx = TestInfiniteQueryContext()
+        val key = TestInfiniteQueryKey(mockFetch = { throw CancellationException("Test") })
+        val variable = 0
+        val job = launch {
+            ctx.fetch(key, variable, TestNonRetry)
+        }
+        job.join()
+        assertTrue(job.isCancelled)
+    }
+
+    @Test
+    fun testRevalidate_success() = runTest {
+        val ctx = TestInfiniteQueryContext()
+        val key = TestInfiniteQueryKey(mockFetch = { "test-data-$it" })
+        val initialChunks = buildChunks {
+            add(QueryChunk("test-data-0", 0))
+            add(QueryChunk("test-data-1", 1))
+        }
+        val job = launch {
+            val result = ctx.revalidate(key, initialChunks)
+            assertTrue(result.isSuccess)
+            val chunks = result.getOrNull()
+            assertNotNull(chunks)
+            assertEquals(2, chunks.size)
+            assertEquals("test-data-0", chunks[0].data)
+            assertEquals(0, chunks[0].param)
+            assertEquals("test-data-1", chunks[1].data)
+            assertEquals(1, chunks[1].param)
+        }
+        job.join()
+        assertTrue(job.isCompleted)
+    }
+
+    @Test
+    fun testRevalidate_success_whenDataCountDecreases() = runTest {
+        val ctx = TestInfiniteQueryContext()
+        val key = TestInfiniteQueryKey(
+            mockFetch = { "test-data-$it" },
+            mockLoadMoreParam = { null }
+        )
+        val initialChunks = buildChunks {
+            add(QueryChunk("test-data-0", 0))
+            add(QueryChunk("test-data-1", 1))
+        }
+        val job = launch {
+            val result = ctx.revalidate(key, initialChunks)
+            assertTrue(result.isSuccess)
+            val chunks = result.getOrNull()
+            assertNotNull(chunks)
+            assertEquals(1, chunks.size)
+            assertEquals("test-data-0", chunks[0].data)
+            assertEquals(0, chunks[0].param)
+        }
+        job.join()
+        assertTrue(job.isCompleted)
+    }
+
+    @Test
+    fun testRevalidate_failure() = runTest {
+        val ctx = TestInfiniteQueryContext()
+        val key = TestInfiniteQueryKey(mockFetch = { error("Test") })
+        val initialChunks = buildChunks {
+            add(QueryChunk("test-data-0", 0))
+            add(QueryChunk("test-data-1", 1))
+        }
+        val job = launch {
+            val result = ctx.revalidate(key, initialChunks)
+            assertTrue(result.isFailure)
+            assertEquals("Test", result.exceptionOrNull()?.message)
+        }
+        job.join()
+        assertTrue(job.isCompleted)
+    }
+
+    @Test
+    fun testRevalidate_cancel() = runTest {
+        val ctx = TestInfiniteQueryContext()
+        val key = TestInfiniteQueryKey(mockFetch = { throw CancellationException("Test") })
+        val initialChunks = buildChunks {
+            add(QueryChunk("test-data-0", 0))
+            add(QueryChunk("test-data-1", 1))
+        }
+        val job = launch {
+            ctx.revalidate(key, initialChunks)
+        }
+        job.join()
+        assertTrue(job.isCancelled)
+    }
+
+    @Test
+    fun testDispatchFetchChunksResult_success() = runTest {
+        var dispatchedAction: QueryAction<QueryChunks<String, Int>>? = null
+        val ctx = TestInfiniteQueryContext(
+            dispatch = { action -> dispatchedAction = action }
+        )
+        val key = TestInfiniteQueryKey(mockFetch = { "test-data-$it" })
+        val variable = 0
+        val marker = Marker.None
+        var callbackResult: Result<QueryChunks<String, Int>>? = null
+        val callback: QueryCallback<QueryChunks<String, Int>> = { result ->
+            callbackResult = result
+        }
+        val job = launch {
+            ctx.dispatchFetchChunksResult(key, variable, marker, callback)
+        }
+        job.join()
+        assertTrue(dispatchedAction is QueryAction.FetchSuccess)
+        assertTrue(callbackResult?.isSuccess == true)
+
+        val actionData = (dispatchedAction as QueryAction.FetchSuccess).data
+        assertEquals(1, actionData.size)
+        assertEquals("test-data-0", actionData[0].data)
+        assertEquals(0, actionData[0].param)
+    }
+
+    @Test
+    fun testDispatchFetchChunksResult_success_whenLoadMore() = runTest {
+        var dispatchedAction: QueryAction<QueryChunks<String, Int>>? = null
+        val ctx = TestInfiniteQueryContext(
+            state = QueryState.success(data = buildChunks {
+                add(QueryChunk("test-data-0", 0))
+            }),
+            dispatch = { action -> dispatchedAction = action }
+        )
+        val key = TestInfiniteQueryKey(mockFetch = { "test-data-$it" })
+        val variable = 1
+        val marker = Marker.None
+        var callbackResult: Result<QueryChunks<String, Int>>? = null
+        val callback: QueryCallback<QueryChunks<String, Int>> = { result ->
+            callbackResult = result
+        }
+        val job = launch {
+            ctx.dispatchFetchChunksResult(key, variable, marker, callback)
+        }
+        job.join()
+        assertTrue(dispatchedAction is QueryAction.FetchSuccess)
+        assertTrue(callbackResult?.isSuccess == true)
+
+        val actionData = (dispatchedAction as QueryAction.FetchSuccess).data
+        assertEquals(2, actionData.size)
+        assertEquals("test-data-0", actionData[0].data)
+        assertEquals(0, actionData[0].param)
+        assertEquals("test-data-1", actionData[1].data)
+        assertEquals(1, actionData[1].param)
+    }
+
+    @Test
+    fun testDispatchFetchChunksResult_failure() = runTest {
+        val errorRelay = ErrorRelay.newAnycast(backgroundScope)
+        var dispatchedAction: QueryAction<QueryChunks<String, Int>>? = null
+        val ctx = TestInfiniteQueryContext(
+            dispatch = { action -> dispatchedAction = action },
+            relay = errorRelay::send
+        )
+        val key = TestInfiniteQueryKey(mockFetch = { error("Test") })
+        val variable = 0
+        val marker = Marker.None
+        var callbackResult: Result<QueryChunks<String, Int>>? = null
+        val callback: QueryCallback<QueryChunks<String, Int>> = { result ->
+            callbackResult = result
+        }
+        val job = launch {
+            ctx.dispatchFetchChunksResult(key, variable, marker, callback)
+        }
+        job.join()
+        assertTrue(dispatchedAction is QueryAction.FetchFailure)
+        assertTrue(callbackResult?.isFailure == true)
+        val job2 = launch {
+            errorRelay.receiveAsFlow().test {
+                assertEquals(TestInfiniteQueryKey.Id, awaitItem().keyId)
+            }
+        }
+        job2.join()
+    }
+
+    @Test
+    fun testDispatchFetchChunksResult_failure_withRecoverData() = runTest {
+        val errorRelay = ErrorRelay.newAnycast(backgroundScope)
+        var dispatchedAction: QueryAction<QueryChunks<String, Int>>? = null
+        val ctx = TestInfiniteQueryContext(
+            dispatch = { action -> dispatchedAction = action },
+            relay = errorRelay::send
+        )
+        val key = TestInfiniteQueryKey(
+            mockFetch = { error("Test") },
+            mockRecoverData = { emptyList() }
+        )
+        val variable = 0
+        val marker = Marker.None
+        var callbackResult: Result<QueryChunks<String, Int>>? = null
+        val callback: QueryCallback<QueryChunks<String, Int>> = { result ->
+            callbackResult = result
+        }
+        val job = launch {
+            ctx.dispatchFetchChunksResult(key, variable, marker, callback)
+        }
+        job.join()
+        assertTrue(dispatchedAction is QueryAction.FetchSuccess)
+        assertTrue(callbackResult?.isSuccess == true)
+
+        val actionData = (dispatchedAction as QueryAction.FetchSuccess).data
+        assertEquals(0, actionData.size)
+    }
+
+    @Test
+    fun testDispatchRevalidateChunksResult_success() = runTest {
+        var dispatchedAction: QueryAction<QueryChunks<String, Int>>? = null
+        val ctx = TestInfiniteQueryContext(
+            dispatch = { action -> dispatchedAction = action }
+        )
+        val key = TestInfiniteQueryKey(mockFetch = { "test-data-$it" })
+        val initialChunks = buildChunks {
+            add(QueryChunk("test-data-0", 0))
+            add(QueryChunk("test-data-1", 1))
+        }
+        val marker = Marker.None
+        var callbackResult: Result<QueryChunks<String, Int>>? = null
+        val callback: QueryCallback<QueryChunks<String, Int>> = { result ->
+            callbackResult = result
+        }
+        val job = launch {
+            ctx.dispatchRevalidateChunksResult(key, initialChunks, marker, callback)
+        }
+        job.join()
+        assertTrue(dispatchedAction is QueryAction.FetchSuccess)
+        assertTrue(callbackResult?.isSuccess == true)
+
+        val actionData = (dispatchedAction as QueryAction.FetchSuccess).data
+        assertEquals(2, actionData.size)
+        assertEquals("test-data-0", actionData[0].data)
+        assertEquals(0, actionData[0].param)
+        assertEquals("test-data-1", actionData[1].data)
+        assertEquals(1, actionData[1].param)
+    }
+
+    @Test
+    fun testDispatchRevalidateChunksResult_failure() = runTest {
+        val errorRelay = ErrorRelay.newAnycast(backgroundScope)
+        var dispatchedAction: QueryAction<QueryChunks<String, Int>>? = null
+        val ctx = TestInfiniteQueryContext(
+            dispatch = { action -> dispatchedAction = action },
+            relay = errorRelay::send
+        )
+        val key = TestInfiniteQueryKey(mockFetch = { error("Test") })
+        val initialChunks = buildChunks {
+            add(QueryChunk("test-data-0", 0))
+            add(QueryChunk("test-data-1", 1))
+        }
+        val marker = Marker.None
+        var callbackResult: Result<QueryChunks<String, Int>>? = null
+        val callback: QueryCallback<QueryChunks<String, Int>> = { result ->
+            callbackResult = result
+        }
+        val job = launch {
+            ctx.dispatchRevalidateChunksResult(key, initialChunks, marker, callback)
+        }
+        job.join()
+        assertTrue(dispatchedAction is QueryAction.FetchFailure)
+        assertTrue(callbackResult?.isFailure == true)
+        val job2 = launch {
+            errorRelay.receiveAsFlow().test {
+                assertEquals(TestInfiniteQueryKey.Id, awaitItem().keyId)
+            }
+        }
+        job2.join()
+    }
+
+    private object TestNonRetry : RetryFn<String> {
+        override suspend fun withRetry(block: suspend () -> String): String = block()
+    }
+
+    private class TestInfiniteQueryKey(
+        private val mockFetch: suspend (Int) -> String = { param ->
+            "test-data-$param"
+        },
+        private val mockLoadMoreParam: (QueryChunks<String, Int>) -> Int? = { chunks ->
+            chunks.lastOrNull()?.param?.plus(1)
+        },
+        private val mockRecoverData: QueryRecoverData<QueryChunks<String, Int>>? = null
+    ) : InfiniteQueryKey<String, Int> by buildInfiniteQueryKey(
+        id = Id,
+        fetch = { mockFetch(it) },
+        initialParam = { 0 },
+        loadMoreParam = mockLoadMoreParam
+    ) {
+        override fun onRecoverData(): QueryRecoverData<QueryChunks<String, Int>>? = mockRecoverData
+
+        object Id : InfiniteQueryId<String, Int>(
+            namespace = "test-infinite-query"
+        )
+    }
+
+    private class TestInfiniteQueryContext(
+        override val state: QueryModel<QueryChunks<String, Int>> = QueryState.initial(),
+        override val dispatch: QueryDispatch<QueryChunks<String, Int>> = {},
+        override val options: QueryOptions = QueryOptions(),
+        override val relay: QueryErrorRelay? = null,
+        override val receiver: QueryReceiver = QueryReceiver {}
+    ) : QueryCommand.Context<QueryChunks<String, Int>>
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/MutationCommandTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/MutationCommandTest.kt
@@ -1,0 +1,171 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import app.cash.turbine.test
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import soil.query.core.Effect
+import soil.query.core.ErrorRelay
+import soil.query.core.Marker
+import soil.query.core.RetryFn
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MutationCommandTest : UnitTest() {
+
+    @Test
+    fun testShouldMutate() {
+        val ctx = TestMutationContext()
+        assertTrue(ctx.shouldMutate(revision = ctx.state.revision))
+    }
+
+    @Test
+    fun testShouldMutate_withOneShotAndMutated() {
+        val ctx = TestMutationContext(
+            options = MutationOptions(isOneShot = true),
+            state = MutationState.success("Test")
+        )
+        assertFalse(ctx.shouldMutate(revision = ctx.state.revision))
+    }
+
+    @Test
+    fun testShouldMutate_withStrictModeAndDifferentRevision() {
+        val ctx = TestMutationContext(
+            options = MutationOptions(isStrictMode = true),
+            state = MutationState.success("Test")
+        )
+        assertFalse(ctx.shouldMutate(ctx.state.revision + "difference"))
+    }
+
+    @Test
+    fun testShouldMutate_withPendingState() {
+        val ctx = TestMutationContext(
+            state = MutationState.pending()
+        )
+        assertFalse(ctx.shouldMutate(ctx.state.revision))
+    }
+
+    @Test
+    fun testMutate_success() = runTest {
+        val ctx = TestMutationContext()
+        val key = TestMutationKey(mockMutate = { "test-data" })
+        val job = launch {
+            val result = ctx.mutate(key, "variable-data", TestNonRetry)
+            assertTrue(result.isSuccess)
+            assertEquals("test-data", result.getOrThrow())
+        }
+        job.join()
+        assertTrue(job.isCompleted)
+    }
+
+    @Test
+    fun testMutate_failure() = runTest {
+        val ctx = TestMutationContext()
+        val key = TestMutationKey(mockMutate = { error("Test") })
+        val job = launch {
+            val result = ctx.mutate(key, "variable-data", TestNonRetry)
+            assertTrue(result.isFailure)
+            assertEquals("Test", result.exceptionOrNull()?.message)
+        }
+        job.join()
+        assertTrue(job.isCompleted)
+    }
+
+    @Test
+    fun testMutate_cancel() = runTest {
+        val ctx = TestMutationContext()
+        val key = TestMutationKey(mockMutate = { throw CancellationException("Test") })
+        val job = launch {
+            ctx.mutate(key, "variable-data", TestNonRetry)
+        }
+        job.join()
+        assertTrue(job.isCancelled)
+    }
+
+    @Test
+    fun testDispatchMutateResult_success() = runTest {
+        var dispatchedAction: MutationAction<String>? = null
+        val ctx = TestMutationContext(
+            dispatch = { action -> dispatchedAction = action }
+        )
+        val key = TestMutationKey(mockMutate = { "test-data" })
+        val marker = Marker.None
+        var callbackResult: Result<String>? = null
+        val callback: MutationCallback<String> = { result ->
+            callbackResult = result
+        }
+        val job = launch {
+            ctx.dispatchMutateResult(key, "variable-data", marker, callback)
+        }
+        job.join()
+        assertTrue(dispatchedAction is MutationAction.MutateSuccess)
+        assertTrue(callbackResult?.isSuccess == true)
+
+        val actionData = (dispatchedAction as MutationAction.MutateSuccess).data
+        assertEquals("test-data", actionData)
+    }
+
+    @Test
+    fun testDispatchMutateResult_failure() = runTest {
+        val errorRelay = ErrorRelay.newAnycast(backgroundScope)
+        var dispatchedAction: MutationAction<String>? = null
+        val ctx = TestMutationContext(
+            dispatch = { action -> dispatchedAction = action },
+            relay = errorRelay::send
+        )
+        val key = TestMutationKey(mockMutate = { error("Test") })
+        val marker = Marker.None
+        var callbackResult: Result<String>? = null
+        val callback: MutationCallback<String> = { result ->
+            callbackResult = result
+        }
+        val job = launch {
+            ctx.dispatchMutateResult(key, "variable-data", marker, callback)
+        }
+        job.join()
+        assertTrue(dispatchedAction is MutationAction.MutateFailure)
+        assertTrue(callbackResult?.isFailure == true)
+        val job2 = launch {
+            errorRelay.receiveAsFlow().test {
+                assertEquals(TestMutationKey.Id, awaitItem().keyId)
+            }
+        }
+        job2.join()
+    }
+
+    private object TestNonRetry : RetryFn<String> {
+        override suspend fun withRetry(block: suspend () -> String): String = block()
+    }
+
+    private class TestMutationKey(
+        private val mockMutate: suspend (String) -> String = { "test-data" },
+        private val mockMutationContentEquals: MutationContentEquals<String>? = null,
+        private val mockMutateEffect: Effect? = null
+    ) : MutationKey<String, String> by buildMutationKey(
+        id = Id,
+        mutate = { mockMutate(it) }
+    ) {
+        override val contentEquals: MutationContentEquals<String>? get() = mockMutationContentEquals
+        override fun onMutateEffect(variable: String, data: String): Effect? = mockMutateEffect
+
+        object Id : MutationId<String, String>(
+            namespace = "test-mutation"
+        )
+    }
+
+    private class TestMutationContext(
+        override val state: MutationModel<String> = MutationState.initial(),
+        override val dispatch: MutationDispatch<String> = {},
+        override val options: MutationOptions = MutationOptions(),
+        override val relay: MutationErrorRelay? = null,
+        override val receiver: MutationReceiver = MutationReceiver {},
+        override val notifier: MutationNotifier = MutationNotifier { Job() }
+    ) : MutationCommand.Context<String>
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/QueryCommandTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/QueryCommandTest.kt
@@ -1,0 +1,249 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import app.cash.turbine.test
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import soil.query.core.ErrorRelay
+import soil.query.core.Marker
+import soil.query.core.Reply
+import soil.query.core.RetryFn
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+
+class QueryCommandTest : UnitTest() {
+
+    @Test
+    fun testShouldFetch_withInitialState() {
+        val ctx = TestQueryContext(
+            state = QueryState.initial()
+        )
+        assertTrue(ctx.shouldFetch())
+    }
+
+    @Test
+    fun testShouldFetch_withRevision() {
+        val ctx = TestQueryContext(
+            state = QueryState.success("test")
+        )
+        assertFalse(ctx.shouldFetch(revision = ctx.state.revision + "dummy"))
+    }
+
+    @Test
+    fun testShouldFetch_withPausedState() {
+        val ctx = TestQueryContext(
+            state = QueryState.test(
+                error = Exception("Test"),
+                status = QueryStatus.Failure,
+                fetchStatus = QueryFetchStatus.Paused(Long.MAX_VALUE)
+            )
+        )
+        assertFalse(ctx.shouldFetch())
+    }
+
+    @Test
+    fun testShouldFetch_withInvalidatedState() {
+        val ctx = TestQueryContext(
+            state = QueryState.test(
+                reply = Reply.some("Test"),
+                status = QueryStatus.Success,
+                staleAt = Long.MAX_VALUE,
+                isInvalidated = true
+            )
+        )
+        assertTrue(ctx.shouldFetch())
+    }
+
+    @Test
+    fun testShouldFetch_withStaledState() {
+        val ctx = TestQueryContext(
+            state = QueryState.test(
+                reply = Reply.some("Test"),
+                status = QueryStatus.Success,
+                staleAt = Long.MIN_VALUE
+            )
+        )
+        assertTrue(ctx.shouldFetch())
+    }
+
+    @Test
+    fun testShouldFetch_withFreshState() {
+        val ctx = TestQueryContext(
+            state = QueryState.test(
+                reply = Reply.some("Test"),
+                status = QueryStatus.Success,
+                staleAt = Long.MAX_VALUE
+            )
+        )
+        assertFalse(ctx.shouldFetch())
+    }
+
+    @Test
+    fun testShouldPause() {
+        val ctx = TestQueryContext()
+        assertNull(ctx.shouldPause(Exception("Test")))
+    }
+
+    @Test
+    fun testShouldPause_withPauseDurationAfter() {
+        val ctx = TestQueryContext(
+            options = QueryOptions(
+                pauseDurationAfter = { 10.minutes }
+            )
+        )
+        val actual = ctx.shouldPause(Exception("Test"))
+        assertNotNull(actual)
+        assertTrue(actual.unpauseAt > 0)
+    }
+
+    @Test
+    fun testFetch_success() = runTest {
+        val ctx = TestQueryContext()
+        val key = TestQueryKey(mockFetch = { "test-data" })
+        val job = launch {
+            val result = ctx.fetch(key, TestNonRetry)
+            assertTrue(result.isSuccess)
+            assertEquals("test-data", result.getOrThrow())
+        }
+        job.join()
+        assertTrue(job.isCompleted)
+    }
+
+    @Test
+    fun testFetch_failure() = runTest {
+        val ctx = TestQueryContext()
+        val key = TestQueryKey(mockFetch = { error("Test") })
+        val job = launch {
+            val result = ctx.fetch(key, TestNonRetry)
+            assertTrue(result.isFailure)
+            assertEquals("Test", result.exceptionOrNull()?.message)
+        }
+        job.join()
+        assertTrue(job.isCompleted)
+    }
+
+    @Test
+    fun testFetch_cancel() = runTest {
+        val ctx = TestQueryContext()
+        val key = TestQueryKey(mockFetch = { throw CancellationException("Test") })
+        val job = launch {
+            ctx.fetch(key, TestNonRetry)
+        }
+        job.join()
+        assertTrue(job.isCancelled)
+    }
+
+    @Test
+    fun testDispatchFetchResult_success() = runTest {
+        var dispatchedAction: QueryAction<String>? = null
+        val ctx = TestQueryContext(
+            dispatch = { action -> dispatchedAction = action }
+        )
+        val key = TestQueryKey(mockFetch = { "test-data" })
+        val marker = Marker.None
+        var callbackResult: Result<String>? = null
+        val callback: QueryCallback<String> = { result ->
+            callbackResult = result
+        }
+        val job = launch {
+            ctx.dispatchFetchResult(key, marker, callback)
+        }
+        job.join()
+        assertTrue(dispatchedAction is QueryAction.FetchSuccess)
+        assertTrue(callbackResult?.isSuccess == true)
+
+        val actionData = (dispatchedAction as QueryAction.FetchSuccess).data
+        assertEquals("test-data", actionData)
+    }
+
+    @Test
+    fun testDispatchFetchResult_failure() = runTest {
+        val errorRelay = ErrorRelay.newAnycast(backgroundScope)
+        var dispatchedAction: QueryAction<String>? = null
+        val ctx = TestQueryContext(
+            dispatch = { action -> dispatchedAction = action },
+            relay = errorRelay::send
+        )
+        val key = TestQueryKey(mockFetch = { error("Test") })
+        val marker = Marker.None
+        var callbackResult: Result<String>? = null
+        val callback: QueryCallback<String> = { result ->
+            callbackResult = result
+        }
+        val job = launch {
+            ctx.dispatchFetchResult(key, marker, callback)
+        }
+        job.join()
+        assertTrue(dispatchedAction is QueryAction.FetchFailure)
+        assertTrue(callbackResult?.isFailure == true)
+        val job2 = launch {
+            errorRelay.receiveAsFlow().test {
+                assertEquals(TestQueryKey.Id, awaitItem().keyId)
+            }
+        }
+        job2.join()
+    }
+
+    @Test
+    fun testDispatchFetchResult_failure_withRecoverData() = runTest {
+        val errorRelay = ErrorRelay.newAnycast(backgroundScope)
+        var dispatchedAction: QueryAction<String>? = null
+        val ctx = TestQueryContext(
+            dispatch = { action -> dispatchedAction = action },
+            relay = errorRelay::send
+        )
+        val key = TestQueryKey(
+            mockFetch = { error("Test") },
+            mockRecoverData = { "recovered-data" }
+        )
+        val marker = Marker.None
+        var callbackResult: Result<String>? = null
+        val callback: QueryCallback<String> = { result ->
+            callbackResult = result
+        }
+        val job = launch {
+            ctx.dispatchFetchResult(key, marker, callback)
+        }
+        job.join()
+        assertTrue(dispatchedAction is QueryAction.FetchSuccess)
+        assertTrue(callbackResult?.isSuccess == true)
+
+        val actionData = (dispatchedAction as QueryAction.FetchSuccess).data
+        assertEquals("recovered-data", actionData)
+    }
+
+    private object TestNonRetry : RetryFn<String> {
+        override suspend fun withRetry(block: suspend () -> String): String = block()
+    }
+
+    private class TestQueryKey(
+        private val mockFetch: suspend () -> String = { "test-data" },
+        private val mockRecoverData: QueryRecoverData<String>? = null
+    ) : QueryKey<String> by buildQueryKey(
+        id = Id,
+        fetch = { mockFetch() }
+    ) {
+        override fun onRecoverData(): QueryRecoverData<String>? = mockRecoverData
+
+        object Id : QueryId<String>(
+            namespace = "test-query"
+        )
+    }
+
+    private class TestQueryContext(
+        override val state: QueryModel<String> = QueryState.initial(),
+        override val dispatch: QueryDispatch<String> = {},
+        override val options: QueryOptions = QueryOptions(),
+        override val relay: QueryErrorRelay? = null,
+        override val receiver: QueryReceiver = QueryReceiver {}
+    ) : QueryCommand.Context<String>
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionCommandTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionCommandTest.kt
@@ -1,0 +1,112 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query
+
+import app.cash.turbine.test
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import soil.query.core.ErrorRelay
+import soil.query.core.Marker
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SubscriptionCommandTest : UnitTest() {
+
+    @Test
+    fun testDispatchResult_success() = runTest {
+        var dispatchedAction: SubscriptionAction<String>? = null
+        val ctx = TestSubscriptionContext(
+            dispatch = { action -> dispatchedAction = action }
+        )
+        val key = TestSubscriptionKey(mockRecoverData = null)
+        val marker = Marker.None
+        val result = Result.success("test-data")
+
+        val job = launch {
+            ctx.dispatchResult(key, result, marker)
+        }
+        job.join()
+        assertTrue(dispatchedAction is SubscriptionAction.ReceiveSuccess)
+
+        val actionData = (dispatchedAction as SubscriptionAction.ReceiveSuccess).data
+        assertEquals("test-data", actionData)
+    }
+
+    @Test
+    fun testDispatchResult_failure() = runTest {
+        val errorRelay = ErrorRelay.newAnycast(backgroundScope)
+        var dispatchedAction: SubscriptionAction<String>? = null
+        val ctx = TestSubscriptionContext(
+            dispatch = { action -> dispatchedAction = action },
+            relay = errorRelay::send
+        )
+        val key = TestSubscriptionKey(mockRecoverData = null)
+        val marker = Marker.None
+        val error = Exception("Test")
+        val result = Result.failure<String>(error)
+
+        val job = launch {
+            ctx.dispatchResult(key, result, marker)
+        }
+        job.join()
+        assertTrue(dispatchedAction is SubscriptionAction.ReceiveFailure)
+        val actionError = (dispatchedAction as SubscriptionAction.ReceiveFailure).error
+        assertEquals("Test", actionError.message)
+
+        val job2 = launch {
+            errorRelay.receiveAsFlow().test {
+                assertEquals(TestSubscriptionKey.Id, awaitItem().keyId)
+            }
+        }
+        job2.join()
+    }
+
+    @Test
+    fun testDispatchResult_failure_withRecoverData() = runTest {
+        val errorRelay = ErrorRelay.newAnycast(backgroundScope)
+        var dispatchedAction: SubscriptionAction<String>? = null
+        val ctx = TestSubscriptionContext(
+            dispatch = { action -> dispatchedAction = action },
+            relay = errorRelay::send
+        )
+        val key = TestSubscriptionKey(mockRecoverData = { "recovered-data" })
+        val marker = Marker.None
+        val error = Exception("Test")
+        val result = Result.failure<String>(error)
+
+        val job = launch {
+            ctx.dispatchResult(key, result, marker)
+        }
+        job.join()
+        assertTrue(dispatchedAction is SubscriptionAction.ReceiveSuccess)
+        val actionData = (dispatchedAction as SubscriptionAction.ReceiveSuccess).data
+        assertEquals("recovered-data", actionData)
+    }
+
+    private class TestSubscriptionKey(
+        private val mockSubscribe: SubscriptionReceiver.() -> Flow<String> = { flow { emit("Test") } },
+        private val mockRecoverData: SubscriptionRecoverData<String>?
+    ) : SubscriptionKey<String> by buildSubscriptionKey(
+        id = Id,
+        subscribe = { mockSubscribe() }
+    ) {
+        override fun onRecoverData(): SubscriptionRecoverData<String>? = mockRecoverData
+
+        object Id : SubscriptionId<String>(
+            namespace = "test-subscription"
+        )
+    }
+
+    private class TestSubscriptionContext(
+        override val state: SubscriptionModel<String> = SubscriptionState.initial(),
+        override val dispatch: SubscriptionDispatch<String> = {},
+        override val options: SubscriptionOptions = SubscriptionOptions(),
+        override val relay: SubscriptionErrorRelay? = null,
+        override val restart: SubscriptionRestart = {}
+    ) : SubscriptionCommand.Context<String>
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for the query, mutation and subscription command functionalities in the soil-query-core module.