### PR TITLE
Add TextFieldState-optimized form field validation

### DIFF
--- a/soil-form/src/commonMain/kotlin/soil/form/compose/text/FormTextField.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/text/FormTextField.kt
@@ -1,0 +1,461 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.form.compose.text
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.currentCompositeKeyHash
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.snapshots.Snapshot
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.scan
+import kotlinx.coroutines.launch
+import soil.form.FieldError
+import soil.form.FieldName
+import soil.form.FieldNames
+import soil.form.FieldOptions
+import soil.form.FieldValidationMode
+import soil.form.FieldValidator
+import soil.form.annotation.InternalSoilFormApi
+import soil.form.compose.BasicFormField
+import soil.form.compose.FieldMetaState
+import soil.form.compose.Form
+import soil.form.compose.FormBinding
+import soil.form.noFieldError
+
+/**
+ * A control interface for managing form text field state with built-in [TextFieldState] integration.
+ *
+ * This interface provides seamless integration with Compose's TextFieldState API, offering
+ * automatic validation, focus management, and error handling for text input fields.
+ *
+ * Usage:
+ * ```kotlin
+ * form.Field(
+ *     selector = { it.emailState },
+ *     render = { field ->
+ *         TextField(
+ *             state = field.state,
+ *             isError = field.hasError,
+ *             modifier = Modifier.onFocusChanged { state ->
+ *                 field.handleFocus(state.isFocused)
+ *             }
+ *         )
+ *     }
+ * )
+ * ```
+ */
+@Stable
+interface FormTextField : BasicFormField {
+    /**
+     * The TextFieldState that manages the text content and editing operations.
+     * This state can be directly passed to Compose text field components.
+     */
+    val state: TextFieldState
+}
+
+/**
+ * Creates a form text field with validation and state management for TextFieldState.
+ *
+ * This function creates a text field that integrates with Compose's TextFieldState API,
+ * providing automatic validation of the text content and seamless integration with
+ * modern text field components.
+ *
+ * Usage:
+ * ```kotlin
+ * form.Field(
+ *     selector = { it.emailState },
+ *     validator = FieldValidator {
+ *         notBlank { "Email is required" }
+ *         email { "Must be a valid email" }
+ *     },
+ *     render = { field ->
+ *         TextField(
+ *             state = field.state,
+ *             isError = field.hasError,
+ *             modifier = Modifier.onFocusChanged { state ->
+ *                 field.handleFocus(state.isFocused)
+ *             }
+ *         )
+ *     }
+ * )
+ * ```
+ *
+ * @param T The type of the form data.
+ * @param selector A function that extracts the TextFieldState from the form data.
+ * @param validator Optional validator for [TextFieldState.text].
+ * @param name Optional custom name for the field. If null, an auto-generated name is used.
+ * @param dependsOn Optional list of field names this field depends on for validation.
+ * @param enabled Whether the field is enabled for input.
+ * @param render The composable content that renders the field UI.
+ */
+@Composable
+fun <T> Form<T>.Field(
+    selector: (T) -> TextFieldState,
+    validator: FieldValidator<CharSequence>? = null,
+    name: FieldName? = null,
+    dependsOn: FieldNames? = null,
+    enabled: Boolean = true,
+    render: @Composable (FormTextField) -> Unit
+) {
+    val control = rememberField(
+        selector = selector,
+        validator = validator,
+        name = name,
+        dependsOn = dependsOn,
+        enabled = enabled
+    )
+    render(control)
+}
+
+/**
+ * Creates a form text field with type adaptation, validation, and state management.
+ *
+ * This overload allows you to use a TextFieldStateAdapter to convert the text content
+ * to a different type for validation. This is useful when you need to validate the
+ * text as a specific data type (e.g., validating numeric input, dates, or custom formats).
+ *
+ * Usage:
+ * ```kotlin
+ * form.Field(
+ *     selector = { it.ageState },
+ *     adapter = IntTextFieldStateAdapter(),
+ *     validator = FieldValidator<Int> {
+ *         min(0) { "Age must be non-negative" }
+ *         max(150) { "Age must be realistic" }
+ *     },
+ *     render = { field ->
+ *         TextField(
+ *             state = field.state,
+ *             isError = field.hasError,
+ *             modifier = Modifier.onFocusChanged { state ->
+ *                 field.handleFocus(state.isFocused)
+ *             }
+ *         )
+ *     }
+ * )
+ * ```
+ *
+ * @param T The type of the form data.
+ * @param S The type used for validation after adaptation.
+ * @param selector A function that extracts the TextFieldState from the form data.
+ * @param adapter The adapter that converts text content to the validation type.
+ * @param validator Optional validator for the adapted type (S).
+ * @param name Optional custom name for the field. If null, an auto-generated name is used.
+ * @param dependsOn Optional list of field names this field depends on for validation.
+ * @param enabled Whether the field is enabled for input.
+ * @param render The composable content that renders the field UI.
+ */
+@Composable
+fun <T, S> Form<T>.Field(
+    selector: (T) -> TextFieldState,
+    adapter: TextFieldStateAdapter<S>,
+    validator: FieldValidator<S>? = null,
+    name: FieldName? = null,
+    dependsOn: FieldNames? = null,
+    enabled: Boolean = true,
+    render: @Composable (FormTextField) -> Unit
+) {
+    val control = rememberField(
+        selector = selector,
+        adapter = adapter,
+        validator = validator,
+        name = name,
+        dependsOn = dependsOn,
+        enabled = enabled
+    )
+    render(control)
+}
+
+/**
+ * Creates and remembers a form text field control with validation and state management.
+ *
+ * This function creates a FormTextField control that can be used to manage text field state
+ * and interactions. Unlike the Field composable functions, this returns the control object
+ * directly without rendering UI, allowing for more flexible usage patterns.
+ *
+ * Usage:
+ * ```kotlin
+ * val emailField = form.rememberField(
+ *     selector = { it.emailState },
+ *     validator = FieldValidator {
+ *         notBlank { "Email is required" }
+ *         email { "Must be a valid email" }
+ *     }
+ * )
+ *
+ * TextField(
+ *     state = emailField.state,
+ *     isError = field.hasError,
+ *     modifier = Modifier.onFocusChanged { state ->
+ *         emailField.handleFocus(state.isFocused)
+ *     }
+ * )
+ * ```
+ *
+ * @param T The type of the form data.
+ * @param selector A function that extracts the TextFieldState from the form data.
+ * @param validator Optional validator for [TextFieldState.text].
+ * @param name Optional custom name for the field. If null, an auto-generated name is used.
+ * @param dependsOn Optional list of field names this field depends on for validation.
+ * @param enabled Whether the field is enabled for input.
+ * @return A FormTextField control object for managing the text field state and interactions.
+ */
+@Composable
+fun <T> Form<T>.rememberField(
+    selector: (T) -> TextFieldState,
+    validator: FieldValidator<CharSequence>? = null,
+    name: FieldName? = null,
+    dependsOn: FieldNames? = null,
+    enabled: Boolean = true,
+): FormTextField = rememberField(
+    selector = selector,
+    adapter = remember { TextFieldPassthroughAdapter() },
+    validator = validator,
+    name = name,
+    dependsOn = dependsOn,
+    enabled = enabled
+)
+
+/**
+ * Creates and remembers a form text field control with type adaptation, validation, and state management.
+ *
+ * This function creates a FormTextField control with type adaptation capabilities, allowing you to
+ * convert the text content to a different type for validation. Unlike the Field composable functions,
+ * this returns the control object directly without rendering UI, providing maximum flexibility for
+ * custom text field implementations.
+ *
+ * Usage:
+ * ```kotlin
+ * val ageField = form.rememberField(
+ *     selector = { it.ageState },
+ *     adapter = IntTextFieldStateAdapter(),
+ *     validator = FieldValidator<Int> {
+ *         min(0) { "Age must be non-negative" }
+ *         max(150) { "Age must be realistic" }
+ *     }
+ * )
+ *
+ * Column {
+ *     TextField(
+ *         state = ageField.state,
+ *         isError = field.hasError,
+ *         modifier = Modifier.onFocusChanged { state ->
+ *             ageField.handleFocus(state.isFocused)
+ *         }
+ *     )
+ * }
+ * ```
+ *
+ * @param T The type of the form data.
+ * @param S The type used for validation after adaptation.
+ * @param selector A function that extracts the TextFieldState from the form data.
+ * @param adapter The adapter that converts text content to the validation type.
+ * @param validator Optional validator for the adapted type (S).
+ * @param name Optional custom name for the field. If null, an auto-generated name is used.
+ * @param dependsOn Optional list of field names this field depends on for validation.
+ * @param enabled Whether the field is enabled for input.
+ * @return A FormTextField control object for managing the text field state and interactions.
+ */
+@OptIn(InternalSoilFormApi::class, FlowPreview::class)
+@Composable
+fun <T, S> Form<T>.rememberField(
+    selector: (T) -> TextFieldState,
+    adapter: TextFieldStateAdapter<S>,
+    validator: FieldValidator<S>? = null,
+    name: FieldName? = null,
+    dependsOn: FieldNames? = null,
+    enabled: Boolean = true,
+): FormTextField {
+    val fieldName = name ?: auto
+    val control = remember(binding) {
+        FormTextFieldController(
+            form = binding,
+            selector = selector,
+            adapter = adapter,
+            validator = validator,
+            name = fieldName,
+            dependsOn = dependsOn.orEmpty(),
+        )
+    }.apply { isEnabled = enabled }
+    if (enabled) {
+        DisposableEffect(control) {
+            control.register()
+            onDispose {
+                control.unregister()
+            }
+        }
+        LaunchedEffect(control) {
+            // validateOnMount
+            launch {
+                snapshotFlow { control.shouldTrigger(FieldValidationMode.Mount) }
+                    .filter { it }
+                    .debounce(control.options.validationDelayOnMount)
+                    .collect {
+                        control.trigger(FieldValidationMode.Mount)
+                    }
+            }
+
+            // validateOnChange
+            launch {
+                snapshotFlow { control.validationTarget }
+                    .drop(1) // Skip the initial value
+                    .onEach { control.notifyFormChange() }
+                    .debounce(control.options.validationDelayOnChange)
+                    .collect {
+                        control.trigger(FieldValidationMode.Change)
+                    }
+            }
+
+            // validateOnBlur
+            launch {
+                snapshotFlow { control.isFocused }
+                    .scan(Pair(false, false)) { acc, value -> Pair(acc.second, value) }
+                    // isFocused: true -> false
+                    .filter { it.first && !it.second }
+                    .debounce(control.options.validationDelayOnBlur)
+                    .collect {
+                        control.trigger(FieldValidationMode.Blur)
+                    }
+            }
+
+            // revalidate
+            launch {
+                control.dependentFieldChanges
+                    .debounce(control.options.validationDelayOnChange)
+                    .collect {
+                        control.revalidateIfNeeded()
+                    }
+            }
+        }
+    }
+    return control
+}
+
+private val auto: FieldName
+    @Composable
+    get() {
+        val keyHash = currentCompositeKeyHash.toString(MaxSupportedRadix)
+        return "text-field-$keyHash"
+    }
+
+// https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/runtime/runtime-saveable/src/commonMain/kotlin/androidx/compose/runtime/saveable/RememberSaveable.kt?q=MaxSupportedRadix
+private const val MaxSupportedRadix: Int = 36
+
+@InternalSoilFormApi
+internal class FormTextFieldController<T, S>(
+    private val form: FormBinding<T>,
+    private val selector: (T) -> TextFieldState,
+    private val adapter: TextFieldStateAdapter<S>,
+    private val validator: FieldValidator<S>?,
+    override val name: FieldName,
+    private val dependsOn: FieldNames
+) : FormTextField {
+
+    private val meta: FieldMetaState = form[name] ?: FieldMetaState(
+        mode = options.validationStrategy.initial
+    )
+
+    override val state: TextFieldState get() = selector(form.state.value)
+
+    val options: FieldOptions get() = form.policy.fieldOptions
+
+    val validationTarget: S get() = adapter.toValidationTarget(state)
+
+    val dependentFieldChanges: Flow<FieldName> get() = form.fieldChanges.filter { it in dependsOn }
+
+    override var error: FieldError
+        get() = meta.error
+        set(value) {
+            meta.error = value
+        }
+
+    override var isTouched: Boolean
+        get() = meta.isTouched
+        set(value) {
+            meta.isTouched = value
+        }
+
+    override var isFocused: Boolean by mutableStateOf(false)
+
+    override var isEnabled: Boolean by mutableStateOf(true)
+
+    fun register() {
+        form.register(name) { value, dryRun ->
+            validate(adapter.toValidationTarget(selector(value)), dryRun)
+        }
+        if (form[name] == null) {
+            form[name] = meta
+        }
+    }
+
+    fun unregister() {
+        form.unregister(name)
+    }
+
+    override fun onFocus() {
+        isFocused = true
+    }
+
+    override fun onBlur() {
+        isTouched = isTouched || isFocused
+        isFocused = false
+    }
+
+    override fun handleFocus(hasFocus: Boolean) {
+        when {
+            hasFocus && !isFocused -> onFocus()
+            !hasFocus && isFocused -> onBlur()
+            else -> Unit
+        }
+    }
+
+    override fun trigger(mode: FieldValidationMode): Boolean {
+        return if (shouldTrigger(mode)) {
+            validate(adapter.toValidationTarget(state))
+            true
+        } else {
+            false
+        }
+    }
+
+    fun shouldTrigger(mode: FieldValidationMode): Boolean {
+        return mode == meta.mode
+    }
+
+    private fun validate(value: S, dryRun: Boolean = false): Boolean {
+        val error = validator?.invoke(value) ?: noFieldError
+        val isValid = error == noFieldError
+        if (!dryRun) {
+            Snapshot.withMutableSnapshot {
+                meta.error = error
+                meta.mode = options.validationStrategy.next(meta.mode, isValid)
+                meta.isValidated = true
+            }
+        }
+        return isValid
+    }
+
+    fun revalidateIfNeeded() {
+        if (meta.isValidated) {
+            validate(adapter.toValidationTarget(state))
+        }
+    }
+
+    suspend fun notifyFormChange() {
+        form.notifyFieldChange(name)
+    }
+}

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/text/TextFieldStateAdapter.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/text/TextFieldStateAdapter.kt
@@ -1,0 +1,48 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.form.compose.text
+
+import androidx.compose.foundation.text.input.TextFieldState
+import soil.form.FieldTypeAdapter
+
+/**
+ * An adapter interface specifically designed for TextFieldState type conversion.
+ *
+ * This specialized adapter works with Compose's TextFieldState, maintaining the state
+ * object for input/display while allowing conversion to a different type for validation.
+ * The stored value and input types are always TextFieldState, but the validation target
+ * type can be customized.
+ *
+ * This is particularly useful when you need to validate the text content as a specific
+ * type (e.g., numbers, dates, emails) while keeping the TextFieldState for UI interaction.
+ *
+ * Usage:
+ * ```kotlin
+ * class IntTextFieldStateAdapter : TextFieldStateAdapter<Int?> {
+ *     override fun toValidationTarget(value: TextFieldState): Int? {
+ *         return value.text.toString().toIntOrNull()
+ *     }
+ * }
+ * ```
+ *
+ * @param S The type used for validation (e.g., Int, Date, or custom types).
+ */
+interface TextFieldStateAdapter<S> : FieldTypeAdapter<TextFieldState, S, TextFieldState> {
+    override fun fromInput(value: TextFieldState, current: TextFieldState): TextFieldState = value
+    override fun toInput(value: TextFieldState): TextFieldState = value
+}
+
+/**
+ * A default adapter that validates [TextFieldState.text] as CharSequence.
+ *
+ * This adapter extracts the text content from TextFieldState for validation
+ * while maintaining the TextFieldState for UI interaction. It's the simplest
+ * adapter that allows direct text validation without type conversion.
+ *
+ * This is the default adapter used when no explicit adapter is provided
+ * to a TextFieldState-based form field.
+ */
+class TextFieldPassthroughAdapter : TextFieldStateAdapter<CharSequence> {
+    override fun toValidationTarget(value: TextFieldState): CharSequence = value.text
+}

