### PR TITLE
Refactor Kover configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.application) apply false
@@ -45,9 +44,7 @@ allprojects {
             } else {
                 events(TestLogEvent.FAILED)
             }
-            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-            events(TestLogEvent.FAILED)
-            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+            exceptionFormat = TestExceptionFormat.FULL
             showStandardStreams = true
         }
     }
@@ -82,12 +79,14 @@ allprojects {
     }
 }
 
-kover {
-    currentProject {
-        createVariant("soil") {
-
-        }
+dependencies {
+    for (module in publicModules) {
+        kover(project(module))
+        dokka(project(module))
     }
+}
+
+kover {
     reports {
         filters {
             excludes {
@@ -99,11 +98,4 @@ kover {
 
 dokka {
     moduleName.set("Soil")
-}
-
-dependencies {
-    for (module in publicModules) {
-        kover(project(module))
-        dokka(project(module))
-    }
 }

--- a/soil-experimental/soil-lazyload/build.gradle.kts
+++ b/soil-experimental/soil-lazyload/build.gradle.kts
@@ -85,11 +85,3 @@ android {
         debugImplementation(compose.uiTooling)
     }
 }
-
-kover {
-    currentProject {
-        createVariant("soil") {
-            add("debug")
-        }
-    }
-}

--- a/soil-experimental/soil-optimistic-update/build.gradle.kts
+++ b/soil-experimental/soil-optimistic-update/build.gradle.kts
@@ -84,11 +84,3 @@ android {
         debugImplementation(compose.uiTooling)
     }
 }
-
-kover {
-    currentProject {
-        createVariant("soil") {
-            add("debug")
-        }
-    }
-}

--- a/soil-experimental/soil-reacty/build.gradle.kts
+++ b/soil-experimental/soil-reacty/build.gradle.kts
@@ -103,11 +103,3 @@ android {
         debugImplementation(compose.uiTooling)
     }
 }
-
-kover {
-    currentProject {
-        createVariant("soil") {
-            add("debug")
-        }
-    }
-}

--- a/soil-form/build.gradle.kts
+++ b/soil-form/build.gradle.kts
@@ -119,11 +119,3 @@ android {
         debugImplementation(compose.uiTooling)
     }
 }
-
-kover {
-    currentProject {
-        createVariant("soil") {
-            add("debug")
-        }
-    }
-}

--- a/soil-query-compose/build.gradle.kts
+++ b/soil-query-compose/build.gradle.kts
@@ -114,11 +114,3 @@ android {
         debugImplementation(compose.uiTooling)
     }
 }
-
-kover {
-    currentProject {
-        createVariant("soil") {
-            add("debug")
-        }
-    }
-}

--- a/soil-query-core/build.gradle.kts
+++ b/soil-query-core/build.gradle.kts
@@ -87,11 +87,3 @@ android {
         unitTests.isIncludeAndroidResources = true
     }
 }
-
-kover {
-    currentProject {
-        createVariant("soil") {
-            add("debug")
-        }
-    }
-}

--- a/soil-query-receivers/ktor/build.gradle.kts
+++ b/soil-query-receivers/ktor/build.gradle.kts
@@ -52,11 +52,3 @@ android {
         unitTests.isIncludeAndroidResources = true
     }
 }
-
-kover {
-    currentProject {
-        createVariant("soil") {
-            add("debug")
-        }
-    }
-}

--- a/soil-query-test/build.gradle.kts
+++ b/soil-query-test/build.gradle.kts
@@ -58,11 +58,3 @@ android {
         unitTests.isIncludeAndroidResources = true
     }
 }
-
-kover {
-    currentProject {
-        createVariant("soil") {
-            add("debug")
-        }
-    }
-}

--- a/soil-serialization-bundle/build.gradle.kts
+++ b/soil-serialization-bundle/build.gradle.kts
@@ -57,11 +57,3 @@ android {
         unitTests.isIncludeAndroidResources = true
     }
 }
-
-kover {
-    currentProject {
-        createVariant("soil") {
-            add("debug")
-        }
-    }
-}

--- a/soil-space/build.gradle.kts
+++ b/soil-space/build.gradle.kts
@@ -82,11 +82,3 @@ android {
         debugImplementation(compose.uiTooling)
     }
 }
-
-kover {
-    currentProject {
-        createVariant("soil") {
-            add("debug")
-        }
-    }
-}


### PR DESCRIPTION
This PR refactors the Kover (code coverage) configuration to centralize it in the root build.gradle.kts file, removing redundant configurations from individual module build files.
