### PR TITLE
Refactor network connectivity API

### DIFF
--- a/soil-query-core/src/iosMain/kotlin/soil/query/IosNetworkConnectivity.kt
+++ b/soil-query-core/src/iosMain/kotlin/soil/query/IosNetworkConnectivity.kt
@@ -15,64 +15,47 @@ import platform.Network.nw_path_status_satisfiable
 import platform.Network.nw_path_status_satisfied
 import platform.Network.nw_path_status_unsatisfied
 import platform.darwin.dispatch_get_main_queue
-import soil.query.core.AbstractNotifier
-import soil.query.core.Listener
 import soil.query.core.NetworkConnectivity
 import soil.query.core.NetworkConnectivityEvent
+import soil.query.core.NetworkConnectivityProvider
 import soil.query.core.Notifier
 
 /**
  * Implementation of [NetworkConnectivity] for iOS using NWPathMonitor.
  */
-class IosNetworkConnectivity : AbstractNotifier<NetworkConnectivityEvent>(), NetworkConnectivity {
+class IosNetworkConnectivity : NetworkConnectivityProvider() {
 
-    private var monitor: Monitor? = null
+    override fun createReceiver(): Receiver = Monitor(
+        notifier = this
+    )
 
-    override fun addListener(listener: Listener<NetworkConnectivityEvent>) {
-        super.addListener(listener)
-        if (monitor == null) {
-            monitor = Monitor.create(notifier = this)
-            monitor?.start()
-        }
-    }
-
-    override fun removeListener(listener: Listener<NetworkConnectivityEvent>) {
-        super.removeListener(listener)
-        if (!hasListeners()) {
-            monitor?.stop()
-            monitor = null
-        }
-    }
-
-    internal class Monitor(
+    private class Monitor(
         private val notifier: Notifier<NetworkConnectivityEvent>
-    ) {
-        private var nwPathMonitor: nw_path_monitor_t? = null
+    ) : Receiver {
 
+        private var nwPathMonitor: nw_path_monitor_t? = null
         private var isOnline: Boolean? = null
 
-        private val handleOnline: () -> Unit = {
-            if (isOnline != true) {
-                isOnline = true
-                notifyListeners()
-            }
-        }
-
-        private val handleOffline: () -> Unit = {
-            if (isOnline != false) {
-                isOnline = false
-                notifyListeners()
-            }
-        }
-
-        fun start() {
+        override fun start() {
             val monitor = nw_path_monitor_create().also { nwPathMonitor = it }
             nw_path_monitor_set_queue(monitor, dispatch_get_main_queue())
             nw_path_monitor_set_update_handler(monitor) { path ->
                 if (path != null) {
                     when (nw_path_get_status(path)) {
-                        nw_path_status_satisfied -> handleOnline()
-                        nw_path_status_unsatisfied -> handleOffline()
+                        nw_path_status_satisfied -> {
+                            if (isOnline != true) {
+                                isOnline = true
+                                notifyListeners()
+                            }
+                        }
+
+                        nw_path_status_unsatisfied -> {
+                            if (isOnline != false) {
+                                isOnline = false
+                                notifyListeners()
+                            }
+                        }
+
                         nw_path_status_satisfiable,
                         nw_path_status_invalid -> Unit
                     }
@@ -81,7 +64,7 @@ class IosNetworkConnectivity : AbstractNotifier<NetworkConnectivityEvent>(), Net
             nw_path_monitor_start(nwPathMonitor)
         }
 
-        fun stop() {
+        override fun stop() {
             val monitor = nwPathMonitor
             if (monitor != null) {
                 nw_path_monitor_cancel(monitor)
@@ -96,14 +79,6 @@ class IosNetworkConnectivity : AbstractNotifier<NetworkConnectivityEvent>(), Net
                 false -> notifier.notify(NetworkConnectivityEvent.Lost)
                 null -> Unit
             }
-        }
-
-        companion object {
-            fun create(
-                notifier: Notifier<NetworkConnectivityEvent>
-            ) = Monitor(
-                notifier = notifier
-            )
         }
     }
 }

--- a/soil-query-core/src/wasmJsMain/kotlin/soil/query/WasmJsNetworkConnectivity.kt
+++ b/soil-query-core/src/wasmJsMain/kotlin/soil/query/WasmJsNetworkConnectivity.kt
@@ -6,39 +6,26 @@ package soil.query
 import kotlinx.browser.window
 import org.w3c.dom.Window
 import org.w3c.dom.events.Event
-import soil.query.core.AbstractNotifier
-import soil.query.core.Listener
 import soil.query.core.NetworkConnectivity
 import soil.query.core.NetworkConnectivityEvent
+import soil.query.core.NetworkConnectivityProvider
 import soil.query.core.Notifier
 
 /**
  * Implementation of [NetworkConnectivity] for WasmJs.
  */
-class WasmJsNetworkConnectivity : AbstractNotifier<NetworkConnectivityEvent>(), NetworkConnectivity {
+class WasmJsNetworkConnectivity : NetworkConnectivityProvider() {
 
-    private var monitor: Monitor? = null
+    override fun createReceiver(): Receiver = Monitor(
+        window = window,
+        notifier = this
+    )
 
-    override fun addListener(listener: Listener<NetworkConnectivityEvent>) {
-        super.addListener(listener)
-        if (monitor == null) {
-            monitor = Monitor.create(notifier = this)
-            monitor?.start()
-        }
-    }
-
-    override fun removeListener(listener: Listener<NetworkConnectivityEvent>) {
-        super.removeListener(listener)
-        if (!hasListeners()) {
-            monitor?.stop()
-            monitor = null
-        }
-    }
-
-    internal class Monitor(
+    private class Monitor(
         private val window: Window,
         private val notifier: Notifier<NetworkConnectivityEvent>
-    ) {
+    ) : Receiver {
+
         private var isOnline: Boolean? = null
 
         private val handleOnline: (Event) -> Unit = {
@@ -55,7 +42,7 @@ class WasmJsNetworkConnectivity : AbstractNotifier<NetworkConnectivityEvent>(), 
             }
         }
 
-        fun start() {
+        override fun start() {
             if (isOnline == null) {
                 isOnline = window.navigator.onLine
                 notifyListeners()
@@ -64,7 +51,7 @@ class WasmJsNetworkConnectivity : AbstractNotifier<NetworkConnectivityEvent>(), 
             window.addEventListener(TYPE_OFFLINE, handleOffline)
         }
 
-        fun stop() {
+        override fun stop() {
             window.removeEventListener(TYPE_ONLINE, handleOnline)
             window.removeEventListener(TYPE_OFFLINE, handleOffline)
             isOnline = null
@@ -77,20 +64,11 @@ class WasmJsNetworkConnectivity : AbstractNotifier<NetworkConnectivityEvent>(), 
                 null -> Unit
             }
         }
-
-        companion object {
-            // https://developer.mozilla.org/en-US/docs/Web/API/Window/online_event
-            private const val TYPE_ONLINE = "online"
-
-            // https://developer.mozilla.org/en-US/docs/Web/API/Window/offline_event
-            private const val TYPE_OFFLINE = "offline"
-
-            fun create(
-                notifier: Notifier<NetworkConnectivityEvent>
-            ) = Monitor(
-                window = window,
-                notifier = notifier
-            )
-        }
     }
 }
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/online_event
+private const val TYPE_ONLINE = "online"
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/offline_event
+private const val TYPE_OFFLINE = "offline"


### PR DESCRIPTION
This PR refactors the NetworkConnectivity implementation across all platforms (Android, iOS, Web) to use a common abstract provider pattern, eliminating code duplication and providing a consistent architecture.

refs: #257 