### PR TITLE
Fix snapshotFlow not detecting field registration changes

### DIFF
--- a/soil-form/src/commonMain/kotlin/soil/form/compose/Form.kt
+++ b/soil-form/src/commonMain/kotlin/soil/form/compose/Form.kt
@@ -122,7 +122,7 @@ fun <T> rememberForm(
         LaunchedEffect(control) {
             // validateOnMount
             launch {
-                snapshotFlow { control.fields }
+                snapshotFlow { control.fields.toSet() }
                     .filter { it.isNotEmpty() }
                     .debounce(control.options.preValidationDelayOnMount)
                     .collect {


### PR DESCRIPTION
The snapshotFlow monitoring FormController.fields was not detecting changes when fields were registered or unregistered. This was because rules.keys returns a view of the mutableStateMapOf's key set that doesn't trigger snapshot invalidation when the underlying map changes.

```kotlin
// incorrect
snapshotFlow { control.fields }

// correct
snapshotFlow { control.fields.toSet() }
```