### PR TITLE
Add test report artifacts to CI workflows for improved debugging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,12 @@ jobs:
 
       - name: Generate test coverage report
         run: ./gradlew koverXmlReport
+
+      - name: Upload reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-build
+          path: |
+            **/build/reports/**
+          retention-days: 5

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -34,3 +34,12 @@ jobs:
 
       - name: Check spotless rules
         run: ./gradlew spotlessCheck
+
+      - name: Upload reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-build
+          path: |
+            **/build/reports/**
+          retention-days: 5

--- a/.github/workflows/run-gradle.yml
+++ b/.github/workflows/run-gradle.yml
@@ -46,3 +46,12 @@ jobs:
 
       - name: Run task on macos
         run: ./gradlew ${{ github.event.inputs.task }}
+
+      - name: Upload reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-build
+          path: |
+            **/build/reports/**
+          retention-days: 5

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -68,3 +68,12 @@ jobs:
       - name: Run tests on linux
         if: matrix.os == 'ubuntu-latest' && matrix.job == 'test'
         run: ./gradlew testDebugUnitTest desktopTest wasmJsTest
+
+      - name: Upload reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-build
+          path: |
+            **/build/reports/**
+          retention-days: 5


### PR DESCRIPTION
Upload build reports as artifacts when CI workflows fail to improve debugging capabilities. Reports are retained for 5 days to help diagnose intermittent failures and flaky tests across all workflows.