### PR TITLE
Refactor Form interface to extend FormData directly

### DIFF
--- a/internal/playground/src/commonMain/kotlin/soil/playground/form/compose/Submit.kt
+++ b/internal/playground/src/commonMain/kotlin/soil/playground/form/compose/Submit.kt
@@ -27,7 +27,7 @@ fun Form<*>.Submit(
     Button(
         onClick = ::handleSubmit,
         modifier = modifier.focusable(interactionSource = btn),
-        enabled = state.meta.canSubmit,
+        enabled = meta.canSubmit,
         interactionSource = btn
     ) {
         Box(contentAlignment = Alignment.Center) {

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/Form.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/Form.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.launch
 import soil.form.FieldName
 import soil.form.FieldNames
 import soil.form.FormData
+import soil.form.FormMeta
 import soil.form.FormOptions
 import soil.form.annotation.InternalSoilFormApi
 
@@ -39,11 +40,7 @@ import soil.form.annotation.InternalSoilFormApi
  * @param T The type of the form data.
  */
 @Stable
-interface Form<T> : HasFormBinding<T> {
-    /**
-     * The current state of the form including data and metadata.
-     */
-    val state: FormData<T>
+interface Form<T> : FormData<T>, HasFormBinding<T> {
 
     /**
      * Handles form submission by validating all fields and calling the submit callback
@@ -169,9 +166,13 @@ internal class FormController<T>(
         }
     }
 
-    // ----- FormBinding ----- //
+    // ----- FormData ----- //
 
     override val value: T get() = state.value
+
+    override val meta: FormMeta = state.meta
+
+    // ----- FormBinding ----- //
 
     override val policy: FormPolicy get() = state.policy
 

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/FormBinding.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/FormBinding.kt
@@ -6,6 +6,7 @@ package soil.form.compose
 import androidx.compose.runtime.Stable
 import kotlinx.coroutines.flow.SharedFlow
 import soil.form.FieldName
+import soil.form.FormData
 import soil.form.annotation.InternalSoilFormApi
 
 /**
@@ -20,10 +21,11 @@ import soil.form.annotation.InternalSoilFormApi
 @InternalSoilFormApi
 @Stable
 interface FormBinding<T> {
+
     /**
-     * The current value of the form data.
+     * The current state of the form including data and metadata.
      */
-    val value: T
+    val state: FormData<T>
 
     /**
      * The form policy that defines validation behavior.

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/FormField.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/FormField.kt
@@ -451,7 +451,7 @@ internal class FormFieldController<T, V, S, U>(
     private val dependsOn: FieldNames
 ) : FormField<U> {
 
-    private val rawValue: V get() = selector(form.value)
+    private val rawValue: V get() = selector(form.state.value)
 
     private val meta: FieldMetaState = form[name] ?: FieldMetaState(
         mode = options.validationStrategy.initial

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/FormWatch.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/FormWatch.kt
@@ -48,6 +48,6 @@ import soil.form.FormData
 fun <T, R> Form<T>.watch(
     calculation: FormData<T>.() -> R,
 ): R {
-    val state = remember { derivedStateOf { state.calculation() } }
+    val state = remember { derivedStateOf { calculation() } }
     return state.value
 }

--- a/soil-form/src/commonTest/kotlin/soil/form/compose/ui/Submit.kt
+++ b/soil-form/src/commonTest/kotlin/soil/form/compose/ui/Submit.kt
@@ -17,7 +17,7 @@ fun Form<*>.Submit(
 ) {
     Button(
         onClick = ::handleSubmit,
-        enabled = state.meta.canSubmit,
+        enabled = meta.canSubmit,
         modifier = modifier.focusable().testTag("submit")
     ) {
         Text("Submit")


### PR DESCRIPTION
Improve #184 

Remove redundant state property from Form interface by making it extend `FormData<T>` directly.
