### PR TITLE
Fix Codecov v5 configuration

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -31,4 +31,4 @@ jobs:
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./build/reports/kover/report.xml
+          files: ./build/reports/kover/report.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,9 @@
-coverage:
+coverage:  
   status:
+    # https://docs.codecov.com/docs/commit-status#disabling-a-status
     project: off
     patch: off
-    
+parsers:
+  jacoco:
+    # https://docs.codecov.com/docs/codecovyml-reference#parsersjacoco
+    partials_as_hits: true


### PR DESCRIPTION
Updated the codecov-action parameter from `file` to `files` to match v5 API requirements.

> [!WARNING] > The following arguments have been changed
>
>file (this has been deprecated in favor of files)
>plugin (this has been deprecated in favor of plugins)

ref: https://github.com/codecov/codecov-action#migration-guide