### PR TITLE
Add manual gradle task workflow for flaky test debugging

### DIFF
--- a/.github/workflows/run-gradle.yml
+++ b/.github/workflows/run-gradle.yml
@@ -1,0 +1,48 @@
+name: Run Gradle Task
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: 'Task to run (e.g., iosSimulatorArm64)'
+        required: true
+        type: string
+
+jobs:
+  run-gradle:
+    runs-on: macos-15
+    timeout-minutes: 60
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set project key
+        id: pj-key
+        run: |
+          echo "KOTLIN_VERSION=$(grep "^kotlin =" gradle/libs.versions.toml | awk -F '=' '{print $2}' | tr -d ' "')" >> $GITHUB_OUTPUT
+
+      - name: Setup java
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - name: Setup gradle
+        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+
+      - name: Cache konan
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          # ref. https://kotlinlang.org/docs/native-improving-compilation-time.html#preserve-downloaded-and-cached-components-between-builds
+          path: ~/.konan
+          key: v1-${{ runner.os }}-konan-${{ steps.pj-key.outputs.KOTLIN_VERSION }}
+
+      - name: Set Xcode version
+        # ref. https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-compatibility-guide.html#version-compatibility
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app
+
+      - name: Run task on macos
+        run: ./gradlew ${{ github.event.inputs.task }}


### PR DESCRIPTION
Only `iosSimulatorArm64` target sometimes test fails when running CI.
So, this workflow adds to investigate the cause.

```
soil.plant.compose.lazy.LazyLoadTest.testLazyLoad_withLazyList[iosSimulatorArm64] FAILED
    kotlin.AssertionError at /opt/buildAgent/work/7377bd4dc65e1c03/kotlin/kotlin-native/runtime/src/main/kotlin/kotlin/Exceptions.kt:14        
```

refs: 
- https://github.com/soil-kt/soil/actions/runs/17340704331
- https://github.com/soil-kt/soil/actions/runs/17351549818