### PR TITLE
Add Kotlin Native build cache to improve CI performance

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -30,6 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Set project key
+        id: pj-key
+        run: |
+          echo "KOTLIN_VERSION=$(grep "^kotlin =" gradle/libs.versions.toml | awk -F '=' '{print $2}' | tr -d ' "')" >> $GITHUB_OUTPUT
       - name: Copy CI gradle.properties
         if: matrix.os == 'ubuntu-latest' && matrix.job == 'test'
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
@@ -42,6 +46,13 @@ jobs:
 
       - name: Setup gradle
         uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+
+      - name: Cache konan
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          # ref. https://kotlinlang.org/docs/native-improving-compilation-time.html#preserve-downloaded-and-cached-components-between-builds
+          path: ~/.konan
+          key: v1-${{ runner.os }}-konan-${{ steps.pj-key.outputs.KOTLIN_VERSION }}
 
       # macos-15
       - name: Set Xcode version


### PR DESCRIPTION
Implements caching for Kotlin Native compiler components (~/.konan) in the CI workflow to reduce build times. The cache key is versioned and includes the Kotlin version to ensure cache invalidation on compiler updates.