### PR TITLE
Simplify LazyListThreshold and LazyGridThreshold

### DIFF
--- a/soil-experimental/soil-lazyload/src/commonMain/kotlin/soil/plant/compose/lazy/LazyListLoad.kt
+++ b/soil-experimental/soil-lazyload/src/commonMain/kotlin/soil/plant/compose/lazy/LazyListLoad.kt
@@ -46,16 +46,13 @@ inline fun <T : Any> LazyLoad(
 /**
  * Configuration class for determining when to load more items in a [LazyColumn] or [LazyRow].
  *
- * Loading more items is triggered when both of the following conditions are met:
- * - The number of remaining items is less than or equal to [remainingItems]
- * - The ratio of remaining items to total items is less than or equal to [remainingRatio]
+ * Loading more items is triggered when the number of remaining items
+ * is less than or equal to [remainingItems].
  *
  * @property remainingItems Threshold for the number of remaining items before triggering load more
- * @property remainingRatio Threshold for the ratio of remaining items to total items (0.2f = 20%)
  */
 class LazyListThreshold(
-    val remainingItems: Int = 6,
-    val remainingRatio: Float = 0.2f
+    val remainingItems: Int = 6
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -63,16 +60,11 @@ class LazyListThreshold(
 
         other as LazyListThreshold
 
-        if (remainingItems != other.remainingItems) return false
-        if (remainingRatio != other.remainingRatio) return false
-
-        return true
+        return remainingItems == other.remainingItems
     }
 
     override fun hashCode(): Int {
-        var result = remainingItems
-        result = 31 * result + remainingRatio.hashCode()
-        return result
+        return remainingItems
     }
 }
 
@@ -80,7 +72,7 @@ class LazyListThreshold(
  * Creates a default [LazyLoadStrategy] for lazy lists based on the specified [threshold].
  *
  * The strategy evaluates the current state of the lazy list and determines if more items
- * should be loaded based on the remaining items count and ratio.
+ * should be loaded based on the remaining items count.
  *
  * @param threshold Configuration that determines when to trigger loading more items
  * @return A [LazyLoadStrategy] for lazy lists
@@ -89,13 +81,13 @@ class LazyListThreshold(
 internal fun defaultLazyListStrategy(threshold: LazyListThreshold) = LazyLoadStrategy<LazyListState> { state ->
     val layoutInfo = state.layoutInfo
     val totalItemsNumber = layoutInfo.totalItemsCount
-    val lastVisibleItemIndex = (layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0) + 1
-    val remainingItems = totalItemsNumber - lastVisibleItemIndex
-    val remainingRatio = if (totalItemsNumber > 0) {
-        remainingItems.toFloat() / totalItemsNumber.toFloat()
-    } else {
-        0f
+
+    if (totalItemsNumber == 0 || layoutInfo.visibleItemsInfo.isEmpty()) {
+        return@LazyLoadStrategy false
     }
-    remainingItems <= threshold.remainingItems &&
-        remainingRatio <= threshold.remainingRatio
+
+    val nextItemIndex = layoutInfo.visibleItemsInfo.last().index + 1
+    val remainingItems = totalItemsNumber - nextItemIndex
+
+    remainingItems <= threshold.remainingItems
 }

--- a/soil-experimental/soil-lazyload/src/commonTest/kotlin/soil/plant/compose/lazy/LazyGridStrategyTest.kt
+++ b/soil-experimental/soil-lazyload/src/commonTest/kotlin/soil/plant/compose/lazy/LazyGridStrategyTest.kt
@@ -1,0 +1,273 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.plant.compose.lazy
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class LazyGridStrategyTest : UnitTest() {
+
+    @Test
+    fun testDefaultLazyGridStrategy_emptyGrid_returnsFalse() = runComposeUiTest {
+        val strategy = defaultLazyGridStrategy(LazyGridThreshold())
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyGridState()
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                // Empty grid
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        assertTrue { result == false }
+    }
+
+    @Test
+    fun testDefaultLazyGridStrategy_farFromEnd_returnsFalse() = runComposeUiTest {
+        val strategy = defaultLazyGridStrategy(LazyGridThreshold(remainingItems = 6))
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyGridState()
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(60) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // In initial state, only first few items are visible, so it returns false
+        assertTrue { result == false }
+    }
+
+    @Test
+    fun testDefaultLazyGridStrategy_nearEnd_returnsTrue() = runComposeUiTest {
+        val strategy = defaultLazyGridStrategy(LazyGridThreshold(remainingItems = 6))
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyGridState(
+                // Start near the end (considering grid has 2 columns)
+                initialFirstVisibleItemIndex = 54
+            )
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(60) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true when remaining items are 6 or less
+        assertTrue { result == true }
+    }
+
+    @Test
+    fun testDefaultLazyGridStrategy_atEnd_returnsTrue() = runComposeUiTest {
+        val strategy = defaultLazyGridStrategy(LazyGridThreshold())
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyGridState(
+                // Start from the last items
+                initialFirstVisibleItemIndex = 58
+            )
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(60) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true when the last items are visible
+        assertTrue { result == true }
+    }
+
+    @Test
+    fun testDefaultLazyGridStrategy_smallGrid_allVisible() = runComposeUiTest {
+        val strategy = defaultLazyGridStrategy(LazyGridThreshold(remainingItems = 6))
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyGridState()
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                state = state,
+                modifier = Modifier.height(500.dp)
+            ) {
+                // Small grid where all items are visible
+                items(10) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true when all items are visible (0 remaining)
+        assertTrue { result == true }
+    }
+
+    @Test
+    fun testDefaultLazyGridStrategy_customThreshold_zeroItems() = runComposeUiTest {
+        val strategy = defaultLazyGridStrategy(
+            LazyGridThreshold(remainingItems = 0)
+        )
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyGridState(
+                initialFirstVisibleItemIndex = 59
+            )
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(60) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true only when exactly 0 items remain
+        assertTrue { result == true }
+    }
+
+    @Test
+    fun testDefaultLazyGridStrategy_highRatio() = runComposeUiTest {
+        val strategy = defaultLazyGridStrategy(
+            LazyGridThreshold(remainingItems = 10)
+        )
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyGridState()
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(20) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true when remaining items condition is met
+        assertTrue { result == true }
+    }
+
+    @Test
+    fun testDefaultLazyGridStrategy_largeThreshold_returnsFalse() = runComposeUiTest {
+        // Large threshold that won't be met in initial state
+        val strategy = defaultLazyGridStrategy(
+            LazyGridThreshold(remainingItems = 100)
+        )
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyGridState()
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(200) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns false when threshold is not met
+        assertTrue { result == false }
+    }
+
+    @Test
+    fun testDefaultLazyGridStrategy_smallThreshold_returnsTrue() = runComposeUiTest {
+        // Small threshold with position near end
+        val strategy = defaultLazyGridStrategy(
+            LazyGridThreshold(remainingItems = 5)
+        )
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyGridState(
+                initialFirstVisibleItemIndex = 195
+            )
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(200) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true when remaining items <= threshold
+        assertTrue { result == true }
+    }
+
+    @Test
+    fun testDefaultLazyGridStrategy_multiColumn_returnsCorrectResult() = runComposeUiTest {
+        val strategy = defaultLazyGridStrategy(LazyGridThreshold(remainingItems = 8))
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyGridState(
+                // Near the end with 3 columns
+                initialFirstVisibleItemIndex = 87
+            )
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(90) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true when remaining items are close to threshold
+        assertTrue { result == true }
+    }
+}

--- a/soil-experimental/soil-lazyload/src/commonTest/kotlin/soil/plant/compose/lazy/LazyListStrategyTest.kt
+++ b/soil-experimental/soil-lazyload/src/commonTest/kotlin/soil/plant/compose/lazy/LazyListStrategyTest.kt
@@ -1,0 +1,239 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.plant.compose.lazy
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class LazyListStrategyTest : UnitTest() {
+
+    @Test
+    fun testDefaultLazyListStrategy_emptyList_returnsFalse() = runComposeUiTest {
+        val strategy = defaultLazyListStrategy(LazyListThreshold())
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyListState()
+            LazyColumn(
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                // Empty list
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        assertTrue { result == false }
+    }
+
+    @Test
+    fun testDefaultLazyListStrategy_farFromEnd_returnsFalse() = runComposeUiTest {
+        val strategy = defaultLazyListStrategy(LazyListThreshold(remainingItems = 6))
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyListState()
+            LazyColumn(
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(30) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // In initial state, only first few items are visible, so it returns false
+        assertTrue { result == false }
+    }
+
+    @Test
+    fun testDefaultLazyListStrategy_nearEnd_returnsTrue() = runComposeUiTest {
+        val strategy = defaultLazyListStrategy(LazyListThreshold(remainingItems = 6))
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyListState(
+                // Start near the end
+                initialFirstVisibleItemIndex = 24
+            )
+            LazyColumn(
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(30) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true when remaining items are 6 or less
+        assertTrue { result == true }
+    }
+
+    @Test
+    fun testDefaultLazyListStrategy_atEnd_returnsTrue() = runComposeUiTest {
+        val strategy = defaultLazyListStrategy(LazyListThreshold())
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyListState(
+                // Start from the last item
+                initialFirstVisibleItemIndex = 29
+            )
+            LazyColumn(
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(30) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true when the last item is visible
+        assertTrue { result == true }
+    }
+
+    @Test
+    fun testDefaultLazyListStrategy_smallList_allVisible() = runComposeUiTest {
+        val strategy = defaultLazyListStrategy(LazyListThreshold(remainingItems = 6))
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyListState()
+            LazyColumn(
+                state = state,
+                modifier = Modifier.height(500.dp)
+            ) {
+                // Small list where all items are visible
+                items(5) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true when all items are visible (0 remaining)
+        assertTrue { result == true }
+    }
+
+    @Test
+    fun testDefaultLazyListStrategy_customThreshold_zeroItems() = runComposeUiTest {
+        val strategy = defaultLazyListStrategy(
+            LazyListThreshold(remainingItems = 0)
+        )
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyListState(
+                initialFirstVisibleItemIndex = 29
+            )
+            LazyColumn(
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(30) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true only when exactly 0 items remain
+        assertTrue { result == true }
+    }
+
+    @Test
+    fun testDefaultLazyListStrategy_highRatio() = runComposeUiTest {
+        val strategy = defaultLazyListStrategy(
+            LazyListThreshold(remainingItems = 10)
+        )
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyListState()
+            LazyColumn(
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(10) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true when remaining items condition is met
+        assertTrue { result == true }
+    }
+
+    @Test
+    fun testDefaultLazyListStrategy_largeThreshold_returnsFalse() = runComposeUiTest {
+        // Small threshold that won't be met in middle position
+        val strategy = defaultLazyListStrategy(
+            LazyListThreshold(remainingItems = 3)
+        )
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyListState(
+                initialFirstVisibleItemIndex = 50
+            )
+            LazyColumn(
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(100) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns false when threshold is not met (50 remaining > 3)
+        assertTrue { result == false }
+    }
+
+    @Test
+    fun testDefaultLazyListStrategy_smallThreshold_returnsTrue() = runComposeUiTest {
+        // Small threshold with position near end
+        val strategy = defaultLazyListStrategy(
+            LazyListThreshold(remainingItems = 5)
+        )
+        var result: Boolean? = null
+        setContent {
+            val state = rememberLazyListState(
+                initialFirstVisibleItemIndex = 95
+            )
+            LazyColumn(
+                state = state,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(100) { index ->
+                    Box(modifier = Modifier.height(50.dp))
+                }
+            }
+            result = strategy.shouldLoadMore(state)
+        }
+
+        waitForIdle()
+        // Returns true when remaining items <= threshold
+        assertTrue { result == true }
+    }
+}


### PR DESCRIPTION
Remove the `remainingRatio` parameter from both `LazyListThreshold` and `LazyGridThreshold` classes, and rely solely on `remainingItems` for load-more detection.

The ratio condition becomes problematic as the dataset grows:

- With 150+ items and a 0.2 ratio, it triggers when 30+ items remain
- With 300+ items, it triggers when 60+ items remain
- This may cause infinite loading loops if the batch size is smaller than the ratio threshold

Because of this, large datasets often triggered loading too early, while the AND condition made the ratio check effectively unused in most cases.

This change ensures more consistent and predictable infinite scrolling behavior in both `LazyList` and `LazyGrid`, regardless of dataset size.