### PR TITLE
Improve mutable form values like TextFieldState

### DIFF
--- a/soil-form/src/commonMain/kotlin/soil/form/compose/Form.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/Form.kt
@@ -114,7 +114,7 @@ fun <T> rememberForm(
     state: FormState<T>,
     onSubmit: (T) -> Unit
 ): Form<T> {
-    val control = remember(state, state.resetKey) {
+    val control = remember(state, state.meta.key) {
         FormController(state = state, onSubmit = onSubmit)
     }
     if (control.options.preValidation) {
@@ -153,7 +153,7 @@ internal class FormController<T>(
 
     private val fieldChangeEmitter = MutableSharedFlow<FieldName>(extraBufferCapacity = Int.MAX_VALUE)
 
-    val options: FormOptions get() = state.policy.formOptions
+    val options: FormOptions get() = state.meta.policy.formOptions
     val fields: FieldNames get() = rules.keys
 
     fun preValidate(value: T = state.value) {
@@ -174,7 +174,7 @@ internal class FormController<T>(
 
     // ----- FormBinding ----- //
 
-    override val policy: FormPolicy get() = state.policy
+    override val policy: FormPolicy get() = state.meta.policy
 
     override val fieldChanges get() = fieldChangeEmitter.asSharedFlow()
 

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/FormState.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/FormState.kt
@@ -6,6 +6,7 @@ package soil.form.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.autoSaver
@@ -41,7 +42,7 @@ fun <T> rememberFormState(
     saver: Saver<T, Any> = autoSaver(),
     policy: FormPolicy = FormPolicy()
 ): FormState<T> {
-    return rememberSaveable(saver = FormState.Saver(formSaver = saver, formPolicy = policy)) {
+    return rememberSaveable(saver = FormState.Saver(valueSaver = saver, policy = policy)) {
         FormState(value = initialValue, policy = policy)
     }
 }
@@ -64,11 +65,9 @@ fun <T> rememberFormState(
  * @param T The type of the form data.
  */
 @Stable
-class FormState<T> internal constructor(
+class FormState<T>(
     value: T,
     override val meta: FormMetaState,
-    resetKey: Int,
-    val policy: FormPolicy
 ) : FormData<T> {
 
     /**
@@ -79,15 +78,10 @@ class FormState<T> internal constructor(
      */
     constructor(value: T, policy: FormPolicy = FormPolicy()) : this(
         value = value,
-        meta = FormMetaState(canSubmit = !policy.formOptions.preValidation),
-        resetKey = 0,
-        policy = policy
+        meta = FormMetaState(policy)
     )
 
     override var value: T by mutableStateOf(value)
-
-    internal var resetKey: Int by mutableStateOf(resetKey)
-        private set
 
     /**
      * Resets the form to a new value and clears all field metadata.
@@ -103,13 +97,8 @@ class FormState<T> internal constructor(
      *
      * @param newValue The new value to reset the form to.
      */
-    fun reset(newValue: T) {
-        Snapshot.withMutableSnapshot {
-            value = newValue
-            meta.fields.clear()
-            meta.canSubmit = !policy.formOptions.preValidation
-            resetKey += 1
-        }
+    inline fun reset(newValue: T) {
+        meta.reset { value = newValue }
     }
 
     /**
@@ -129,48 +118,94 @@ class FormState<T> internal constructor(
      *
      * @param pairs Pairs of field names and their corresponding errors.
      */
-    fun setError(vararg pairs: Pair<FieldName, FieldError>) {
-        Snapshot.withMutableSnapshot {
-            pairs.forEach { (fieldName, fieldError) ->
-                meta.fields[fieldName]?.let { fieldMeta ->
-                    fieldMeta.error = fieldError + fieldMeta.error
-                }
-            }
-        }
+    inline fun setError(vararg pairs: Pair<FieldName, FieldError>) {
+        meta.setError(*pairs)
     }
 
     override fun toString(): String {
-        return "FormState(value=$value, meta=$meta, resetKey=$resetKey, policy=$policy)"
+        return "FormState(value=$value, meta=$meta)"
     }
 
     companion object {
-        fun <T> Saver(formSaver: Saver<T, Any>, formPolicy: FormPolicy) = Saver<FormState<T>, Any>(
+        fun <T> Saver(valueSaver: Saver<T, Any>, policy: FormPolicy) = Saver<FormState<T>, Any>(
             save = { value ->
                 listOf(
-                    with(formSaver) {
+                    with(valueSaver) {
                         save(value.value)
                     },
-                    with(FormMetaState.Saver()) {
+                    with(FormMetaState.Saver(policy)) {
                         save(value.meta)
-                    },
-                    value.resetKey
+                    }
                 )
             },
             restore = {
-                val (value, meta, resetKey) = it as List<*>
+                val value = it as List<*>
                 FormState(
-                    value = with(formSaver) {
+                    value = with(valueSaver) {
                         @Suppress("UNCHECKED_CAST")
-                        restore(checkNotNull(value)) as T
+                        restore(checkNotNull(value[0])) as T
                     },
-                    meta = with(FormMetaState.Saver()) {
-                        restore(checkNotNull(meta)) as FormMetaState
-                    },
-                    resetKey = resetKey as Int,
-                    policy = formPolicy
+                    meta = with(FormMetaState.Saver(policy)) {
+                        restore(checkNotNull(value[1])) as FormMetaState
+                    }
                 )
             }
         )
+    }
+}
+
+/**
+ * Remembers form metadata state with automatic state restoration.
+ *
+ * This function is specifically designed for scenarios where your form values contain
+ * mutable data types (like `TextFieldState`) that would require custom Saver implementations
+ * when using [rememberFormState]. Instead of implementing complex Savers, you can manage
+ * field state restoration manually (e.g., with `rememberTextFieldState`) and use this
+ * function to handle only the form metadata restoration.
+ *
+ * **When to use this function:**
+ * - Your form contains mutable data types like `TextFieldState`, `MutableState`, etc.
+ * - You want to avoid implementing custom Saver logic for complex form data
+ * - You prefer to manage individual field state restoration manually
+ *
+ * **When NOT to use this function:**
+ * - Your form uses immutable data classes - use [rememberFormState] instead
+ * - You want automatic restoration of both form data and metadata together
+ *
+ * Usage pattern:
+ * ```kotlin
+ * @Composable
+ * fun MyForm() {
+ *     // Manage field state restoration manually
+ *     val nameState = rememberTextFieldState()
+ *     val emailState = rememberTextFieldState()
+ *
+ *     // Use rememberFormMetaState for metadata only
+ *     val formMeta = rememberFormMetaState(
+ *         policy = FormPolicy()
+ *     )
+ *
+ *     // Create FormState with remember (no custom Saver needed)
+ *     val formState = remember(formMeta.key) {
+ *         FormState(
+ *             value = FormData(name = nameState, email = emailState),
+ *             meta = formMeta
+ *         )
+ *     }
+ * }
+ * ```
+ *
+ * @param policy The form policy that defines validation behavior and form options.
+ * @return The remembered [FormMetaState] with automatic state restoration.
+ *
+ * @see rememberFormState For immutable form data that can use automatic Savers.
+ */
+@Composable
+fun rememberFormMetaState(
+    policy: FormPolicy = FormPolicy()
+): FormMetaState {
+    return rememberSaveable(saver = FormMetaState.Saver(policy = policy)) {
+        FormMetaState(policy = policy)
     }
 }
 
@@ -180,23 +215,120 @@ class FormState<T> internal constructor(
  * This class manages form-wide metadata including field states and submission readiness.
  * It provides mutable access to form metadata for internal form management operations.
  */
+@Stable
 class FormMetaState internal constructor(
-    fields: Map<FieldName, FieldMetaState> = emptyMap(),
-    canSubmit: Boolean = false
+    val policy: FormPolicy,
+    fields: Map<FieldName, FieldMetaState>,
+    canSubmit: Boolean,
+    resetCount: Int
 ) : FormMeta {
+
+    constructor(policy: FormPolicy = FormPolicy()) : this(
+        policy = policy,
+        fields = emptyMap(),
+        canSubmit = !policy.formOptions.preValidation,
+        resetCount = 0
+    )
 
     override val fields: MutableMap<FieldName, FieldMetaState> =
         mutableMapOf(*fields.map { (k, v) -> k to v }.toTypedArray())
 
     override var canSubmit: Boolean by mutableStateOf(canSubmit)
 
+    private var resetCount: Int by mutableIntStateOf(resetCount)
+
+    internal val key: Int get() = resetCount
+
+    /**
+     * Resets the form metadata and executes a custom reset block for synchronization.
+     *
+     * This function is specifically designed for scenarios where you manage mutable form values
+     * manually (like `TextFieldState`, `MutableState`, etc.) and need to synchronize their reset
+     * operations with the form metadata reset. The provided block allows you to reset your
+     * manually managed mutable values at the same time as the form metadata.
+     *
+     * **Use Case:**
+     * When using [rememberFormMetaState] with manually managed field states, you need a way to
+     * reset both the form metadata and your custom field states simultaneously. This function
+     * provides that synchronization mechanism.
+     *
+     * **What this function does:**
+     * 1. Executes the provided block (where you reset your mutable values)
+     * 2. Clears all field metadata (errors, dirty flags, touched flags, validation state)
+     * 3. Resets the form submission state based on pre-validation policy
+     * 4. Increments the reset counter (which updates the `key` property)
+     *
+     * Usage pattern:
+     * ```kotlin
+     * @Composable
+     * fun MyForm() {
+     *     val nameState = rememberTextFieldState()
+     *     val emailState = rememberTextFieldState()
+     *     val formMeta = rememberFormMetaState()
+     *
+     *     val formState = remember(formMeta.key) {
+     *         FormState(
+     *             value = FormData(name = nameState, email = emailState),
+     *             meta = formMeta
+     *         )
+     *     }
+     *
+     *     // Reset both form metadata and field states synchronously
+     *     fun resetForm() {
+     *         formMeta.reset {
+     *             nameState.clearText()
+     *             emailState.clearText()
+     *         }
+     *     }
+     * }
+     * ```
+     *
+     * @param block A lambda function where you should reset your manually managed mutable values.
+     *              This block is executed within a Compose snapshot to ensure atomic updates.
+     */
+    fun reset(block: () -> Unit) {
+        Snapshot.withMutableSnapshot {
+            block()
+            fields.clear()
+            canSubmit = !policy.formOptions.preValidation
+            resetCount += 1
+        }
+    }
+
+    /**
+     * Sets validation errors for specific fields.
+     *
+     * This function allows you to programmatically set validation errors for
+     * specific fields, typically used for server-side validation errors or
+     * custom validation scenarios. Errors are combined with existing field errors.
+     *
+     * Usage:
+     * ```kotlin
+     * formMetaState.setError(
+     *     "email" to FieldError("Email already exists"),
+     *     "username" to FieldError("Username is taken")
+     * )
+     * ```
+     *
+     * @param pairs Pairs of field names and their corresponding errors.
+     */
+    fun setError(vararg pairs: Pair<FieldName, FieldError>) {
+        Snapshot.withMutableSnapshot {
+            pairs.forEach { (fieldName, fieldError) ->
+                fields[fieldName]?.let { fieldMeta ->
+                    fieldMeta.error = fieldError + fieldMeta.error
+                }
+            }
+        }
+    }
+
     override fun toString(): String {
-        return "FormMetaState(fields=$fields, canSubmit=$canSubmit)"
+        return "FormMetaState(fields=$fields, canSubmit=$canSubmit, key=$key)"
     }
 
     companion object {
         @Suppress("UNCHECKED_CAST")
-        fun Saver() = Saver<FormMetaState, Any>(
+        fun Saver(policy: FormPolicy) = Saver<FormMetaState, Any>(
             save = { value ->
                 listOf(
                     value.fields.mapValues {
@@ -204,18 +336,21 @@ class FormMetaState internal constructor(
                             save(it.value)
                         }
                     },
-                    value.canSubmit
+                    value.canSubmit,
+                    value.resetCount
                 )
             },
             restore = {
                 val value = it as List<*>
                 FormMetaState(
+                    policy = policy,
                     fields = with(FieldMetaState.Saver()) {
                         (value[0] as Map<FieldName, Any>).mapValues { (_, v) ->
                             restore(v) as FieldMetaState
                         }
                     },
                     canSubmit = value[1] as Boolean,
+                    resetCount = value[2] as Int
                 )
             }
         )
@@ -229,6 +364,7 @@ class FormMetaState internal constructor(
  * validation mode, and user interaction state. It provides mutable access
  * to field metadata for internal form field management operations.
  */
+@Stable
 class FieldMetaState internal constructor(
     error: FieldError = noFieldError,
     mode: FieldValidationMode = FieldValidationMode.Blur,


### PR DESCRIPTION
Improve #184 

This change makes it easier to work with mutable data types in forms without requiring complex custom Saver implementations.

```kotlin
// Manage field state restoration manually
val nameState = rememberTextFieldState()
val emailState = rememberTextFieldState()

// Use rememberFormMetaState for metadata only
val formMeta = rememberFormMetaState(
    policy = FormPolicy()
)

// Create FormState with remember (no custom Saver needed)
val formState = remember(formMeta.key) {
    FormState(
        value = FormData(name = nameState, email = emailState),
        meta = formMeta
    )
}
```