--- a/soil-form/src/commonMain/kotlin/soil/form/compose/text/TextFieldStateForm.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/text/TextFieldStateForm.kt
@@ -1,0 +1,119 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.form.compose.text
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import soil.form.FieldName
+import soil.form.FieldValidator
+import soil.form.compose.Form
+import soil.form.compose.FormMetaState
+import soil.form.compose.FormState
+import soil.form.compose.rememberFormMetaState
+
+/**
+ * Converts a TextFieldState into a FormState for single-field form management.
+ *
+ * This extension function allows you to treat a single TextFieldState as a complete form,
+ * enabling validation, submission handling, and state management for standalone text fields.
+ * This is particularly useful for simple forms with a single text input, such as search bars,
+ * comment fields, or single-field dialogs.
+ *
+ * Usage:
+ * ```kotlin
+ * val emailState = rememberTextFieldState()
+ * val form = rememberForm(
+ *     state = emailState.asFormState(),
+ *     onSubmit = { state ->
+ *         // Handle submission with state.text
+ *         sendEmail(state.text.toString())
+ *     }
+ * )
+ *
+ * form.Field(
+ *     validator = FieldValidator {
+ *         notBlank { "Email is required" }
+ *         email { "Must be a valid email" }
+ *     },
+ *     render = { field ->
+ *         TextField(
+ *             state = field.state,
+ *             isError = field.hasError
+ *         )
+ *     }
+ * )
+ * ```
+ *
+ * @param meta The form metadata state for tracking validation and submission status.
+ * @return A FormState wrapping this TextFieldState for use with the Form composable.
+ */
+@Composable
+fun TextFieldState.asFormState(
+    meta: FormMetaState = rememberFormMetaState()
+): FormState<TextFieldState> = remember(meta.key) {
+    FormState(value = this, meta = meta)
+}
+
+/**
+ * Creates a field for a TextFieldState-based form with direct text validation.
+ *
+ * This specialized Field function is designed for forms where the entire form data
+ * is a single TextFieldState. It provides a streamlined API for single-field forms,
+ * eliminating the need for selector and updater functions since the form data itself
+ * is the TextFieldState.
+ *
+ * @param validator Optional validator for [TextFieldState.text].
+ * @param name Optional custom name for the field. If null, an auto-generated name is used.
+ * @param enabled Whether the field is enabled for input.
+ * @param render The composable content that renders the field UI.
+ */
+@Composable
+fun Form<TextFieldState>.Field(
+    validator: FieldValidator<CharSequence>? = null,
+    name: FieldName? = null,
+    enabled: Boolean = true,
+    render: @Composable (FormTextField) -> Unit
+) {
+    val control = rememberField(
+        selector = { it },
+        validator = validator,
+        name = name,
+        enabled = enabled
+    )
+    render(control)
+}
+
+/**
+ * Creates a field for a TextFieldState-based form with type adaptation and validation.
+ *
+ * This overload allows you to use a TextFieldStateAdapter to convert the text content
+ * to a different type for validation. This is useful for single-field forms that need
+ * to validate the input as a specific data type while maintaining the simplicity of
+ * a TextFieldState-only form.
+ *
+ * @param S The type used for validation after adaptation.
+ * @param adapter The adapter that converts text content to the validation type.
+ * @param validator Optional validator for the adapted type (S).
+ * @param name Optional custom name for the field. If null, an auto-generated name is used.
+ * @param enabled Whether the field is enabled for input.
+ * @param render The composable content that renders the field UI.
+ */
+@Composable
+fun <S> Form<TextFieldState>.Field(
+    adapter: TextFieldStateAdapter<S>,
+    validator: FieldValidator<S>? = null,
+    name: FieldName? = null,
+    enabled: Boolean = true,
+    render: @Composable (FormTextField) -> Unit
+) {
+    val control = rememberField(
+        selector = { it },
+        adapter = adapter,
+        validator = validator,
+        name = name,
+        enabled = enabled
+    )
+    render(control)
+}

