### PR TITLE
Add Compose Hot Reload support for desktop development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ sample.android.run:
 sample.desktop.run:
 	@$(GRADLE_CMD) runDistributable
 
+.PHONY: sample.desktop.hotRun
+sample.desktop.hotRun:
+	@$(GRADLE_CMD) hotRunDesktop --auto
+
+
 .PHONY: sample.wasm.dist
 sample.wasm.dist:
 	@$(GRADLE_CMD) wasmJsBrowserDistribution

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.compose.multiplatform) apply false
+    alias(libs.plugins.compose.hotReload) apply false
     alias(libs.plugins.kotlin.compose.compiler) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.kotlin.serialization) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ androidx-lifecycle = "2.9.1"
 androidx-test = "1.6.1"
 androidx-test-ext-junit = "1.2.1"
 compose = "1.8.2"
+compose-hotReload = "1.0.0-beta04"
 compose-multiplatform = "1.8.2"
 dokka = "2.0.0"
 jbx-core-bundle = "1.1.0-alpha03"
@@ -70,6 +71,7 @@ turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 android-application = { id = "com.android.application", version.ref = "android-gradle" }
 android-library = { id = "com.android.library", version.ref = "android-gradle" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+compose-hotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "compose-hotReload" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.compose.hotReload)
     alias(libs.plugins.kotlin.compose.compiler)
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,10 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "soil"
 
 // https://docs.gradle.org/7.4/userguide/declaring_dependencies.html#sec:type-safe-project-accessors


### PR DESCRIPTION
Integrate [Compose Hot Reload](https://github.com/JetBrains/compose-hot-reload) plugin to enable live code reloading during desktop development. This improves developer experience by allowing instant UI updates without full application restarts.