### PR TITLE
Add Compose UI tooling preview dependency

### DIFF
--- a/internal/playground/build.gradle.kts
+++ b/internal/playground/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
             implementation(compose.foundation)
             implementation(compose.material3)
             implementation(compose.ui)
+            implementation(compose.components.uiToolingPreview)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.ktor.core)
@@ -59,6 +60,7 @@ kotlin {
         }
 
         androidMain.dependencies {
+            implementation(libs.compose.ui.tooling.preview)
             implementation(libs.androidx.activity.compose)
             implementation(libs.kotlinx.coroutines.android)
             implementation(libs.ktor.client.okhttp)


### PR DESCRIPTION
Fixed a build failure in the internal module caused by missing Compose UI preview tooling dependencies when running `make test`.

```
> Task :internal:playground:compileReleaseKotlinAndroid FAILED
e: ../internal/playground/src/androidMain/kotlin/soil/playground/form/compose/InputField.android.kt:5:28 Unresolved reference 'tooling'.
e: ../internal/playground/src/androidMain/kotlin/soil/playground/form/compose/InputField.android.kt:11:2 Unresolved reference 'Preview'.
e: ../internal/playground/src/androidMain/kotlin/soil/playground/form/compose/RadioField.android.kt:7:28 Unresolved reference 'tooling'.
e: ../internal/playground/src/androidMain/kotlin/soil/playground/form/compose/RadioField.android.kt:14:2 Unresolved reference 'Preview'.
e: ../internal/playground/src/androidMain/kotlin/soil/playground/form/compose/SelectField.android.kt:5:28 Unresolved reference 'tooling'.
e: ../internal/playground/src/androidMain/kotlin/soil/playground/form/compose/SelectField.android.kt:12:2 Unresolved reference 'Preview'.
```