### PR TITLE
Fix wasmJs test timeout

### DIFF
--- a/soil-experimental/soil-optimistic-update/build.gradle.kts
+++ b/soil-experimental/soil-optimistic-update/build.gradle.kts
@@ -29,7 +29,15 @@ kotlin {
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        browser()
+        browser {
+            testTask {
+                useMocha {
+                    // Workaround: "Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves."
+                    // https://stackoverflow.com/questions/75471611/kotlin-javascript-karma-test-fails
+                    timeout = "10s"
+                }
+            }
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
This PR resolves test timeout issues occurring in the wasmJs browser tests for the soil-optimistic-update experimental module. 

refs: 
- #250
- https://github.com/soil-kt/soil/actions/runs/17889057666