### PR TITLE
Redesign network connectivity API

### DIFF
--- a/sample/composeApp/src/iosMain/kotlin/MainViewController.kt
+++ b/sample/composeApp/src/iosMain/kotlin/MainViewController.kt
@@ -4,6 +4,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import soil.playground.createHttpClient
 import soil.query.IosMemoryPressure
+import soil.query.IosNetworkConnectivity
 import soil.query.IosWindowVisibility
 import soil.query.SwrCachePlus
 import soil.query.SwrCachePlusPolicy
@@ -17,6 +18,7 @@ private val swrClient = SwrCachePlus(
     policy = SwrCachePlusPolicy(
         coroutineScope = SwrCacheScope(),
         memoryPressure = IosMemoryPressure(),
+        networkConnectivity = IosNetworkConnectivity(),
         windowVisibility = IosWindowVisibility()
     ) {
         httpClient = createHttpClient {

--- a/soil-query-core/src/androidMain/kotlin/soil/query/AndroidNetworkConnectivity.kt
+++ b/soil-query-core/src/androidMain/kotlin/soil/query/AndroidNetworkConnectivity.kt
@@ -3,14 +3,18 @@
 
 package soil.query
 
+import android.Manifest
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import androidx.annotation.RequiresPermission
+import soil.query.core.AbstractNotifier
+import soil.query.core.Listener
 import soil.query.core.NetworkConnectivity
 import soil.query.core.NetworkConnectivityEvent
+import soil.query.core.Notifier
 
 /**
  * Implementation of [NetworkConnectivity] for Android.
@@ -25,41 +29,90 @@ import soil.query.core.NetworkConnectivityEvent
  */
 class AndroidNetworkConnectivity(
     private val context: Context
-) : NetworkConnectivity {
+) : AbstractNotifier<NetworkConnectivityEvent>(), NetworkConnectivity {
 
-    private val request = NetworkRequest.Builder()
-        .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-        .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
-        .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
-        .build()
+    private var monitor: Monitor? = null
 
-    private val manager: ConnectivityManager
-        get() = context.getSystemService(ConnectivityManager::class.java)
-
-    private var obw: ObserverWrapper? = null
-
-    @RequiresPermission(android.Manifest.permission.ACCESS_NETWORK_STATE)
-    override fun addObserver(observer: NetworkConnectivity.Observer) {
-        manager.registerNetworkCallback(request, ObserverWrapper(observer).also { obw = it })
+    @RequiresPermission(Manifest.permission.ACCESS_NETWORK_STATE)
+    override fun addListener(listener: Listener<NetworkConnectivityEvent>) {
+        super.addListener(listener)
+        if (monitor == null) {
+            monitor = Monitor.create(context = context, notifier = this)
+            monitor?.start()
+        }
     }
 
-    override fun removeObserver(observer: NetworkConnectivity.Observer) {
-        obw?.let { manager.unregisterNetworkCallback(it) }
-        obw = null
+    override fun removeListener(listener: Listener<NetworkConnectivityEvent>) {
+        super.removeListener(listener)
+        if (!hasListeners()) {
+            monitor?.stop()
+            monitor = null
+        }
     }
 
-    /**
-     * Implementation of [ConnectivityManager.NetworkCallback] for observing network connectivity.
-     */
-    class ObserverWrapper(
-        private val observer: NetworkConnectivity.Observer
+    internal class Monitor(
+        private val connectivityManager: ConnectivityManager,
+        private val notifier: Notifier<NetworkConnectivityEvent>
     ) : ConnectivityManager.NetworkCallback() {
-        override fun onAvailable(network: Network) {
-            observer.onReceive(NetworkConnectivityEvent.Available)
+        private var isOnline: Boolean? = null
+
+        @RequiresPermission(Manifest.permission.ACCESS_NETWORK_STATE)
+        override fun onLost(network: Network) {
+            if (hasValidatedNetwork()) return
+            if (isOnline == false) return
+            isOnline = false
+            notifyListeners()
         }
 
-        override fun onLost(network: Network) {
-            observer.onReceive(NetworkConnectivityEvent.Lost)
+        override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
+            if (!networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)) return
+            if (isOnline == true) return
+            isOnline = true
+            notifyListeners()
+        }
+
+        @RequiresPermission(Manifest.permission.ACCESS_NETWORK_STATE)
+        fun start() {
+            if (isOnline == null) {
+                isOnline = hasValidatedNetwork()
+                notifyListeners()
+            }
+            connectivityManager.registerNetworkCallback(
+                NetworkRequest.Builder()
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .build(),
+                this
+            )
+        }
+
+        fun stop() {
+            connectivityManager.unregisterNetworkCallback(this)
+            isOnline = null
+        }
+
+        private fun notifyListeners() {
+            when (isOnline) {
+                true -> notifier.notify(NetworkConnectivityEvent.Available)
+                false -> notifier.notify(NetworkConnectivityEvent.Lost)
+                null -> Unit
+            }
+        }
+
+        @RequiresPermission(Manifest.permission.ACCESS_NETWORK_STATE)
+        private fun hasValidatedNetwork(): Boolean {
+            val activeNetwork = connectivityManager.activeNetwork ?: return false
+            val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return false
+            return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        }
+
+        companion object {
+            fun create(
+                context: Context,
+                notifier: Notifier<NetworkConnectivityEvent>
+            ) = Monitor(
+                connectivityManager = context.getSystemService(ConnectivityManager::class.java),
+                notifier = notifier
+            )
         }
     }
 }

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/Listenable.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/Listenable.kt
@@ -1,0 +1,54 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * Interface for objects that support listener-based event observation.
+ *
+ * This interface provides a mechanism to register and unregister listeners
+ * that will be notified when events of type [E] occur. It follows the
+ * observer pattern and is designed to be used with event-driven architectures.
+ *
+ * @param E The type of event that listeners will receive
+ */
+interface Listenable<E> {
+    /**
+     * Registers a [listener] to receive events.
+     *
+     * The listener will be notified whenever an event of type [E] occurs.
+     * Multiple listeners can be registered, and they will all receive the same events.
+     *
+     * @param listener The listener to register for receiving events
+     */
+    fun addListener(listener: Listener<E>)
+
+    /**
+     * Unregisters a [listener] from receiving events.
+     *
+     * After calling this method, the listener will no longer be notified of events.
+     * If the listener was not previously registered, this method should have no effect.
+     *
+     * @param listener The listener to unregister from receiving events
+     */
+    fun removeListener(listener: Listener<E>)
+}
+
+/**
+ * Converts this [Listenable] into a [Flow] that emits events.
+ *
+ * This extension function creates a cold Flow that will register a listener
+ * when collection starts and automatically unregister it when collection stops.
+ * The Flow will emit all events received by the listener during the collection period.
+ *
+ * @return A Flow that emits events of type [E] from this Listenable
+ */
+fun <E> Listenable<E>.asFlow(): Flow<E> = callbackFlow {
+    val fn = Listener<E> { trySend(it) }
+    addListener(fn)
+    awaitClose { removeListener(fn) }
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/Listener.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/Listener.kt
@@ -1,0 +1,25 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+/**
+ * Functional interface for receiving events from a [Listenable] source.
+ *
+ * This interface represents a callback that will be invoked when an event occurs.
+ * It uses Kotlin's functional interface feature, allowing it to be implemented
+ * using lambda expressions for concise event handling.
+ *
+ * @param E The type of event this listener can handle
+ */
+fun interface Listener<E> {
+    /**
+     * Called when an event occurs.
+     *
+     * This method will be invoked by the event source whenever an event
+     * of type [E] needs to be delivered to this listener.
+     *
+     * @param event The event that occurred
+     */
+    fun onEvent(event: E)
+}

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/NetworkConnectivity.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/NetworkConnectivity.kt
@@ -3,11 +3,8 @@
 
 package soil.query.core
 
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.onEach
@@ -17,49 +14,14 @@ import kotlin.time.Duration
 /**
  * Interface for receiving events of network connectivity.
  */
-interface NetworkConnectivity {
-
-    /**
-     * Adds an [observer] to receive events.
-     */
-    fun addObserver(observer: Observer)
-
-    /**
-     * Removes an [observer] that receives events.
-     */
-    fun removeObserver(observer: Observer)
-
-    /**
-     * Provides a Flow to receive events of network connectivity.
-     */
-    fun asFlow(): Flow<NetworkConnectivityEvent> = callbackFlow {
-        val observer = object : Observer {
-            override fun onReceive(event: NetworkConnectivityEvent) {
-                trySend(event)
-            }
-        }
-        addObserver(observer)
-        awaitClose { removeObserver(observer) }
-    }
-
-    /**
-     * Observer interface for receiving events of network connectivity.
-     */
-    interface Observer {
-
-        /**
-         * Receives a [event] of network connectivity.
-         */
-        fun onReceive(event: NetworkConnectivityEvent)
-    }
+interface NetworkConnectivity : Listenable<NetworkConnectivityEvent> {
 
     /**
      * An object indicating unsupported for the capability of network connectivity.
      */
     companion object Unsupported : NetworkConnectivity {
-        override fun addObserver(observer: Observer) = Unit
-
-        override fun removeObserver(observer: Observer) = Unit
+        override fun addListener(listener: Listener<NetworkConnectivityEvent>) = Unit
+        override fun removeListener(listener: Listener<NetworkConnectivityEvent>) = Unit
     }
 }
 

--- a/soil-query-core/src/commonMain/kotlin/soil/query/core/Notifier.kt
+++ b/soil-query-core/src/commonMain/kotlin/soil/query/core/Notifier.kt
@@ -1,0 +1,61 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+/**
+ * Interface for objects that can notify about events.
+ *
+ * This interface represents the producer side of the observer pattern,
+ * providing the ability to send events to registered listeners.
+ *
+ * @param E The type of event that can be notified
+ */
+interface Notifier<E> {
+    /**
+     * Notifies all registered listeners about an [event].
+     *
+     * This method should deliver the event to all currently registered
+     * listeners. The implementation should handle any exceptions thrown
+     * by individual listeners to prevent one listener from affecting others.
+     *
+     * @param event The event to send to all listeners
+     */
+    fun notify(event: E)
+}
+
+/**
+ * Abstract implementation of [Notifier] that also implements [Listenable].
+ *
+ * This class provides a complete implementation of the observer pattern,
+ * combining both the ability to register/unregister listeners (from [Listenable])
+ * and the ability to notify them of events (from [Notifier]).
+ *
+ * The implementation maintains a set of listeners and ensures safe event
+ * delivery even if individual listeners throw exceptions.
+ *
+ * @param E The type of event this notifier handles
+ */
+abstract class AbstractNotifier<E> : Notifier<E>, Listenable<E> {
+    private val listeners = mutableSetOf<Listener<E>>()
+
+    /**
+     * Checks if there are any registered listeners.
+     *
+     * @return true if at least one listener is registered, false otherwise
+     */
+    fun hasListeners(): Boolean = listeners.isNotEmpty()
+
+    override fun addListener(listener: Listener<E>) {
+        listeners += listener
+    }
+
+    override fun removeListener(listener: Listener<E>) {
+        listeners -= listener
+    }
+
+    override fun notify(event: E) {
+        val snapshot = listeners.toList()
+        snapshot.forEach { runCatching { it.onEvent(event) } }
+    }
+}

--- a/soil-query-core/src/commonTest/kotlin/soil/query/core/NetworkConnectivityTest.kt
+++ b/soil-query-core/src/commonTest/kotlin/soil/query/core/NetworkConnectivityTest.kt
@@ -1,0 +1,121 @@
+// Copyright 2025 Soil Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package soil.query.core
+
+import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import soil.testing.UnitTest
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NetworkConnectivityTest : UnitTest() {
+
+    @Test
+    fun testObserveOnNetworkReconnect() = runTest {
+        val mockConnectivity = MockConnectivity()
+        val flow = flow {
+            observeOnNetworkReconnect(
+                networkConnectivity = mockConnectivity,
+                networkResumeAfterDelay = 1.seconds,
+                collector = this
+            )
+        }
+
+        flow.test {
+            mockConnectivity.notify(NetworkConnectivityEvent.Lost)
+            mockConnectivity.notify(NetworkConnectivityEvent.Available)
+            advanceTimeBy(1.seconds)
+            awaitItem()
+        }
+    }
+
+    @Test
+    fun testObserveOnNetworkReconnect_noEventIfNoDisconnection() = runTest {
+        val mockConnectivity = MockConnectivity()
+        val flow = flow {
+            observeOnNetworkReconnect(
+                networkConnectivity = mockConnectivity,
+                networkResumeAfterDelay = 1.seconds,
+                collector = this
+            )
+        }
+
+        flow.test {
+            mockConnectivity.notify(NetworkConnectivityEvent.Available)
+            advanceTimeBy(2.seconds)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun testObserveOnNetworkReconnect_multipleReconnects() = runTest {
+        val mockConnectivity = MockConnectivity()
+        val flow = flow {
+            observeOnNetworkReconnect(
+                networkConnectivity = mockConnectivity,
+                networkResumeAfterDelay = 1.seconds,
+                collector = this
+            )
+        }
+
+        flow.test {
+            mockConnectivity.notify(NetworkConnectivityEvent.Lost)
+            mockConnectivity.notify(NetworkConnectivityEvent.Available)
+            advanceTimeBy(1.seconds)
+            awaitItem()
+
+            mockConnectivity.notify(NetworkConnectivityEvent.Lost)
+            mockConnectivity.notify(NetworkConnectivityEvent.Available)
+            advanceTimeBy(1.seconds)
+            awaitItem()
+        }
+    }
+
+    @Test
+    fun testObserveOnNetworkReconnect_noEventIfStaysDisconnected() = runTest {
+        val mockConnectivity = MockConnectivity()
+        val flow = flow {
+            observeOnNetworkReconnect(
+                networkConnectivity = mockConnectivity,
+                networkResumeAfterDelay = 1.seconds,
+                collector = this
+            )
+        }
+
+        flow.test {
+            mockConnectivity.notify(NetworkConnectivityEvent.Lost)
+            advanceTimeBy(5.seconds)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun testObserveOnNetworkReconnect_delayIsRespected() = runTest {
+        val mockConnectivity = MockConnectivity()
+        val flow = flow {
+            observeOnNetworkReconnect(
+                networkConnectivity = mockConnectivity,
+                networkResumeAfterDelay = 3.seconds,
+                collector = this
+            )
+        }
+
+        flow.test {
+            mockConnectivity.notify(NetworkConnectivityEvent.Lost)
+            mockConnectivity.notify(NetworkConnectivityEvent.Available)
+
+            advanceTimeBy(2.seconds)
+            expectNoEvents()
+
+            advanceTimeBy(1.seconds)
+            awaitItem()
+        }
+    }
+
+    private class MockConnectivity : AbstractNotifier<NetworkConnectivityEvent>(), NetworkConnectivity
+}

--- a/soil-query-core/src/iosMain/kotlin/soil/query/IosNetworkConnectivity.kt
+++ b/soil-query-core/src/iosMain/kotlin/soil/query/IosNetworkConnectivity.kt
@@ -3,4 +3,107 @@
 
 package soil.query
 
-// TODO: NWPathMonitor isn't included in the prebuilt libraries for Kotlin Native.
+import platform.Network.nw_path_get_status
+import platform.Network.nw_path_monitor_cancel
+import platform.Network.nw_path_monitor_create
+import platform.Network.nw_path_monitor_set_queue
+import platform.Network.nw_path_monitor_set_update_handler
+import platform.Network.nw_path_monitor_start
+import platform.Network.nw_path_monitor_t
+import platform.Network.nw_path_status_invalid
+import platform.Network.nw_path_status_satisfiable
+import platform.Network.nw_path_status_satisfied
+import platform.Network.nw_path_status_unsatisfied
+import platform.darwin.dispatch_get_main_queue
+import soil.query.core.AbstractNotifier
+import soil.query.core.Listener
+import soil.query.core.NetworkConnectivity
+import soil.query.core.NetworkConnectivityEvent
+import soil.query.core.Notifier
+
+/**
+ * Implementation of [NetworkConnectivity] for iOS using NWPathMonitor.
+ */
+class IosNetworkConnectivity : AbstractNotifier<NetworkConnectivityEvent>(), NetworkConnectivity {
+
+    private var monitor: Monitor? = null
+
+    override fun addListener(listener: Listener<NetworkConnectivityEvent>) {
+        super.addListener(listener)
+        if (monitor == null) {
+            monitor = Monitor.create(notifier = this)
+            monitor?.start()
+        }
+    }
+
+    override fun removeListener(listener: Listener<NetworkConnectivityEvent>) {
+        super.removeListener(listener)
+        if (!hasListeners()) {
+            monitor?.stop()
+            monitor = null
+        }
+    }
+
+    internal class Monitor(
+        private val notifier: Notifier<NetworkConnectivityEvent>
+    ) {
+        private var nwPathMonitor: nw_path_monitor_t? = null
+
+        private var isOnline: Boolean? = null
+
+        private val handleOnline: () -> Unit = {
+            if (isOnline != true) {
+                isOnline = true
+                notifyListeners()
+            }
+        }
+
+        private val handleOffline: () -> Unit = {
+            if (isOnline != false) {
+                isOnline = false
+                notifyListeners()
+            }
+        }
+
+        fun start() {
+            val monitor = nw_path_monitor_create().also { nwPathMonitor = it }
+            nw_path_monitor_set_queue(monitor, dispatch_get_main_queue())
+            nw_path_monitor_set_update_handler(monitor) { path ->
+                if (path != null) {
+                    when (nw_path_get_status(path)) {
+                        nw_path_status_satisfied -> handleOnline()
+                        nw_path_status_unsatisfied -> handleOffline()
+                        nw_path_status_satisfiable,
+                        nw_path_status_invalid -> Unit
+                    }
+                }
+            }
+            nw_path_monitor_start(nwPathMonitor)
+        }
+
+        fun stop() {
+            val monitor = nwPathMonitor
+            if (monitor != null) {
+                nw_path_monitor_cancel(monitor)
+            }
+            nwPathMonitor = null
+            isOnline = null
+        }
+
+        private fun notifyListeners() {
+            when (isOnline) {
+                true -> notifier.notify(NetworkConnectivityEvent.Available)
+                false -> notifier.notify(NetworkConnectivityEvent.Lost)
+                null -> Unit
+            }
+        }
+
+        companion object {
+            fun create(
+                notifier: Notifier<NetworkConnectivityEvent>
+            ) = Monitor(
+                notifier = notifier
+            )
+        }
+    }
+}

--- a/soil-query-core/src/wasmJsMain/kotlin/soil/query/WasmJsNetworkConnectivity.kt
+++ b/soil-query-core/src/wasmJsMain/kotlin/soil/query/WasmJsNetworkConnectivity.kt
@@ -4,36 +4,93 @@
 package soil.query
 
 import kotlinx.browser.window
+import org.w3c.dom.Window
 import org.w3c.dom.events.Event
+import soil.query.core.AbstractNotifier
+import soil.query.core.Listener
 import soil.query.core.NetworkConnectivity
 import soil.query.core.NetworkConnectivityEvent
+import soil.query.core.Notifier
 
 /**
  * Implementation of [NetworkConnectivity] for WasmJs.
  */
-class WasmJsNetworkConnectivity : NetworkConnectivity {
+class WasmJsNetworkConnectivity : AbstractNotifier<NetworkConnectivityEvent>(), NetworkConnectivity {
 
-    private var onlineListener: ((Event) -> Unit)? = null
-    private var offlineListener: ((Event) -> Unit)? = null
+    private var monitor: Monitor? = null
 
-    override fun addObserver(observer: NetworkConnectivity.Observer) {
-        onlineListener = { observer.onReceive(NetworkConnectivityEvent.Available) }
-        offlineListener = { observer.onReceive(NetworkConnectivityEvent.Lost) }
-        window.addEventListener(TYPE_ONLINE, onlineListener)
-        window.addEventListener(TYPE_OFFLINE, offlineListener)
+    override fun addListener(listener: Listener<NetworkConnectivityEvent>) {
+        super.addListener(listener)
+        if (monitor == null) {
+            monitor = Monitor.create(notifier = this)
+            monitor?.start()
+        }
     }
 
-    override fun removeObserver(observer: NetworkConnectivity.Observer) {
-        onlineListener?.let { window.removeEventListener(TYPE_ONLINE, it) }
-        offlineListener?.let { window.removeEventListener(TYPE_OFFLINE, it) }
-        onlineListener = null
-        offlineListener = null
+    override fun removeListener(listener: Listener<NetworkConnectivityEvent>) {
+        super.removeListener(listener)
+        if (!hasListeners()) {
+            monitor?.stop()
+            monitor = null
+        }
     }
 
-    companion object {
-        // https://developer.mozilla.org/en-US/docs/Web/API/Window/online_event
-        private const val TYPE_ONLINE = "online"
-        // https://developer.mozilla.org/en-US/docs/Web/API/Window/offline_event
-        private const val TYPE_OFFLINE = "offline"
+    internal class Monitor(
+        private val window: Window,
+        private val notifier: Notifier<NetworkConnectivityEvent>
+    ) {
+        private var isOnline: Boolean? = null
+
+        private val handleOnline: (Event) -> Unit = {
+            if (isOnline != true) {
+                isOnline = true
+                notifyListeners()
+            }
+        }
+
+        private val handleOffline: (Event) -> Unit = {
+            if (isOnline != false) {
+                isOnline = false
+                notifyListeners()
+            }
+        }
+
+        fun start() {
+            if (isOnline == null) {
+                isOnline = window.navigator.onLine
+                notifyListeners()
+            }
+            window.addEventListener(TYPE_ONLINE, handleOnline)
+            window.addEventListener(TYPE_OFFLINE, handleOffline)
+        }
+
+        fun stop() {
+            window.removeEventListener(TYPE_ONLINE, handleOnline)
+            window.removeEventListener(TYPE_OFFLINE, handleOffline)
+            isOnline = null
+        }
+
+        private fun notifyListeners() {
+            when (isOnline) {
+                true -> notifier.notify(NetworkConnectivityEvent.Available)
+                false -> notifier.notify(NetworkConnectivityEvent.Lost)
+                null -> Unit
+            }
+        }
+
+        companion object {
+            // https://developer.mozilla.org/en-US/docs/Web/API/Window/online_event
+            private const val TYPE_ONLINE = "online"
+
+            // https://developer.mozilla.org/en-US/docs/Web/API/Window/offline_event
+            private const val TYPE_OFFLINE = "offline"
+
+            fun create(
+                notifier: Notifier<NetworkConnectivityEvent>
+            ) = Monitor(
+                window = window,
+                notifier = notifier
+            )
+        }
     }
 }


### PR DESCRIPTION
Introduces reusable abstractions (Listenable, Listener, Notifier) that provide better separation of concerns and improved data handling.

Platform Implementations:
- Android: Refactored to extend AbstractNotifier, improved network state tracking with proper capability validation, added lifecycle-aware monitor management
- iOS: Implemented previously missing functionality using NWPathMonitor API with proper queue management
- WasmJs: Refactored to extend AbstractNotifier, added initial state checking using `navigator.onLine`