### PR TITLE
Add Dokka source links to GitHub 🪄 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,27 @@ allprojects {
         }
     }
 
+    // NOTE: Source code link to GitHub
+    // https://kotlinlang.org/docs/dokka-migration.html#source-links
+    plugins.withId("org.jetbrains.dokka") {
+        val githubSourceUrl = providers.zip(
+            providers.gradleProperty("source"),
+            providers.gradleProperty("version")
+        ) { source, version ->
+            val modulePath = project.path.replace(":", "/")
+            "${source}${version}${modulePath}/src"
+        }
+        configure<org.jetbrains.dokka.gradle.DokkaExtension> {
+            dokkaSourceSets.all {
+                sourceLink {
+                    localDirectory.set(file("src"))
+                    remoteUrl(githubSourceUrl)
+                    remoteLineSuffix.set("#L")
+                }
+            }
+        }
+    }
+
     apply(plugin = "com.diffplug.spotless")
     configure<com.diffplug.gradle.spotless.SpotlessExtension> {
         format("format") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ development=true
 #Product
 group=com.soil-kt.soil
 version=1.0.0-alpha12
+source=https://github.com/soil-kt/soil/blob/
 #Maven Publish - https://vanniktech.github.io/gradle-maven-publish-plugin/central/#configuring-maven-central
 SONATYPE_HOST=CENTRAL_PORTAL
 RELEASE_SIGNING_ENABLED=true


### PR DESCRIPTION
This PR enhances the generated API documentation by adding source links that connect documentation to the corresponding source code on GitHub.

<img width="640" src="https://github.com/user-attachments/assets/7f43e400-d428-4a9b-9150-da85eb487fd1"></img>

This improvement makes it easier for library users to navigate from the API documentation directly to the implementation details.