### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   check:
     runs-on: macos-15
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/deploy-sample-wasm.yml
+++ b/.github/workflows/deploy-sample-wasm.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     env:
       RELEASE_PAGES_BRANCH: main


### PR DESCRIPTION
Add 'contents: read' permissions to check-release and deploy-sample-wasm workflows to follow GitHub Actions security best practices and principle of the least privilege.