--- a/soil-form/src/commonTest/kotlin/soil/form/compose/text/FormTextFieldTest.kt
+++ b/soil-form/src/commonTest/kotlin/soil/form/compose/text/FormTextFieldTest.kt
@@ -1,0 +1,477 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.form.compose.text
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import soil.form.FieldError
+import soil.form.FieldValidationMode
+import soil.form.FieldValidator
+import soil.form.annotation.InternalSoilFormApi
+import soil.form.compose.FormController
+import soil.form.compose.FormState
+import soil.form.compose.hasError
+import soil.form.noFieldError
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+@OptIn(InternalSoilFormApi::class)
+class FormTextFieldTest : UnitTest() {
+
+    @Test
+    fun testInitialization() {
+        val textFieldState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = null,
+            name = "testField",
+            dependsOn = emptySet()
+        )
+
+        assertEquals("testField", controller.name)
+        assertEquals(textFieldState, controller.state)
+        assertEquals("", controller.state.text.toString())
+        assertEquals(noFieldError, controller.error)
+        assertFalse(controller.hasError)
+        assertFalse(controller.isTouched)
+        assertFalse(controller.isFocused)
+        assertTrue(controller.isEnabled)
+    }
+
+    @Test
+    fun testTextFieldStateChanges() {
+        val textFieldState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = null,
+            name = "name",
+            dependsOn = emptySet()
+        )
+
+        controller.register()
+
+        textFieldState.setTextAndPlaceCursorAtEnd("John Doe")
+        assertEquals("John Doe", controller.state.text.toString())
+        assertEquals("John Doe", controller.validationTarget.toString())
+    }
+
+    @Test
+    fun testFocusHandling() {
+        val textFieldState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = null,
+            name = "name",
+            dependsOn = emptySet()
+        )
+
+        // Test onFocus
+        controller.onFocus()
+        assertTrue(controller.isFocused)
+
+        // Test onBlur
+        controller.onBlur()
+        assertFalse(controller.isFocused)
+        assertTrue(controller.isTouched)
+    }
+
+    @Test
+    fun testHandleFocus() {
+        val textFieldState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = null,
+            name = "name",
+            dependsOn = emptySet()
+        )
+
+        // Test gaining focus
+        controller.handleFocus(true)
+        assertTrue(controller.isFocused)
+
+        // Test losing focus
+        controller.handleFocus(false)
+        assertFalse(controller.isFocused)
+        assertTrue(controller.isTouched)
+
+        // Test no change when already focused
+        controller.isFocused = true
+        controller.isTouched = false
+        controller.handleFocus(true)
+        assertTrue(controller.isFocused)
+        assertFalse(controller.isTouched)
+    }
+
+    @Test
+    fun testValidationWithValidator() {
+        val textFieldState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val validator: FieldValidator<CharSequence> = { value ->
+            if (value.isBlank()) FieldError("Name is required") else noFieldError
+        }
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = validator,
+            name = "name",
+            dependsOn = emptySet()
+        )
+
+        controller.register()
+
+        // Test validation failure
+        controller.trigger(FieldValidationMode.Blur)
+        assertTrue(controller.hasError)
+        assertEquals(listOf("Name is required"), controller.error.messages)
+
+        // Test validation success
+        textFieldState.setTextAndPlaceCursorAtEnd("John")
+        controller.trigger(FieldValidationMode.Change)
+        assertFalse(controller.hasError)
+        assertEquals(noFieldError, controller.error)
+    }
+
+    @Test
+    fun testValidationWithoutValidator() {
+        val textFieldState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = null,
+            name = "name",
+            dependsOn = emptySet()
+        )
+
+        controller.register()
+        controller.trigger(FieldValidationMode.Blur)
+
+        assertFalse(controller.hasError)
+        assertEquals(noFieldError, controller.error)
+    }
+
+    @Test
+    fun testShouldTrigger() {
+        val textFieldState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = null,
+            name = "name",
+            dependsOn = emptySet()
+        )
+
+        controller.register()
+        val meta = formController.binding["name"]!!
+
+        // Test with matching mode
+        meta.mode = FieldValidationMode.Blur
+        assertTrue(controller.shouldTrigger(FieldValidationMode.Blur))
+
+        // Test with non-matching mode
+        assertFalse(controller.shouldTrigger(FieldValidationMode.Change))
+    }
+
+    @Test
+    fun testRegisterAndUnregister() {
+        val textFieldState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = null,
+            name = "name",
+            dependsOn = emptySet()
+        )
+
+        // Test register
+        controller.register()
+        assertTrue(formController.fields.contains("name"))
+        assertTrue(formState.meta.fields.containsKey("name"))
+
+        // Test unregister
+        controller.unregister()
+        assertFalse(formController.fields.contains("name"))
+    }
+
+    @Test
+    fun testRevalidateIfNeeded() {
+        val textFieldState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = { value: CharSequence ->
+                if (value.isBlank()) FieldError("must be not blank") else noFieldError
+            },
+            name = "name",
+            dependsOn = emptySet()
+        )
+
+        controller.register()
+
+        val fieldState = checkNotNull(formState.meta.fields["name"])
+
+        assertFalse(fieldState.isValidated)
+        assertEquals(noFieldError, fieldState.error)
+
+        controller.revalidateIfNeeded()
+
+        assertFalse(fieldState.isValidated)
+        assertEquals(noFieldError, fieldState.error)
+
+        fieldState.isValidated = true
+        controller.revalidateIfNeeded()
+
+        assertNotEquals(noFieldError, fieldState.error)
+        assertTrue(controller.hasError)
+        assertTrue(fieldState.isValidated)
+    }
+
+    @Test
+    fun testValidationTargetWithAdapter() {
+        val textFieldState = TextFieldState()
+        textFieldState.setTextAndPlaceCursorAtEnd("25")
+
+        val formState = FormState(value = TestFormData(ageState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.ageState },
+            adapter = IntTextFieldStateAdapter(),
+            validator = null,
+            name = "age",
+            dependsOn = emptySet()
+        )
+
+        assertEquals(25, controller.validationTarget)
+        assertEquals("25", controller.state.text.toString())
+    }
+
+    @Test
+    fun testErrorState() {
+        val textFieldState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = null,
+            name = "name",
+            dependsOn = emptySet()
+        )
+
+        controller.register()
+
+        // Test no error initially
+        assertFalse(controller.hasError)
+
+        // Test setting error
+        controller.error = FieldError("Test error")
+        assertTrue(controller.hasError)
+        assertEquals(listOf("Test error"), controller.error.messages)
+    }
+
+    @Test
+    fun testEnabledState() {
+        val textFieldState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = null,
+            name = "name",
+            dependsOn = emptySet()
+        )
+
+        // Test default enabled state
+        assertTrue(controller.isEnabled)
+
+        // Test disabling
+        controller.isEnabled = false
+        assertFalse(controller.isEnabled)
+    }
+
+    @Test
+    fun testDependentFieldChanges() = runTest {
+        val nameState = TextFieldState()
+        val ageState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = nameState, ageState = ageState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val nameController = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = null,
+            name = "name",
+            dependsOn = setOf("age")
+        ).also { it.register() }
+
+        val emailController = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.emailState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = null,
+            name = "email",
+            dependsOn = emptySet()
+        ).also { it.register() }
+
+        // Test nameController receives notifications for fields it depends on
+        nameController.dependentFieldChanges.test {
+            // Emit field changes after starting the test
+            formController.binding.notifyFieldChange("age")
+            assertEquals("age", awaitItem())
+
+            formController.binding.notifyFieldChange("age")
+            assertEquals("age", awaitItem())
+
+            // This should not be received since "name" is not in dependsOn
+            formController.binding.notifyFieldChange("name")
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Test emailController doesn't receive any notifications since it has no dependencies
+        emailController.dependentFieldChanges.test {
+            // Emit various field changes
+            formController.binding.notifyFieldChange("age")
+            formController.binding.notifyFieldChange("name")
+            formController.binding.notifyFieldChange("email")
+
+            // Should not receive any events since dependsOn is empty
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun testNotifyFormChange() = runTest {
+        val textFieldState = TextFieldState()
+        val formState = FormState(value = TestFormData(nameState = textFieldState))
+        val formController = FormController(
+            state = formState,
+            onSubmit = {}
+        )
+
+        val controller = FormTextFieldController(
+            form = formController.binding,
+            selector = { it.nameState },
+            adapter = TextFieldPassthroughAdapter(),
+            validator = null,
+            name = "name",
+            dependsOn = emptySet()
+        )
+
+        controller.register()
+
+        formController.binding.fieldChanges.test {
+            controller.notifyFormChange()
+            assertEquals("name", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    data class TestFormData(
+        val nameState: TextFieldState = TextFieldState(),
+        val ageState: TextFieldState = TextFieldState(),
+        val emailState: TextFieldState = TextFieldState()
+    )
+
+    private class IntTextFieldStateAdapter : TextFieldStateAdapter<Int> {
+        override fun toValidationTarget(value: TextFieldState): Int {
+            return value.text.toString().toIntOrNull() ?: 0
+        }
+    }
+}

--- a/soil-form/src/commonTest/kotlin/soil/form/compose/text/TextFieldStateFormSimpleTest.kt
+++ b/soil-form/src/commonTest/kotlin/soil/form/compose/text/TextFieldStateFormSimpleTest.kt
@@ -1,0 +1,97 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.form.compose.text
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material.Scaffold
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalInputModeManager
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.isNotEnabled
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.waitUntilDoesNotExist
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import soil.form.FieldValidator
+import soil.form.compose.rememberForm
+import soil.form.compose.ui.FieldLayout
+import soil.form.compose.ui.InputField
+import soil.form.compose.ui.Submit
+import soil.form.rule.notEmpty
+import soil.testing.UnitTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class TextFieldStateFormTest : UnitTest() {
+
+    @Test
+    fun testForm() = runComposeUiTest {
+        var measured = false
+        val textFieldState = TextFieldState()
+        setContent {
+            // ref: https://developer.android.com/codelabs/large-screens/keyboard-focus-management-in-compose#9
+            LocalInputModeManager.current.requestInputMode(InputMode.Keyboard)
+            val form = rememberForm(state = textFieldState.asFormState()) {
+                // no-op
+            }
+            Scaffold(
+                modifier = Modifier.fillMaxSize().onGloballyPositioned { measured = true },
+                bottomBar = {
+                    form.Submit()
+                }
+            ) {
+                form.Field(
+                    name = "testField",
+                    validator = FieldValidator {
+                        notEmpty { "Must be not empty" }
+                    },
+                    render = { field ->
+                        FieldLayout(field) {
+                            InputField()
+                        }
+                    }
+                )
+            }
+        }
+        waitUntil { measured }
+        waitUntilExactlyOneExists(hasTestTag("submit") and isNotEnabled())
+
+        onNodeWithTag("testField_error").assertDoesNotExist()
+        onNodeWithTag("testField")
+            .requestFocus()
+            .performTextInput("")
+
+        onNodeWithTag("testField")
+            .performKeyInput { pressKey(Key.Tab) }
+
+        onNodeWithTag("submit").assertIsFocused()
+
+        waitUntilExactlyOneExists(hasTestTag("testField_error") and hasText("Must be not empty"))
+        waitUntilExactlyOneExists(hasTestTag("submit") and isNotEnabled())
+
+        onNodeWithTag("testField")
+            .requestFocus()
+            .performTextInput("hello")
+
+        onNodeWithTag("testField")
+            .performKeyInput { pressKey(Key.Tab) }
+
+        onNodeWithTag("submit").assertIsFocused()
+
+        waitUntilDoesNotExist(hasTestTag("testField_error"))
+        waitUntilExactlyOneExists(hasTestTag("submit") and isEnabled())
+    }
+}

--- a/soil-form/src/commonTest/kotlin/soil/form/compose/ui/InputField.kt
+++ b/soil-form/src/commonTest/kotlin/soil/form/compose/ui/InputField.kt
@@ -5,6 +5,10 @@ package soil.form.compose.ui
 
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.KeyboardActionHandler
+import androidx.compose.foundation.text.input.OutputTransformation
+import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,6 +17,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.VisualTransformation
 import soil.form.compose.FormField
 import soil.form.compose.hasError
+import soil.form.compose.text.FormTextField
 
 @Composable
 fun FormField<String>.InputField(
@@ -38,5 +43,29 @@ fun FormField<String>.InputField(
         minLines = minLines,
         visualTransformation = visualTransformation,
         isError = hasError,
+    )
+}
+
+@Composable
+fun FormTextField.InputField(
+    modifier: Modifier = Modifier,
+    inputTransformation: InputTransformation? = null,
+    outputTransformation: OutputTransformation? = null,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    onKeyboardAction: KeyboardActionHandler? = null,
+    lineLimits: TextFieldLineLimits = TextFieldLineLimits.SingleLine
+) {
+    OutlinedTextField(
+        state = state,
+        modifier = modifier
+            .onFocusChanged { state -> handleFocus(state.isFocused || state.hasFocus) }
+            .testTag(name),
+        enabled = isEnabled,
+        inputTransformation = inputTransformation,
+        outputTransformation = outputTransformation,
+        keyboardOptions = keyboardOptions,
+        onKeyboardAction = onKeyboardAction,
+        lineLimits = lineLimits,
+        isError = hasError
     )
 }


### PR DESCRIPTION
Introduces specialized form field components optimized for Compose's TextFieldState API.

While TextFieldState was previously usable through the generic form field, this update provides a tailored API that directly exposes TextFieldState and simplifies validation.

```kotlin
form.Field(
    selector = { it.emailState },
    validator = FieldValidator {
        notBlank { "Email is required" }
        email { "Must be a valid email" }
    },
    render = { field ->
        TextField(
            state = field.state,  // Direct access
            isError = field.hasError,
            modifier = Modifier.onFocusChanged { state ->
                field.handleFocus(state.isFocused)
            }
        )
    }
)
```