### PR TITLE
Remove deprecated soil-query-compose-runtime module

### DIFF
--- a/buildSrc/src/main/kotlin/BuildModule.kt
+++ b/buildSrc/src/main/kotlin/BuildModule.kt
@@ -4,7 +4,6 @@ val publicModules = setOf(
     ":soil-experimental:soil-reacty",
     ":soil-query-core",
     ":soil-query-compose",
-    ":soil-query-compose-runtime",
     ":soil-query-receivers:ktor",
     ":soil-query-test",
     ":soil-form",

--- a/internal/playground/build.gradle.kts
+++ b/internal/playground/build.gradle.kts
@@ -43,7 +43,6 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.soilQueryCore)
             implementation(projects.soilQueryCompose)
-            implementation(projects.soilQueryComposeRuntime)
             implementation(projects.soilQueryReceivers.ktor)
             implementation(projects.soilForm)
             implementation(projects.soilSpace)

--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -63,10 +63,11 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.soilQueryCore)
             implementation(projects.soilQueryCompose)
-            implementation(projects.soilQueryComposeRuntime)
             implementation(projects.soilQueryReceivers.ktor)
             implementation(projects.soilForm)
             implementation(projects.soilSpace)
+            implementation(projects.soilExperimental.soilReacty)
+            implementation(projects.soilExperimental.soilLazyload)
             implementation(projects.internal.playground)
             implementation(compose.runtime)
             implementation(compose.foundation)

--- a/sample/composeApp/src/commonMain/kotlin/soil/kmp/screen/HelloQueryDetailScreen.kt
+++ b/sample/composeApp/src/commonMain/kotlin/soil/kmp/screen/HelloQueryDetailScreen.kt
@@ -21,9 +21,9 @@ import soil.playground.query.compose.rememberGetUserQuery
 import soil.playground.query.data.Post
 import soil.playground.query.data.Posts
 import soil.playground.query.data.User
-import soil.query.compose.runtime.Await
-import soil.query.compose.runtime.ErrorBoundary
-import soil.query.compose.runtime.Suspense
+import soil.plant.compose.reacty.Await
+import soil.plant.compose.reacty.ErrorBoundary
+import soil.plant.compose.reacty.Suspense
 import soil.query.compose.util.rememberQueriesErrorReset
 import soil.query.core.getOrElse
 

--- a/sample/composeApp/src/commonMain/kotlin/soil/kmp/screen/HelloQueryScreen.kt
+++ b/sample/composeApp/src/commonMain/kotlin/soil/kmp/screen/HelloQueryScreen.kt
@@ -21,10 +21,10 @@ import soil.playground.query.data.PageParam
 import soil.playground.query.data.Posts
 import soil.playground.router.NavLink
 import soil.playground.style.withAppTheme
-import soil.query.compose.runtime.Await
-import soil.query.compose.runtime.ErrorBoundary
-import soil.query.compose.runtime.LazyLoadEffect
-import soil.query.compose.runtime.Suspense
+import soil.plant.compose.reacty.Await
+import soil.plant.compose.reacty.ErrorBoundary
+import soil.plant.compose.lazy.LazyLoad
+import soil.plant.compose.reacty.Suspense
 import soil.query.compose.util.rememberQueriesErrorReset
 
 @Composable
@@ -89,11 +89,10 @@ private fun HelloQueryContent(
                 }
             }
         }
-        LazyLoadEffect(
+        LazyLoad(
             state = lazyListState,
             loadMore = state.loadMore,
-            loadMoreParam = state.loadMoreParam,
-            totalItemsCount = state.posts.size
+            loadMoreParam = state.loadMoreParam
         )
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,7 +40,6 @@ include(
     ":soil-experimental:soil-reacty",
     ":soil-query-core",
     ":soil-query-compose",
-    ":soil-query-compose-runtime",
     ":soil-query-receivers:ktor",
     ":soil-query-test",
     ":soil-form",


### PR DESCRIPTION
This module has been deprecated for a reasonable period and is now being removed. All references have been migrated to the appropriate replacement modules:
- soil.query.compose.runtime.* → soil.plant.compose.reacty.*
- LazyLoadEffect → LazyLoad from soil.plant.compose.lazy

refs: https://github.com/soil-kt/soil/pull/170 , https://github.com/soil-kt/soil/pull/167