### PR TITLE
Change FormField.trigger() to return boolean

### DIFF
--- a/soil-form/src/commonMain/kotlin/soil/form/compose/FormField.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/FormField.kt
@@ -126,8 +126,9 @@ interface FormField<V> {
      * Manually triggers validation for this field with the specified mode.
      *
      * @param mode The validation mode to trigger.
+     * @return True if validation was triggered, false if it was not needed.
      */
-    fun trigger(mode: FieldValidationMode)
+    fun trigger(mode: FieldValidationMode): Boolean
 }
 
 /**
@@ -520,9 +521,12 @@ internal class FormFieldController<T, V, S, U>(
         }
     }
 
-    override fun trigger(mode: FieldValidationMode) {
-        if (shouldTrigger(mode)) {
+    override fun trigger(mode: FieldValidationMode): Boolean {
+        return if (shouldTrigger(mode)) {
             validate(rawValue)
+            true
+        } else {
+            false
         }
     }
 


### PR DESCRIPTION
Improve #184 

Update `FormField.trigger()` method to return true when validation is performed and false when validation is skipped, providing better feedback to callers about whether the validation was actually executed.
