### PR TITLE
Update iOS test target to use ARM64 simulator

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run tests on macos
         if: matrix.os == 'macos-15' && matrix.job == 'test'
-        run: ./gradlew iosX64Test
+        run: ./gradlew iosSimulatorArm64Test
 
       # ubuntu-latest
       - name: Run tests on linux


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use the ARM64 iOS simulator test target instead of the x64 variant, ensuring compatibility with Apple Silicon-based macOS runners.

https://github.com/soil-kt/soil/blob/dd350e3816f6e8ce922633bdba5c482c5211a45c/.github/workflows/check-pr.yml#L40

ref: https://github.com/actions/runner-images#available-images