### PR TITLE
Skip wasmJsBrowserTest in CI due to flaky test execution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,8 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_16.3.app
 
       - name: Run build
-        run: ./gradlew --scan buildLibs
+        # Skip wasmJsBrowserTest due to flaky behavior on GitHub Actions macOS runners
+        run: ./gradlew --scan buildLibs -x wasmJsBrowserTest
 
       - name: Generate test coverage report
         run: ./gradlew koverXmlReport


### PR DESCRIPTION
The wasmJsBrowserTest target exhibits flaky behavior when running on GitHub Actions macOS runners.

refs:
- unit-test.yml (linux) - https://github.com/soil-kt/soil/actions/runs/17890521794
- build.yml (mac) - https://github.com/soil-kt/soil/actions/runs/17890524391