### PR TITLE
Extract BasicFormField interface and remove isDirty property

### DIFF
--- a/soil-form/src/commonMain/kotlin/soil/form/FormData.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/FormData.kt
@@ -64,11 +64,6 @@ interface FieldMeta {
     val mode: FieldValidationMode
 
     /**
-     * Whether the field value has been modified from its initial value.
-     */
-    val isDirty: Boolean
-
-    /**
      * Whether the field has been touched (focused and then blurred) by the user.
      */
     val isTouched: Boolean

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/BasicFormField.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/BasicFormField.kt
@@ -1,0 +1,70 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.form.compose
+
+import soil.form.FieldError
+import soil.form.FieldName
+import soil.form.FieldValidationMode
+import soil.form.noFieldError
+
+interface BasicFormField {
+    /**
+     * The unique name identifier for this field within the form.
+     */
+    val name: FieldName
+
+    /**
+     * The current validation error for this field, if any.
+     */
+    val error: FieldError
+
+    /**
+     * Whether the field has been touched (focused and then blurred) by the user.
+     */
+    val isTouched: Boolean
+
+    /**
+     * Whether the field currently has focus.
+     */
+    val isFocused: Boolean
+
+    /**
+     * Whether the field is enabled for user interaction.
+     */
+    val isEnabled: Boolean
+
+    /**
+     * Marks the field as focused.
+     */
+    fun onFocus()
+
+    /**
+     * Marks the field as blurred (not focused) and touched.
+     */
+    fun onBlur()
+
+    /**
+     * Handles focus state changes by calling onFocus() or onBlur() as appropriate.
+     *
+     * @param hasFocus Whether the field currently has focus.
+     */
+    fun handleFocus(hasFocus: Boolean)
+
+    /**
+     * Manually triggers validation for this field with the specified mode.
+     *
+     * @param mode The validation mode to trigger.
+     * @return True if validation was triggered, false if it was not needed.
+     */
+    fun trigger(mode: FieldValidationMode): Boolean
+}
+
+/**
+ * Whether the field currently has any validation errors.
+ *
+ * This is a convenience property that returns true when the field has validation
+ * error messages, false otherwise. It's commonly used to conditionally apply
+ * error styling to UI components.
+ */
+val BasicFormField.hasError: Boolean get() = error != noFieldError

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/FormField.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/FormField.kt
@@ -62,11 +62,7 @@ import soil.form.noFieldError
  * @param V The type of the field value.
  */
 @Stable
-interface FormField<V> {
-    /**
-     * The unique name identifier for this field within the form.
-     */
-    val name: FieldName
+interface FormField<V> : BasicFormField {
 
     /**
      * The current value of the field.
@@ -74,71 +70,12 @@ interface FormField<V> {
     val value: V
 
     /**
-     * The current validation error for this field, if any.
-     */
-    val error: FieldError
-
-    /**
-     * Whether the field value has been modified from its initial value.
-     */
-    val isDirty: Boolean
-
-    /**
-     * Whether the field has been touched (focused and then blurred) by the user.
-     */
-    val isTouched: Boolean
-
-    /**
-     * Whether the field currently has focus.
-     */
-    val isFocused: Boolean
-
-    /**
-     * Whether the field is enabled for user interaction.
-     */
-    val isEnabled: Boolean
-
-    /**
      * Updates the field value and triggers validation if configured.
      *
      * @param value The new value for the field.
      */
     fun onValueChange(value: V)
-
-    /**
-     * Marks the field as focused.
-     */
-    fun onFocus()
-
-    /**
-     * Marks the field as blurred (not focused) and touched.
-     */
-    fun onBlur()
-
-    /**
-     * Handles focus state changes by calling onFocus() or onBlur() as appropriate.
-     *
-     * @param hasFocus Whether the field currently has focus.
-     */
-    fun handleFocus(hasFocus: Boolean)
-
-    /**
-     * Manually triggers validation for this field with the specified mode.
-     *
-     * @param mode The validation mode to trigger.
-     * @return True if validation was triggered, false if it was not needed.
-     */
-    fun trigger(mode: FieldValidationMode): Boolean
 }
-
-/**
- * Whether the field currently has any validation errors.
- *
- * This is a convenience property that returns true when the field has validation
- * error messages, false otherwise. It's commonly used to conditionally apply
- * error styling to UI components.
- */
-val FormField<*>.hasError: Boolean get() = error != noFieldError
 
 /**
  * Creates a form field with validation and state management.
@@ -472,12 +409,6 @@ internal class FormFieldController<T, V, S, U>(
             meta.error = value
         }
 
-    override var isDirty: Boolean
-        get() = meta.isDirty
-        set(value) {
-            meta.isDirty = value
-        }
-
     override var isTouched: Boolean
         get() = meta.isTouched
         set(value) {
@@ -501,7 +432,6 @@ internal class FormFieldController<T, V, S, U>(
 
     override fun onValueChange(value: U) {
         form.handleChange { updater(adapter.fromInput(value, rawValue)) }
-        isDirty = true
     }
 
     override fun onFocus() {

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/FormState.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/FormState.kt
@@ -368,19 +368,17 @@ class FormMetaState internal constructor(
 class FieldMetaState internal constructor(
     error: FieldError = noFieldError,
     mode: FieldValidationMode = FieldValidationMode.Blur,
-    isDirty: Boolean = false,
     isTouched: Boolean = false,
     isValidated: Boolean = false
 ) : FieldMeta {
 
     override var error: FieldError by mutableStateOf(error)
     override var mode: FieldValidationMode by mutableStateOf(mode)
-    override var isDirty: Boolean by mutableStateOf(isDirty)
     override var isTouched: Boolean by mutableStateOf(isTouched)
     override var isValidated: Boolean by mutableStateOf(isValidated)
 
     override fun toString(): String {
-        return "FieldMetaState(error=$error, mode=$mode, isDirty=$isDirty, isTouched=$isTouched, isValidated=$isValidated)"
+        return "FieldMetaState(error=$error, mode=$mode, isTouched=$isTouched, isValidated=$isValidated)"
     }
 
     companion object {
@@ -390,7 +388,6 @@ class FieldMetaState internal constructor(
                 listOf(
                     value.error.messages,
                     value.mode,
-                    value.isDirty,
                     value.isTouched,
                     value.isValidated
                 )
@@ -400,9 +397,8 @@ class FieldMetaState internal constructor(
                 FieldMetaState(
                     error = FieldError(value[0] as List<String>),
                     mode = value[1] as FieldValidationMode,
-                    isDirty = value[2] as Boolean,
-                    isTouched = value[3] as Boolean,
-                    isValidated = value[4] as Boolean
+                    isTouched = value[2] as Boolean,
+                    isValidated = value[3] as Boolean
                 )
             }
         )

--- a/soil-form/src/commonTest/kotlin/soil/form/compose/FormFieldControllerTest.kt
+++ b/soil-form/src/commonTest/kotlin/soil/form/compose/FormFieldControllerTest.kt
@@ -45,7 +45,6 @@ class FormFieldControllerTest : UnitTest() {
         assertEquals("", controller.value)
         assertEquals(noFieldError, controller.error)
         assertFalse(controller.hasError)
-        assertFalse(controller.isDirty)
         assertFalse(controller.isTouched)
         assertFalse(controller.isFocused)
         assertTrue(controller.isEnabled)
@@ -74,7 +73,6 @@ class FormFieldControllerTest : UnitTest() {
 
         assertEquals("John", formState.value.name)
         assertEquals("John", controller.value)
-        assertTrue(controller.isDirty)
     }
 
     @Test
@@ -100,7 +98,6 @@ class FormFieldControllerTest : UnitTest() {
 
         assertEquals(25, formState.value.age)
         assertEquals("25", controller.value)
-        assertTrue(controller.isDirty)
     }
 
     @Test

--- a/soil-form/src/commonTest/kotlin/soil/form/compose/FormStateTest.kt
+++ b/soil-form/src/commonTest/kotlin/soil/form/compose/FormStateTest.kt
@@ -45,12 +45,10 @@ class FormStateTest : UnitTest() {
         formState.meta.fields["firstName"] = FieldMetaState(
             error = FieldError("Some error"),
             mode = FieldValidationMode.Change,
-            isDirty = true,
             isTouched = true,
             isValidated = true
         )
         formState.meta.fields["lastName"] = FieldMetaState(
-            isDirty = true,
             isTouched = true
         )
 
@@ -94,8 +92,7 @@ class FormStateTest : UnitTest() {
 
         // Add some field metadata
         formState.meta.fields["firstName"] = FieldMetaState(
-            error = FieldError("Some error"),
-            isDirty = true
+            error = FieldError("Some error")
         )
         formState.meta.canSubmit = false
 
@@ -118,20 +115,17 @@ class FormStateTest : UnitTest() {
         val restoredFieldMeta = restored.meta.fields["firstName"]
         val originalFieldMeta = formState.meta.fields["firstName"]
         assertEquals(originalFieldMeta?.error, restoredFieldMeta?.error)
-        assertEquals(originalFieldMeta?.isDirty, restoredFieldMeta?.isDirty)
     }
 
     @Test
     fun testMetaState() {
         val fields = mapOf(
-            "firstName" to FieldMetaState(isDirty = true),
             "lastName" to FieldMetaState(isTouched = true)
         )
         val formMeta = FormMetaState(policy = FormPolicy(), fields = fields, canSubmit = true, resetCount = 0)
 
-        assertEquals(2, formMeta.fields.size)
+        assertEquals(1, formMeta.fields.size)
         assertTrue(formMeta.canSubmit)
-        assertTrue(formMeta.fields["firstName"]?.isDirty == true)
         assertTrue(formMeta.fields["lastName"]?.isTouched == true)
     }
 
@@ -146,7 +140,7 @@ class FormStateTest : UnitTest() {
     @Test
     fun testFormMetaState_saver() {
         val fields = mapOf(
-            "firstName" to FieldMetaState(isDirty = true, error = FieldError("Error"))
+            "firstName" to FieldMetaState(error = FieldError("Error"))
         )
         val policy = FormPolicy()
         val formMeta = FormMetaState(policy = policy, fields = fields, canSubmit = true, resetCount = 3)
@@ -168,7 +162,6 @@ class FormStateTest : UnitTest() {
 
         val restoredFieldMeta = restored.fields["firstName"]
         val originalFieldMeta = formMeta.fields["firstName"]
-        assertEquals(originalFieldMeta?.isDirty, restoredFieldMeta?.isDirty)
         assertEquals(originalFieldMeta?.error, restoredFieldMeta?.error)
     }
 
@@ -178,14 +171,12 @@ class FormStateTest : UnitTest() {
         val fieldMeta = FieldMetaState(
             error = error,
             mode = FieldValidationMode.Change,
-            isDirty = true,
             isTouched = true,
             isValidated = true
         )
 
         assertEquals(error, fieldMeta.error)
         assertEquals(FieldValidationMode.Change, fieldMeta.mode)
-        assertTrue(fieldMeta.isDirty)
         assertTrue(fieldMeta.isTouched)
         assertTrue(fieldMeta.isValidated)
     }
@@ -196,7 +187,6 @@ class FormStateTest : UnitTest() {
         val fieldMeta = FieldMetaState(
             error = error,
             mode = FieldValidationMode.Change,
-            isDirty = true,
             isTouched = true,
             isValidated = true
         )
@@ -214,7 +204,6 @@ class FormStateTest : UnitTest() {
 
         assertEquals(fieldMeta.error, restored.error)
         assertEquals(fieldMeta.mode, restored.mode)
-        assertEquals(fieldMeta.isDirty, restored.isDirty)
         assertEquals(fieldMeta.isTouched, restored.isTouched)
         assertEquals(fieldMeta.isValidated, restored.isValidated)
     }

--- a/soil-form/src/commonTest/kotlin/soil/form/compose/ui/FieldLayout.kt
+++ b/soil-form/src/commonTest/kotlin/soil/form/compose/ui/FieldLayout.kt
@@ -10,14 +10,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import soil.form.compose.FormField
+import soil.form.compose.BasicFormField
 import soil.form.compose.hasError
 
 @Composable
-fun <V> FieldLayout(
-    field: FormField<V>,
+fun <T : BasicFormField> FieldLayout(
+    field: T,
     modifier: Modifier = Modifier,
-    content: @Composable FormField<V>.() -> Unit
+    content: @Composable T.() -> Unit
 ) {
     Column(
         modifier = modifier,


### PR DESCRIPTION
This change prepares the foundation for TextFieldState integration by separating value-agnostic operations from the existing structure. Additionally, the isDirty property has been removed due to its incompatibility with TextFieldState's input mechanism, which will streamline the integration process and ensure consistent behavior across the form field implementations.

**Breaking changes:**
- Removed `isDirty` property from `FieldMeta` interface and `FormField` interface


