### PR TITLE
Use spotlessCheck

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -17,9 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
-    permissions:
-      contents: write
-
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -34,13 +31,8 @@ jobs:
           distribution: 'zulu'
           java-version: 17
 
-      - name: Apply spotless rules
-        run: ./gradlew spotlessApply
-
-      - name: Commit newly formatted files
-        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
-        with:
-          file_pattern: "**/*.kt **/*.gradle.kts **/*.yml"
+      - name: Check spotless rules
+        run: ./gradlew spotlessCheck
 
   build:
     strategy:


### PR DESCRIPTION
Refactor CI workflow to remove automatic formatting and commit steps, retaining only the spotless check.

It looks like there was a regression in v6 of [git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action/issues/383).

ref: https://github.com/soil-kt/soil/actions/runs/16868507558/job/47778981386