### PR TITLE
Add buildLibs task for optimized public module builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 
 .PHONY: build
 build:
-	@$(GRADLE_CMD) assemble
+	@$(GRADLE_CMD) buildLibs
 
 .PHONY: test
 test:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,6 +101,16 @@ allprojects {
     }
 }
 
+tasks.register("buildLibs") {
+    group = "build"
+    description = "Build all public modules"
+    dependsOn(
+        subprojects
+            .filter { it.path in publicModules }
+            .map { it.tasks.named("build") }
+    )
+}
+
 dependencies {
     for (module in publicModules) {
         kover(project(module))


### PR DESCRIPTION
Introduces a new `buildLibs` Gradle task that specifically builds only the public modules.
