### PR TITLE
Improve form change detection for mutable objects

### DIFF
--- a/soil-form/build.gradle.kts
+++ b/soil-form/build.gradle.kts
@@ -45,6 +45,8 @@ kotlin {
 
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.turbine)
             @OptIn(ExperimentalComposeLibrary::class)
             implementation(compose.uiTest)
             implementation(compose.runtime)

--- a/soil-form/src/commonMain/kotlin/soil/form/FieldOptions.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/FieldOptions.kt
@@ -53,7 +53,7 @@ interface FieldOptions {
     companion object Default : FieldOptions {
         override val validationStrategy: FieldValidationStrategy = FieldValidationStrategy()
         override val validationDelayOnMount: Duration = Duration.ZERO
-        override val validationDelayOnChange: Duration = 250.milliseconds
+        override val validationDelayOnChange: Duration = 400.milliseconds
         override val validationDelayOnBlur: Duration = Duration.ZERO
     }
 }
@@ -78,7 +78,7 @@ interface FieldOptions {
  *
  * @param validationStrategy The validation strategy to use. Defaults to the standard strategy.
  * @param validationDelayOnMount The delay before validation on field mount. Defaults to no delay.
- * @param validationDelayOnChange The delay before validation on value change. Defaults to 250ms.
+ * @param validationDelayOnChange The delay before validation on value change. Defaults to 400ms.
  * @param validationDelayOnBlur The delay before validation on field blur. Defaults to no delay.
  * @return A [FieldOptions] instance with the specified configuration.
  */

--- a/soil-form/src/commonMain/kotlin/soil/form/FormOptions.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/FormOptions.kt
@@ -47,7 +47,7 @@ interface FormOptions {
     companion object Default : FormOptions {
         override val preValidation: Boolean = true
         override val preValidationDelayOnMount: Duration = 200.milliseconds
-        override val preValidationDelayOnChange: Duration = 200.milliseconds
+        override val preValidationDelayOnChange: Duration = 400.milliseconds
     }
 }
 
@@ -69,7 +69,7 @@ interface FormOptions {
  *
  * @param preValidation Whether to enable form pre-validation. Defaults to true.
  * @param preValidationDelayOnMount The delay before pre-validation when fields are added or removed. Defaults to 200ms.
- * @param preValidationDelayOnChange The delay before pre-validation on value change. Defaults to 200ms.
+ * @param preValidationDelayOnChange The delay before pre-validation on value change. Defaults to 400ms.
  * @return A [FormOptions] instance with the specified configuration.
  */
 fun FormOptions(

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/FormBinding.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/FormBinding.kt
@@ -4,8 +4,8 @@
 package soil.form.compose
 
 import androidx.compose.runtime.Stable
+import kotlinx.coroutines.flow.SharedFlow
 import soil.form.FieldName
-import soil.form.FieldNames
 import soil.form.annotation.InternalSoilFormApi
 
 /**
@@ -31,6 +31,15 @@ interface FormBinding<T> {
     val policy: FormPolicy
 
     /**
+     * A shared flow of field change notifications.
+     *
+     * This flow emits the names of fields that have changed, allowing dependent fields
+     * to react to changes in other fields. This is particularly useful for cross-field
+     * validation and conditional field behavior.
+     */
+    val fieldChanges: SharedFlow<FieldName>
+
+    /**
      * Gets the metadata for a specific field.
      *
      * @param name The name of the field.
@@ -47,13 +56,12 @@ interface FormBinding<T> {
     operator fun set(name: FieldName, fieldMeta: FieldMetaState)
 
     /**
-     * Registers a field with its validation rule and dependencies.
+     * Registers a field with its validation rule.
      *
      * @param name The name of the field.
-     * @param dependsOn The set of field names this field depends on.
      * @param rule The validation rule for this field.
      */
-    fun register(name: FieldName, dependsOn: FieldNames, rule: FieldRule<T>)
+    fun register(name: FieldName, rule: FieldRule<T>)
 
     /**
      * Unregisters a field from the form.
@@ -72,18 +80,18 @@ interface FormBinding<T> {
     fun validate(value: T, dryRun: Boolean): Boolean
 
     /**
-     * Revalidates fields that depend on the specified field.
-     *
-     * @param name The name of the field whose dependents should be revalidated.
-     */
-    fun revalidateDependents(name: FieldName)
-
-    /**
      * Handles a change to the form data.
      *
      * @param updater A function that updates the form data.
      */
     fun handleChange(updater: T.() -> T)
+
+    /**
+     * Notifies the form that a field's validation target has changed.
+     *
+     * @param name The name of the field that has changed.
+     */
+    suspend fun notifyFieldChange(name: FieldName)
 }
 
 /**

--- a/soil-form/src/commonTest/kotlin/soil/form/compose/FormControllerTest.kt
+++ b/soil-form/src/commonTest/kotlin/soil/form/compose/FormControllerTest.kt
@@ -34,7 +34,7 @@ class FormControllerTest : UnitTest() {
             state = formState,
             onSubmit = { submittedData = it }
         )
-        formController.register("firstName", dependsOn = emptySet()) { _, _ ->
+        formController.register("firstName") { _, _ ->
             false // Simulate validation error
         }
 
@@ -62,7 +62,7 @@ class FormControllerTest : UnitTest() {
             onSubmit = {}
         )
 
-        formController.register("firstName", dependsOn = emptySet()) { _, _ ->
+        formController.register("firstName") { _, _ ->
             false // Simulate validation error
         }
 
@@ -80,14 +80,14 @@ class FormControllerTest : UnitTest() {
         ).binding
 
         var firstNameValidationCount = 0
-        binding.register("firstName", dependsOn = emptySet()) { _, _ ->
+        binding.register("firstName") { _, _ ->
             firstNameValidationCount++
             false // Simulate validation error
         }
         binding["firstName"] = FieldMetaState()
 
         var lastNameValidationCount = 0
-        binding.register("lastName", dependsOn = emptySet()) { _, _ ->
+        binding.register("lastName") { _, _ ->
             lastNameValidationCount++
             false // Simulate validation error
         }
@@ -108,14 +108,14 @@ class FormControllerTest : UnitTest() {
         ).binding
 
         var firstNameValidationCount = 0
-        binding.register("firstName", dependsOn = emptySet()) { _, _ ->
+        binding.register("firstName") { _, _ ->
             firstNameValidationCount++
             false // Simulate validation error
         }
         binding["firstName"] = FieldMetaState()
 
         var lastNameValidationCount = 0
-        binding.register("lastName", dependsOn = emptySet()) { _, _ ->
+        binding.register("lastName") { _, _ ->
             lastNameValidationCount++
             false // Simulate validation error
         }
@@ -139,46 +139,6 @@ class FormControllerTest : UnitTest() {
 
         binding.handleChange { copy(lastName = "Doe") }
         assertEquals("Doe", formState.value.lastName)
-    }
-
-    @OptIn(InternalSoilFormApi::class)
-    @Test
-    fun testRevalidateDependents() {
-        val formState = FormState(value = TestData())
-        val binding = FormController(
-            state = formState,
-            onSubmit = {}
-        ).binding
-
-        var firstNameValidationCount = 0
-        binding.register("firstName", dependsOn = emptySet()) { _, _ ->
-            firstNameValidationCount++
-            true // Simulate validation success
-        }
-        binding["firstName"] = FieldMetaState()
-
-        var lastNameValidationCount = 0
-        binding.register("lastName", dependsOn = setOf("firstName")) { _, _ ->
-            lastNameValidationCount++
-            true // Simulate validation success
-        }
-        binding["lastName"] = FieldMetaState()
-
-        binding.revalidateDependents("firstName")
-        assertEquals(firstNameValidationCount, 0)
-        assertEquals(lastNameValidationCount, 0)
-
-        formState.meta.fields["lastName"]?.isValidated = true
-
-        binding.revalidateDependents("firstName")
-        assertEquals(firstNameValidationCount, 0)
-        assertEquals(lastNameValidationCount, 1)
-
-        binding.unregister("lastName")
-
-        binding.revalidateDependents("firstName")
-        assertEquals(firstNameValidationCount, 0)
-        assertEquals(lastNameValidationCount, 1)
     }
 
     data class TestData(


### PR DESCRIPTION
Improve #184 

Replace snapshotFlow-based change detection with field-level notification system to properly detect changes within mutable objects like TextFieldState.
