### PR TITLE
Add Gradle Build Scan integration with Develocity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_16.3.app
 
       - name: Run build
-        run: ./gradlew buildLibs
+        run: ./gradlew --scan buildLibs
 
       - name: Generate test coverage report
         run: ./gradlew koverXmlReport

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,29 @@ dependencyResolutionManagement {
 }
 
 plugins {
+    id("com.gradle.develocity") version "4.1.1"
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
+val version: String by extra.properties
+develocity {
+    buildScan {
+        termsOfUseUrl = "https://gradle.com/terms-of-service"
+        termsOfUseAgree = "yes"
+
+        tag(if (System.getenv("CI").isNullOrBlank()) "Local" else "CI")
+        tag(version)
+
+        obfuscation {
+            username { "Redacted" }
+            hostname { "Redacted" }
+            ipAddresses { addresses -> addresses.map { "0.0.0.0" } }
+        }
+
+        // You can then add the --scan argument to any Gradle build to publish a Build Scan.
+        // https://docs.gradle.com/develocity/gradle-plugin/current/
+        publishing.onlyIf { false }
+    }
 }
 
 rootProject.name = "soil"


### PR DESCRIPTION
This PR integrates Gradle Build Scans via Develocity to provide better visibility into build performance and issues, particularly for debugging flaky tests and build failures in CI.
