### PR TITLE
Use outputModuleName in wasmJs configuration

### DIFF
--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        moduleName = "composeApp"
+        outputModuleName = "composeApp"
         browser {
             commonWebpackConfig {
                 outputFileName = "composeApp.js"


### PR DESCRIPTION
moduleName is deprecated, so we replaced it.
