### PR TITLE
Add onPreloadData function to Query and Subscription keys

### DIFF
--- a/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/InfiniteQueryKey.kt
@@ -73,6 +73,19 @@ interface InfiniteQueryKey<T, S> {
     fun onConfigureOptions(): QueryOptionsOverride? = null
 
     /**
+     * Function to provide initial data before making a fetch request.
+     *
+     * This is primarily intended for reading from locally cached data stored on the device.
+     * Temporary data storage can be useful as a fallback when API response is slow or when the device is offline.
+     * Any exceptions thrown by this function will be silently ignored.
+     *
+     * **NOTE:** This function is called only once when there is no cache for this key.
+     *
+     * @see QueryKey.onPreloadData
+     */
+    fun onPreloadData(): QueryPreloadData<QueryChunks<T, S>>? = null
+
+    /**
      * Function to convert specific exceptions as data.
      *
      * Depending on the type of exception that occurred during data retrieval, it is possible to recover it as normal data.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryClient.kt
@@ -78,6 +78,7 @@ interface QueryReadonlyClient {
 }
 
 typealias QueryInitialData<T> = QueryReadonlyClient.() -> T?
+typealias QueryPreloadData<T> = suspend QueryReceiver.() -> T?
 typealias QueryContentEquals<T> = (oldData: T, newData: T) -> Boolean
 typealias QueryContentCacheable<T> = (currentData: T) -> Boolean
 typealias QueryRecoverData<T> = (error: Throwable) -> T

--- a/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/QueryKey.kt
@@ -81,6 +81,26 @@ interface QueryKey<T> {
     fun onInitialData(): QueryInitialData<T>? = null
 
     /**
+     * Function to provide initial data before making a fetch request.
+     *
+     * This is primarily intended for reading from locally cached data stored on the device.
+     * Temporary data storage can be useful as a fallback when API response is slow or when the device is offline.
+     * Any exceptions thrown by this function will be silently ignored.
+     *
+     * **NOTE:** This function is called only once when there is no cache for this key.
+     *
+     * ```kotlin
+     * override fun onPreloadData(): QueryPreloadData<User> = {
+     *     // Load from local cache/database
+     *     localCache.getUser(userId)
+     * }
+     * ```
+     *
+     * @see QueryPreloadData
+     */
+    fun onPreloadData(): QueryPreloadData<T>? = null
+
+    /**
      * Function to convert specific exceptions as data.
      *
      * Depending on the type of exception that occurred during data retrieval, it is possible to recover it as normal data.

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionClient.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionClient.kt
@@ -42,6 +42,7 @@ interface SubscriptionReadonlyClient {
 }
 
 typealias SubscriptionInitialData<T> = SubscriptionReadonlyClient.() -> T?
+typealias SubscriptionPreloadData<T> = suspend SubscriptionReceiver.() -> T?
 typealias SubscriptionContentEquals<T> = (oldData: T, newData: T) -> Boolean
 typealias SubscriptionContentCacheable<T> = (currentData: T) -> Boolean
 typealias SubscriptionRecoverData<T> = (error: Throwable) -> T

--- a/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionKey.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/SubscriptionKey.kt
@@ -81,6 +81,26 @@ interface SubscriptionKey<T> {
     fun onInitialData(): SubscriptionInitialData<T>? = null
 
     /**
+     * Function to provide initial data before making a subscription.
+     *
+     * This is primarily intended for reading from locally cached data stored on the device.
+     * Temporary data storage can be useful as a fallback when API response is slow or when the device is offline.
+     * Any exceptions thrown by this function will be silently ignored.
+     *
+     * **NOTE:** This function is called only once when there is no cache for this key.
+     *
+     * ```kotlin
+     * override fun onPreloadData(): SubscriptionPreloadData<User> = {
+     *     // Load from local cache/database
+     *     localCache.getUser(userId)
+     * }
+     * ```
+     *
+     * @see SubscriptionPreloadData
+     */
+    fun onPreloadData(): SubscriptionPreloadData<T>? = null
+
+    /**
      * Function to recover data from the error.
      *
      * You can recover data from the error instead of the error state.

--- a/soil-query-core/src/commonTest/kotlin/soil/query/QueryKeyTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/QueryKeyTest.kt
@@ -59,6 +59,14 @@ class QueryKeyTest : UnitTest() {
     }
 
     @Test
+    fun testPreloadData() = runTest {
+        val testKey = TestQueryKey()
+        val testClient = SwrCache(backgroundScope)
+        val actual = testKey.onPreloadData().invoke(testClient.queryReceiver)
+        assertEquals("Preloaded", actual)
+    }
+
+    @Test
     fun testRecoverData() = runTest {
         val testKey = TestQueryKey()
         assertEquals(testKey.onRecoverData().invoke(RuntimeException()), "Recovered")
@@ -87,6 +95,10 @@ class QueryKeyTest : UnitTest() {
 
         override fun onInitialData(): QueryInitialData<String> = {
             getQueryData(QueryId("sample"))
+        }
+
+        override fun onPreloadData(): QueryPreloadData<String> = {
+            "Preloaded"
         }
 
         override fun onRecoverData(): QueryRecoverData<String> = { err ->

--- a/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionKeyTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/SubscriptionKeyTest.kt
@@ -67,6 +67,14 @@ class SubscriptionKeyTest : UnitTest() {
     }
 
     @Test
+    fun testPreloadData() = runTest {
+        val testKey = TestSubscriptionKey()
+        val testClient = SwrCachePlus(backgroundScope)
+        val actual = testKey.onPreloadData().invoke(testClient.subscriptionReceiver)
+        assertEquals("Preloaded", actual)
+    }
+
+    @Test
     fun testRecoverData() = runTest {
         val testKey = TestSubscriptionKey()
         assertEquals(testKey.onRecoverData().invoke(RuntimeException()), "Recovered")
@@ -99,6 +107,10 @@ class SubscriptionKeyTest : UnitTest() {
 
         override fun onInitialData(): SubscriptionInitialData<String> = {
             getSubscriptionData(SubscriptionId("sample"))
+        }
+
+        override fun onPreloadData(): SubscriptionPreloadData<String> = {
+            "Preloaded"
         }
 
         override fun onRecoverData(): SubscriptionRecoverData<String> = { err ->


### PR DESCRIPTION
This new feature allows loading initial data from local storage before making network requests. 
The onPreloadData function is called only once when there is no cache for the key.

```kotlin
override fun onPreloadData(): QueryPreloadData<User> = {
    // Load from local cache/database
    localStorage.getUser(userId)
}
```